### PR TITLE
Fix Text object position after string updates

### DIFF
--- a/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
+++ b/Extensions/TextObject/textruntimeobject-pixi-renderer.ts
@@ -144,6 +144,7 @@ namespace gdjs {
 
       //Work around a PIXI.js bug.
       this._text.updateText(false);
+      this.updatePosition();
     }
 
     getWidth(): float {


### PR DESCRIPTION
Fixes #975.

This keeps the Pixi text renderer position in sync after a Text object's string changes. `PIXI.Text.updateText(false)` recalculates the rendered text metrics, so the renderer also needs to call `updatePosition()` afterward; otherwise a rotated Text object can keep the old center/anchor placement and appear to move as the displayed string changes width.

This matches the existing BBText and BitmapText renderer behavior, where text-content updates already refresh positioning.

Validation:
- `git diff --check`

I made the change in a sparse checkout, so I did not run the full GDevelop test suite locally.
