### PR TITLE
Fix a regression on the displayed position of custom objects

### DIFF
--- a/GDJS/Runtime/RuntimeCustomObjectLayer.ts
+++ b/GDJS/Runtime/RuntimeCustomObjectLayer.ts
@@ -25,7 +25,8 @@ namespace gdjs {
 
       // Let the renderer do its final set up:
       this._renderer.onCreated();
-      this._renderer.updatePosition();
+      // We don't call `this._renderer.updatePosition` because the camera has
+      // no effect unless it's moved.
     }
 
     override onGameResolutionResized(

--- a/GDJS/Runtime/RuntimeLayer.ts
+++ b/GDJS/Runtime/RuntimeLayer.ts
@@ -281,7 +281,16 @@ namespace gdjs {
      * @returns the scene the layer belongs to directly or indirectly
      */
     getRuntimeScene(): gdjs.RuntimeScene {
+      // TODO Check that method is not wrongly called instead of `getInstanceContainer`.
       return this._runtimeScene.getScene();
+    }
+
+    /**
+     * Returns the scene the layer directly belongs
+     * @returns the scene the layer directly belongs
+     */
+    getInstanceContainer(): gdjs.RuntimeInstanceContainer {
+      return this._runtimeScene;
     }
 
     /**

--- a/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
+++ b/GDJS/Runtime/pixi-renderers/layer-pixi-renderer.ts
@@ -829,7 +829,8 @@ namespace gdjs {
     }
 
     updatePosition(): void {
-      const runtimeGame = this._layer.getRuntimeScene().getGame();
+      const instanceContainer = this._layer.getInstanceContainer();
+      const runtimeGame = instanceContainer.getGame();
 
       // Update the 3D camera position and rotation.
       if (this._threeCamera) {
@@ -921,8 +922,10 @@ namespace gdjs {
         const centerY =
           this._layer.getCameraX() * effectivePixiZoom * angleSinValue +
           this._layer.getCameraY() * effectivePixiZoom * angleCosValue;
-        this._pixiContainer.position.x = this._layer.getWidth() / 2 - centerX;
-        this._pixiContainer.position.y = this._layer.getHeight() / 2 - centerY;
+        this._pixiContainer.position.x =
+          instanceContainer.getViewportOriginX() - centerX;
+        this._pixiContainer.position.y =
+          instanceContainer.getViewportOriginY() - centerY;
       }
 
       // Pixel rounding for the Pixi rendering (be it for 2D only


### PR DESCRIPTION
Manually tested on:
- the future scrollable text object
- the top-down RPG template (which use camera zoom and scrolling)
- the multi-touch joystick (which uses an origin at center and legacy AABB evaluation)