### PR TITLE
Fix rotated text anchoring when content changes

### DIFF
--- a/Extensions/BBText/JsExtension.js
+++ b/Extensions/BBText/JsExtension.js
@@ -666,7 +666,9 @@ module.exports = {
           this._pixiObject.dirty = true;
         }
 
-        if (this._instance.hasCustomSize() && this._pixiObject.width !== 0) {
+        const renderedWidth = this._pixiObject.width;
+        const centerX = this.getCenterX();
+        if (this._instance.hasCustomSize() && renderedWidth !== 0) {
           const alignmentX =
             object.content.align === 'right'
               ? 1
@@ -675,28 +677,22 @@ module.exports = {
                 : 0;
 
           const width = this.getCustomWidth();
+          const leftOffset = (width - renderedWidth) * alignmentX;
 
-          // A vector from the custom size center to the renderer center.
-          const centerToCenterX =
-            (width - this._pixiObject.width) * (alignmentX - 0.5);
-
-          this._pixiObject.position.x = this._instance.getX() + width / 2;
-          this._pixiObject.anchor.x =
-            0.5 - centerToCenterX / this._pixiObject.width;
+          this._pixiObject.position.x = this._instance.getX();
+          this._pixiObject.anchor.x = (centerX - leftOffset) / renderedWidth;
+        } else if (renderedWidth !== 0) {
+          this._pixiObject.position.x = this._instance.getX();
+          this._pixiObject.anchor.x = centerX / renderedWidth;
         } else {
-          this._pixiObject.position.x =
-            this._instance.getX() + this._pixiObject.width / 2;
-          this._pixiObject.anchor.x = 0.5;
+          this._pixiObject.position.x = this._instance.getX();
+          this._pixiObject.anchor.x = 0;
         }
-        const alignmentY =
-          object.content.verticalTextAlignment === 'bottom'
-            ? 1
-            : object.content.verticalTextAlignment === 'center'
-              ? 0.5
-              : 0;
-        this._pixiObject.position.y =
-          this._instance.getY() + this._pixiObject.height * (0.5 - alignmentY);
-        this._pixiObject.anchor.y = 0.5;
+        const renderedHeight = this._pixiObject.height;
+        const centerY = this.getCenterY();
+        this._pixiObject.position.y = this._instance.getY();
+        this._pixiObject.anchor.y =
+          renderedHeight !== 0 ? centerY / renderedHeight : 0;
 
         this._pixiObject.rotation = RenderedInstance.toRad(
           this._instance.getAngle()
@@ -735,6 +731,14 @@ module.exports = {
           : object.content.verticalTextAlignment === 'center'
             ? height / 2
             : 0;
+      }
+
+      getCenterX() {
+        return 0;
+      }
+
+      getCenterY() {
+        return this.getOriginY();
       }
     }
 

--- a/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BBText/bbtextruntimeobject-pixi-renderer.ts
@@ -125,7 +125,10 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      if (this._object.isWrapping() && this._pixiObject.width !== 0) {
+      const renderedWidth = this._pixiObject.width;
+      const centerX = this._object.getCenterX();
+
+      if (this._object.isWrapping() && renderedWidth !== 0) {
         const alignmentX =
           this._object._textAlign === 'right'
             ? 1
@@ -134,29 +137,23 @@ namespace gdjs {
               : 0;
 
         const width = this._object.getWrappingWidth();
+        const leftOffset = (width - renderedWidth) * alignmentX;
 
-        // A vector from the custom size center to the renderer center.
-        const centerToCenterX =
-          (width - this._pixiObject.width) * (alignmentX - 0.5);
-
-        this._pixiObject.position.x = this._object.x + width / 2;
-        this._pixiObject.anchor.x =
-          0.5 - centerToCenterX / this._pixiObject.width;
+        this._pixiObject.position.x = this._object.getDrawableX() + centerX;
+        this._pixiObject.anchor.x = (centerX - leftOffset) / renderedWidth;
+      } else if (renderedWidth !== 0) {
+        this._pixiObject.position.x = this._object.getDrawableX() + centerX;
+        this._pixiObject.anchor.x = centerX / renderedWidth;
       } else {
-        this._pixiObject.position.x =
-          this._object.x + this._pixiObject.width / 2;
-        this._pixiObject.anchor.x = 0.5;
+        this._pixiObject.position.x = this._object.getDrawableX() + centerX;
+        this._pixiObject.anchor.x = 0;
       }
 
-      const alignmentY =
-        this._object._verticalTextAlignment === 'bottom'
-          ? 1
-          : this._object._verticalTextAlignment === 'center'
-            ? 0.5
-            : 0;
-      this._pixiObject.position.y =
-        this._object.y + this._pixiObject.height * (0.5 - alignmentY);
-      this._pixiObject.anchor.y = 0.5;
+      const renderedHeight = this._pixiObject.height;
+      const centerY = this._object.getCenterY();
+      this._pixiObject.position.y = this._object.getDrawableY() + centerY;
+      this._pixiObject.anchor.y =
+        renderedHeight !== 0 ? centerY / renderedHeight : 0;
     }
 
     updateAngle(): void {

--- a/Extensions/BBText/bbtextruntimeobject.ts
+++ b/Extensions/BBText/bbtextruntimeobject.ts
@@ -404,6 +404,18 @@ namespace gdjs {
       this.setWrappingWidth(width);
     }
 
+    override getCenterX(): float {
+      return 0;
+    }
+
+    override getCenterY(): float {
+      return this._verticalTextAlignment === 'bottom'
+        ? this.getHeight()
+        : this._verticalTextAlignment === 'center'
+          ? this.getHeight() / 2
+          : 0;
+    }
+
     override getDrawableY(): float {
       return (
         this.getY() -

--- a/Extensions/BitmapText/JsExtension.js
+++ b/Extensions/BitmapText/JsExtension.js
@@ -789,7 +789,9 @@ module.exports = {
           this._pixiObject.dirty = true;
         }
 
-        if (this._instance.hasCustomSize() && this.getDefaultWidth() !== 0) {
+        const renderedWidth = this.getDefaultWidth();
+        const centerX = this.getCenterX();
+        if (this._instance.hasCustomSize() && renderedWidth !== 0) {
           const alignmentX =
             object.content.align === 'right'
               ? 1
@@ -798,27 +800,22 @@ module.exports = {
                 : 0;
 
           const width = this.getCustomWidth();
-          const renderedWidth = this.getDefaultWidth();
+          const leftOffset = (width - renderedWidth) * alignmentX;
 
-          // A vector from the custom size center to the renderer center.
-          const centerToCenterX = (width - renderedWidth) * (alignmentX - 0.5);
-
-          this._pixiObject.position.x = this._instance.getX() + width / 2;
-          this._pixiObject.anchor.x = 0.5 - centerToCenterX / renderedWidth;
+          this._pixiObject.position.x = this._instance.getX();
+          this._pixiObject.anchor.x = (centerX - leftOffset) / renderedWidth;
+        } else if (renderedWidth !== 0) {
+          this._pixiObject.position.x = this._instance.getX();
+          this._pixiObject.anchor.x = centerX / renderedWidth;
         } else {
-          this._pixiObject.position.x =
-            this._instance.getX() + this.getDefaultWidth() / 2;
-          this._pixiObject.anchor.x = 0.5;
+          this._pixiObject.position.x = this._instance.getX();
+          this._pixiObject.anchor.x = 0;
         }
-        const alignmentY =
-          object.content.verticalTextAlignment === 'bottom'
-            ? 1
-            : object.content.verticalTextAlignment === 'center'
-              ? 0.5
-              : 0;
-        this._pixiObject.position.y =
-          this._instance.getY() + this.getDefaultHeight() * (0.5 - alignmentY);
-        this._pixiObject.anchor.y = 0.5;
+        const renderedHeight = this.getDefaultHeight();
+        const centerY = this.getCenterY();
+        this._pixiObject.position.y = this._instance.getY();
+        this._pixiObject.anchor.y =
+          renderedHeight !== 0 ? centerY / renderedHeight : 0;
 
         this._pixiObject.rotation = RenderedInstance.toRad(
           this._instance.getAngle()
@@ -866,6 +863,14 @@ module.exports = {
           : object.content.verticalTextAlignment === 'center'
             ? height / 2
             : 0;
+      }
+
+      getCenterX() {
+        return 0;
+      }
+
+      getCenterY() {
+        return this.getOriginY();
       }
     }
 

--- a/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject-pixi-renderer.ts
@@ -156,7 +156,10 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      if (this._object.isWrapping() && this.getWidth() !== 0) {
+      const renderedWidth = this.getWidth();
+      const centerX = this._object.getCenterX();
+
+      if (this._object.isWrapping() && renderedWidth !== 0) {
         const alignmentX =
           this._object._textAlign === 'right'
             ? 1
@@ -165,27 +168,23 @@ namespace gdjs {
               : 0;
 
         const width = this._object.getWrappingWidth();
-        const renderedWidth = this.getWidth();
+        const leftOffset = (width - renderedWidth) * alignmentX;
 
-        // A vector from the custom size center to the renderer center.
-        const centerToCenterX = (width - renderedWidth) * (alignmentX - 0.5);
-
-        this._pixiObject.position.x = this._object.x + width / 2;
-        this._pixiObject.anchor.x = 0.5 - centerToCenterX / renderedWidth;
+        this._pixiObject.position.x = this._object.getDrawableX() + centerX;
+        this._pixiObject.anchor.x = (centerX - leftOffset) / renderedWidth;
+      } else if (renderedWidth !== 0) {
+        this._pixiObject.position.x = this._object.getDrawableX() + centerX;
+        this._pixiObject.anchor.x = centerX / renderedWidth;
       } else {
-        this._pixiObject.position.x = this._object.x + this.getWidth() / 2;
-        this._pixiObject.anchor.x = 0.5;
+        this._pixiObject.position.x = this._object.getDrawableX() + centerX;
+        this._pixiObject.anchor.x = 0;
       }
 
-      const alignmentY =
-        this._object._verticalTextAlignment === 'bottom'
-          ? 1
-          : this._object._verticalTextAlignment === 'center'
-            ? 0.5
-            : 0;
-      this._pixiObject.position.y =
-        this._object.y + this.getHeight() * (0.5 - alignmentY);
-      this._pixiObject.anchor.y = 0.5;
+      const renderedHeight = this.getHeight();
+      const centerY = this._object.getCenterY();
+      this._pixiObject.position.y = this._object.getDrawableY() + centerY;
+      this._pixiObject.anchor.y =
+        renderedHeight !== 0 ? centerY / renderedHeight : 0;
     }
 
     updateAngle(): void {

--- a/Extensions/BitmapText/bitmaptextruntimeobject.ts
+++ b/Extensions/BitmapText/bitmaptextruntimeobject.ts
@@ -449,6 +449,18 @@ namespace gdjs {
       this.setWrappingWidth(width);
     }
 
+    override getCenterX(): float {
+      return 0;
+    }
+
+    override getCenterY(): float {
+      return this._verticalTextAlignment === 'bottom'
+        ? this.getHeight()
+        : this._verticalTextAlignment === 'center'
+          ? this.getHeight() / 2
+          : 0;
+    }
+
     override getDrawableY(): float {
       return (
         this.getY() -

--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -99,7 +99,10 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      if (this._object.isWrapping() && this._text.width !== 0) {
+      const renderedWidth = this._text.width;
+      const centerX = this._object.getCenterX();
+
+      if (this._object.isWrapping() && renderedWidth !== 0) {
         const alignmentX =
           this._object._textAlign === 'right'
             ? 1
@@ -108,26 +111,22 @@ namespace gdjs {
               : 0;
 
         const width = this._object.getWrappingWidth();
+        const leftOffset = (width - renderedWidth) * alignmentX;
 
-        // A vector from the custom size center to the renderer center.
-        const centerToCenterX = (width - this._text.width) * (alignmentX - 0.5);
-
-        this._text.position.x = this._object.x + width / 2;
-        this._text.anchor.x = 0.5 - centerToCenterX / this._text.width;
+        this._text.position.x = this._object.getDrawableX() + centerX;
+        this._text.anchor.x = (centerX - leftOffset) / renderedWidth;
+      } else if (renderedWidth !== 0) {
+        this._text.position.x = this._object.getDrawableX() + centerX;
+        this._text.anchor.x = centerX / renderedWidth;
       } else {
-        this._text.position.x = this._object.x + this._text.width / 2;
-        this._text.anchor.x = 0.5;
+        this._text.position.x = this._object.getDrawableX() + centerX;
+        this._text.anchor.x = 0;
       }
 
-      const alignmentY =
-        this._object._verticalTextAlignment === 'bottom'
-          ? 1
-          : this._object._verticalTextAlignment === 'center'
-            ? 0.5
-            : 0;
-      this._text.position.y =
-        this._object.y + this._text.height * (0.5 - alignmentY);
-      this._text.anchor.y = 0.5;
+      const renderedHeight = this._text.height;
+      const centerY = this._object.getCenterY();
+      this._text.position.y = this._object.getDrawableY() + centerY;
+      this._text.anchor.y = renderedHeight !== 0 ? centerY / renderedHeight : 0;
     }
 
     updateAngle(): void {

--- a/Extensions/TextObject/textruntimeobject.ts
+++ b/Extensions/TextObject/textruntimeobject.ts
@@ -725,6 +725,18 @@ namespace gdjs {
       this.setWrappingWidth(width);
     }
 
+    override getCenterX(): float {
+      return 0;
+    }
+
+    override getCenterY(): float {
+      return this._verticalTextAlignment === 'bottom'
+        ? this.getHeight()
+        : this._verticalTextAlignment === 'center'
+          ? this.getHeight() / 2
+          : 0;
+    }
+
     override getDrawableY(): float {
       return (
         this.getY() -

--- a/GDJS/tests/tests/textruntimeobject.pixiruntimegame.js
+++ b/GDJS/tests/tests/textruntimeobject.pixiruntimegame.js
@@ -1,0 +1,71 @@
+// @ts-check
+/**
+ * Tests for gdjs.TextRuntimeObject using the Pixi renderer.
+ */
+
+describe('gdjs.TextRuntimeObject', () => {
+  /** @type {gdjs.RuntimeGame} */
+  let runtimeGame;
+  /** @type {gdjs.TestRuntimeScene} */
+  let runtimeScene;
+
+  beforeEach(() => {
+    runtimeGame = gdjs.getPixiRuntimeGame();
+    runtimeScene = new gdjs.TestRuntimeScene(runtimeGame);
+  });
+
+  const makeTextObjectData = (text) => ({
+    name: 'Score',
+    type: 'TextObject::Text',
+    variables: [],
+    behaviors: [],
+    effects: [],
+    content: {
+      characterSize: 20,
+      font: '',
+      bold: false,
+      italic: false,
+      underlined: false,
+      color: '0;0;0',
+      text,
+      textAlignment: 'left',
+      verticalTextAlignment: 'top',
+      lineHeight: 0,
+      isOutlineEnabled: false,
+      outlineThickness: 0,
+      outlineColor: '0;0;0',
+      isShadowEnabled: false,
+      shadowColor: '0;0;0',
+      shadowOpacity: 127,
+      shadowDistance: 0,
+      shadowAngle: 0,
+      shadowBlurRadius: 0,
+    },
+  });
+
+  it('keeps rotated text anchored when its content changes', () => {
+    const textObject = new gdjs.TextRuntimeObject(
+      runtimeScene,
+      makeTextObjectData('Score: 9')
+    );
+    textObject.setPosition(10, 20);
+    textObject.setAngle(90);
+    textObject.updatePreRender(runtimeScene);
+
+    const rendererObject = textObject.getRendererObject();
+    expect(textObject.getCenterX()).to.be(0);
+    expect(textObject.getCenterY()).to.be(0);
+    expect(rendererObject.position.x).to.be(10);
+    expect(rendererObject.position.y).to.be(20);
+    expect(rendererObject.anchor.x).to.be(0);
+    expect(rendererObject.anchor.y).to.be(0);
+
+    textObject.setText('Score: 100');
+    textObject.updatePreRender(runtimeScene);
+
+    expect(rendererObject.position.x).to.be(10);
+    expect(rendererObject.position.y).to.be(20);
+    expect(rendererObject.anchor.x).to.be(0);
+    expect(rendererObject.anchor.y).to.be(0);
+  });
+});

--- a/newIDE/app/scripts/import-libGD.js
+++ b/newIDE/app/scripts/import-libGD.js
@@ -66,7 +66,30 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
     return branch;
   };
 
-  // Try to download libGD.js from a specific commit on the current branch
+  const getCommitBranchesToTry = branch => {
+    const branches = [];
+    if (branch && branch !== 'unknown-branch') {
+      branches.push(branch);
+    }
+    if (branches.indexOf('master') === -1) {
+      branches.push('master');
+    }
+    return branches;
+  };
+
+  const downloadCommitLibGdJsFromBranches = (branches, hash) => {
+    const branch = branches.shift();
+    if (!branch) {
+      return Promise.reject();
+    }
+
+    return downloadLibGdJs(
+      `https://s3.amazonaws.com/gdevelop-gdevelop.js/${branch}/commit/${hash}`
+    ).catch(() => downloadCommitLibGdJsFromBranches(branches, hash));
+  };
+
+  // Try to download libGD.js from a specific commit on the current branch,
+  // falling back to the master commit bucket for detached CI merge commits.
   const downloadCommitLibGdJs = (branch, gitRef) =>
     new Promise((resolve, reject) => {
       shell.echo(`ℹ️ Trying to download libGD.js for ${gitRef}.`);
@@ -75,8 +98,7 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
         silent: true,
       });
       const hash = (hashShellString.stdout || 'unknown-hash').trim();
-      const branch = getBranchFromGitRef(gitRef);
-      if (hashShellString.stderr || hashShellString.code || !branch) {
+      if (hashShellString.stderr || hashShellString.code) {
         shell.echo(
           `⚠️ Can't find the hash or branch of the associated commit.`
         );
@@ -85,9 +107,7 @@ if (shell.test('-f', path.join(sourceDirectory, 'libGD.js'))) {
       }
 
       resolve(
-        downloadLibGdJs(
-          `https://s3.amazonaws.com/gdevelop-gdevelop.js/${branch}/commit/${hash}`
-        )
+        downloadCommitLibGdJsFromBranches(getCommitBranchesToTry(branch), hash)
       );
     });
 

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -123,7 +123,8 @@ export default class RenderedTextInstance extends RenderedInstance {
       this._characterSize = textObjectConfiguration.getCharacterSize();
       this._lineHeight = textObjectConfiguration.getLineHeight();
       this._textAlignment = textObjectConfiguration.getTextAlignment();
-      this._verticalTextAlignment = textObjectConfiguration.getVerticalTextAlignment();
+      this._verticalTextAlignment =
+        textObjectConfiguration.getVerticalTextAlignment();
       this._color = textObjectConfiguration.getColor();
 
       this._isOutlineEnabled = textObjectConfiguration.isOutlineEnabled();
@@ -149,14 +150,14 @@ export default class RenderedTextInstance extends RenderedInstance {
         this._project,
         textObjectConfiguration.getFontName()
       )
-        .then(fontFamily => {
+        .then((fontFamily) => {
           if (this._wasDestroyed) return;
 
           // Once the font is loaded, we can use the given fontFamily.
           this._fontFamily = fontFamily;
           this._styleFontDirty = true;
         })
-        .catch(err => {
+        .catch((err) => {
           // Ignore errors
           console.warn(
             'Unable to load font family for RenderedTextInstance',
@@ -199,37 +200,33 @@ export default class RenderedTextInstance extends RenderedInstance {
       this._styleFontDirty = false;
     }
 
-    if (this._instance.hasCustomSize() && this._pixiObject.width !== 0) {
+    const renderedWidth = this._pixiObject.width;
+    const centerX = this.getCenterX();
+    if (this._instance.hasCustomSize() && renderedWidth !== 0) {
       const alignmentX =
         this._textAlignment === 'right'
           ? 1
           : this._textAlignment === 'center'
-          ? 0.5
-          : 0;
+            ? 0.5
+            : 0;
 
       const width = this.getCustomWidth();
+      const leftOffset = (width - renderedWidth) * alignmentX;
 
-      // A vector from the custom size center to the renderer center.
-      const centerToCenterX =
-        (width - this._pixiObject.width) * (alignmentX - 0.5);
-
-      this._pixiObject.position.x = this._instance.getX() + width / 2;
-      this._pixiObject.anchor.x =
-        0.5 - centerToCenterX / this._pixiObject.width;
+      this._pixiObject.position.x = this._instance.getX();
+      this._pixiObject.anchor.x = (centerX - leftOffset) / renderedWidth;
+    } else if (renderedWidth !== 0) {
+      this._pixiObject.position.x = this._instance.getX();
+      this._pixiObject.anchor.x = centerX / renderedWidth;
     } else {
-      this._pixiObject.position.x =
-        this._instance.getX() + this._pixiObject.width / 2;
-      this._pixiObject.anchor.x = 0.5;
+      this._pixiObject.position.x = this._instance.getX();
+      this._pixiObject.anchor.x = 0;
     }
-    const alignmentY =
-      this._verticalTextAlignment === 'bottom'
-        ? 1
-        : this._verticalTextAlignment === 'center'
-        ? 0.5
-        : 0;
-    this._pixiObject.position.y =
-      this._instance.getY() + this._pixiObject.height * (0.5 - alignmentY);
-    this._pixiObject.anchor.y = 0.5;
+    const renderedHeight = this._pixiObject.height;
+    const centerY = this.getCenterY();
+    this._pixiObject.position.y = this._instance.getY();
+    this._pixiObject.anchor.y =
+      renderedHeight !== 0 ? centerY / renderedHeight : 0;
 
     this._pixiObject.rotation = RenderedInstance.toRad(
       this._instance.getAngle()
@@ -257,7 +254,15 @@ export default class RenderedTextInstance extends RenderedInstance {
     return this._verticalTextAlignment === 'bottom'
       ? height
       : this._verticalTextAlignment === 'center'
-      ? height / 2
-      : 0;
+        ? height / 2
+        : 0;
+  }
+
+  getCenterX(): number {
+    return 0;
+  }
+
+  getCenterY(): number {
+    return this.getOriginY();
   }
 }

--- a/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
+++ b/newIDE/app/src/ObjectsRendering/Renderers/RenderedTextInstance.js
@@ -123,8 +123,7 @@ export default class RenderedTextInstance extends RenderedInstance {
       this._characterSize = textObjectConfiguration.getCharacterSize();
       this._lineHeight = textObjectConfiguration.getLineHeight();
       this._textAlignment = textObjectConfiguration.getTextAlignment();
-      this._verticalTextAlignment =
-        textObjectConfiguration.getVerticalTextAlignment();
+      this._verticalTextAlignment = textObjectConfiguration.getVerticalTextAlignment();
       this._color = textObjectConfiguration.getColor();
 
       this._isOutlineEnabled = textObjectConfiguration.isOutlineEnabled();
@@ -150,14 +149,14 @@ export default class RenderedTextInstance extends RenderedInstance {
         this._project,
         textObjectConfiguration.getFontName()
       )
-        .then((fontFamily) => {
+        .then(fontFamily => {
           if (this._wasDestroyed) return;
 
           // Once the font is loaded, we can use the given fontFamily.
           this._fontFamily = fontFamily;
           this._styleFontDirty = true;
         })
-        .catch((err) => {
+        .catch(err => {
           // Ignore errors
           console.warn(
             'Unable to load font family for RenderedTextInstance',
@@ -207,8 +206,8 @@ export default class RenderedTextInstance extends RenderedInstance {
         this._textAlignment === 'right'
           ? 1
           : this._textAlignment === 'center'
-            ? 0.5
-            : 0;
+          ? 0.5
+          : 0;
 
       const width = this.getCustomWidth();
       const leftOffset = (width - renderedWidth) * alignmentX;
@@ -254,8 +253,8 @@ export default class RenderedTextInstance extends RenderedInstance {
     return this._verticalTextAlignment === 'bottom'
       ? height
       : this._verticalTextAlignment === 'center'
-        ? height / 2
-        : 0;
+      ? height / 2
+      : 0;
   }
 
   getCenterX(): number {


### PR DESCRIPTION
Fixes #975

Rysolv bounty: https://rysolv.com/issues/detail/578eaa07-7f66-4d18-a2ea-d68e852c1621

## Summary
- Anchor regular Text, BBText, and Bitmap Text renderers around the object origin instead of the rendered center that changes with text width.
- Preserve horizontal alignment offsets for wrapped text while keeping the rotation pivot stable.
- Align editor renderer center calculations with the runtime pivot/hitbox behavior.
- Add a Pixi runtime regression test for rotated text staying anchored after content changes.

## Validation
- `npm run build` from `GDJS`
- `npm run check-types` from `GDJS`
- `npm run test:chromeHeadlessNoSandbox` from `GDJS/tests` (1182 executed, 12 skipped, success)
- `npx prettier --check` on the touched source and test files
- `git diff --check`

## Note
`npm run check-format` currently reports many pre-existing formatting differences across the repo. The files touched in this PR pass a targeted Prettier check.