### PR TITLE
Add possibility to override preview layout from gdevelop-settings.yml

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -211,7 +211,10 @@ import { QuickCustomizationDialog } from '../QuickCustomization/QuickCustomizati
 import { type ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import useGamesList from '../GameDashboard/UseGamesList';
 import useCapturesManager from './UseCapturesManager';
-import { readProjectSettings } from '../Utils/ProjectSettingsReader';
+import {
+  readProjectSettings,
+  getOverridenPreviewLayoutNameFromPreferences,
+} from '../Utils/ProjectSettingsReader';
 import useNpmScriptRunner from './NpmScriptRunner/useNpmScriptRunner';
 import { applyProjectPreferences } from '../Utils/ApplyProjectPreferences';
 import {
@@ -1228,6 +1231,21 @@ const MainFrame = (props: Props): React.MixedElement => {
               ...currentState,
               toolbarButtons: parsedProjectSettings.toolbarButtons || [],
             }));
+
+            const overridenPreviewLayoutName = getOverridenPreviewLayoutNameFromPreferences(
+              parsedProjectSettings.preferences
+            );
+            if (
+              overridenPreviewLayoutName &&
+              project.hasLayoutNamed(overridenPreviewLayoutName)
+            ) {
+              setPreviewState(previewState => ({
+                ...previewState,
+                isPreviewOverriden: true,
+                overridenPreviewLayoutName,
+                overridenPreviewExternalLayoutName: null,
+              }));
+            }
           }
         } catch (error) {
           console.warn(

--- a/newIDE/app/src/Utils/ProjectSettingsReader.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.js
@@ -17,6 +17,25 @@ export type ParsedProjectSettings = {
 
 const SETTINGS_FILE_NAME = 'gdevelop-settings.yaml';
 
+/**
+ * Key inside the `preferences:` block of `gdevelop-settings.yaml` that forces
+ * "Use this scene to start all previews" to the given scene name when opening
+ * the project (if the scene exists).
+ */
+export const OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY = 'overridenPreviewLayoutName';
+
+/**
+ * Reads the overriden preview scene name from a parsed `preferences` map.
+ * Returns null when missing or not a non-empty string.
+ */
+export const getOverridenPreviewLayoutNameFromPreferences = (
+  preferences: ?$ReadOnly<{ [string]: boolean | string | number }>
+): string | null => {
+  if (!preferences) return null;
+  const value = preferences[OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+};
+
 // Only allow safe characters in npm script names to prevent command injection
 const SAFE_SCRIPT_NAME_PATTERN = /^[a-zA-Z0-9_:-]+$/;
 

--- a/newIDE/app/src/Utils/ProjectSettingsReader.spec.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.spec.js
@@ -3,7 +3,11 @@ import {
   filterAllowedPreferences,
   applyProjectPreferences,
 } from './ApplyProjectPreferences';
-import { parseToolbarButtons } from './ProjectSettingsReader';
+import {
+  parseToolbarButtons,
+  getOverridenPreviewLayoutNameFromPreferences,
+  OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY,
+} from './ProjectSettingsReader';
 import YAML from 'yaml';
 import { type Preferences } from '../MainFrame/Preferences/PreferencesContext';
 
@@ -157,6 +161,71 @@ preferences:
       const parsed = YAML.parse(yamlContent);
       // readProjectSettings checks for preferences and returns null if empty/null
       expect(parsed.preferences).toBeNull();
+    });
+
+    test('overridenPreviewLayoutName is parsed but not applied to global preferences', () => {
+      const yamlContent = `
+preferences:
+  themeName: "Dark"
+  ${OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY}: "MyMenuScene"
+`;
+      const parsed = YAML.parse(yamlContent);
+      const rawPreferences = parsed.preferences;
+      expect(rawPreferences[OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]).toBe(
+        'MyMenuScene'
+      );
+
+      // The key is not in the allowlist, so it must not reach setMultipleValues.
+      const filtered = filterAllowedPreferences(rawPreferences);
+      expect(filtered).toEqual({ themeName: 'Dark' });
+      expect(filtered[OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]).toBeUndefined();
+
+      // The key is exposed for MainFrame to read via the helper.
+      expect(getOverridenPreviewLayoutNameFromPreferences(rawPreferences)).toBe(
+        'MyMenuScene'
+      );
+    });
+  });
+
+  describe('getOverridenPreviewLayoutNameFromPreferences', () => {
+    test('returns the scene name when present and a non-empty string', () => {
+      expect(
+        getOverridenPreviewLayoutNameFromPreferences({
+          [OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]: 'Intro',
+        })
+      ).toBe('Intro');
+    });
+
+    test('returns null when missing or not a non-empty string', () => {
+      expect(getOverridenPreviewLayoutNameFromPreferences(null)).toBeNull();
+      expect(getOverridenPreviewLayoutNameFromPreferences({})).toBeNull();
+      expect(
+        getOverridenPreviewLayoutNameFromPreferences({
+          [OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]: '',
+        })
+      ).toBeNull();
+      expect(
+        getOverridenPreviewLayoutNameFromPreferences({
+          [OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]: 123,
+        })
+      ).toBeNull();
+      expect(
+        getOverridenPreviewLayoutNameFromPreferences({
+          [OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]: true,
+        })
+      ).toBeNull();
+    });
+
+    test('does not mutate the preferences map', () => {
+      const prefs = {
+        themeName: 'Dark',
+        [OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]: 'Intro',
+      };
+      getOverridenPreviewLayoutNameFromPreferences(prefs);
+      expect(prefs).toEqual({
+        themeName: 'Dark',
+        [OVERRIDEN_PREVIEW_LAYOUT_NAME_KEY]: 'Intro',
+      });
     });
   });
 


### PR DESCRIPTION
Once the following parameter is added to gdevelop-settings.yml:
```
preferences:
  overridenPreviewLayoutName: "Initializer"
```
The editor opens with enabled "Start all previews from scene 'Initializer'".
<img width="576" height="236" alt="ScreenshotPreviewInGDevelop" src="https://github.com/user-attachments/assets/7845697f-0c33-4570-8c36-432802db39af" /> 

This parameter is ignored if the project does not contain the specified scene.
