### PR TITLE
Store preview layout in project json

### DIFF
--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -902,6 +902,7 @@ void Project::UnserializeFrom(const SerializerElement& element) {
     layout.UnserializeFrom(*this, layoutElement);
   }
   SetFirstLayout(element.GetChild("firstLayout").GetStringValue());
+  SetPreviewLayout(element.GetChild("previewLayout").GetStringValue());
 
   externalEvents.clear();
   const SerializerElement& externalEventsElement =
@@ -1207,6 +1208,7 @@ void Project::SerializeTo(SerializerElement& element) const {
   GetVariables().SerializeTo(element.AddChild("variables"));
 
   element.SetAttribute("firstLayout", firstLayout);
+  element.SetAttribute("previewLayout", previewLayout);
   gd::SerializerElement& layoutsElement = element.AddChild("layouts");
   layoutsElement.ConsiderAsArrayOf("layout");
   for (std::size_t i = 0; i < GetLayoutsCount(); i++)
@@ -1289,6 +1291,7 @@ void Project::Init(const gd::Project& game) {
   categories = game.categories;
   description = game.description;
   firstLayout = game.firstLayout;
+  previewLayout = game.previewLayout;
   version = game.version;
   windowWidth = game.windowWidth;
   windowHeight = game.windowHeight;

--- a/Core/GDCore/Project/Project.cpp
+++ b/Core/GDCore/Project/Project.cpp
@@ -1208,7 +1208,9 @@ void Project::SerializeTo(SerializerElement& element) const {
   GetVariables().SerializeTo(element.AddChild("variables"));
 
   element.SetAttribute("firstLayout", firstLayout);
-  element.SetAttribute("previewLayout", previewLayout);
+  if (!previewLayout.empty()) {
+    element.SetAttribute("previewLayout", previewLayout);
+  }
   gd::SerializerElement& layoutsElement = element.AddChild("layouts");
   layoutsElement.ConsiderAsArrayOf("layout");
   for (std::size_t i = 0; i < GetLayoutsCount(); i++)

--- a/Core/GDCore/Project/Project.h
+++ b/Core/GDCore/Project/Project.h
@@ -848,6 +848,18 @@ class GD_CORE_API Project {
    */
   const gd::String& GetFirstLayout() { return firstLayout; }
 
+  /**
+   * Set the layout used by the IDE to start all previews.
+   * An empty string means there is no preview override.
+   */
+  void SetPreviewLayout(const gd::String& name) { previewLayout = name; }
+
+  /**
+   * Get the layout used by the IDE to start all previews.
+   * Returns an empty string if there is no preview override.
+   */
+  const gd::String& GetPreviewLayout() const { return previewLayout; }
+
   ///@}
 
   /** \name Events functions extensions management
@@ -1159,6 +1171,8 @@ class GD_CORE_API Project {
   std::vector<gd::Platform*>
       platforms;  ///< Pointers to the platforms this project supports.
   gd::String firstLayout;
+  gd::String previewLayout;  ///< Editor-only: layout used by the IDE to start
+                             ///< all previews. Empty if not set.
   gd::String author;        ///< Game author name, for publishing purpose.
   std::vector<gd::String>
       authorIds;  ///< Game author ids, from GDevelop users DB.

--- a/GDevelop.js/Bindings/Bindings.idl
+++ b/GDevelop.js/Bindings/Bindings.idl
@@ -633,6 +633,8 @@ interface Project {
     void RemoveLayout([Const] DOMString name);
     void SetFirstLayout([Const] DOMString name);
     [Const, Ref] DOMString GetFirstLayout();
+    void SetPreviewLayout([Const] DOMString name);
+    [Const, Ref] DOMString GetPreviewLayout();
     unsigned long GetLayoutPosition([Const] DOMString name);
 
     boolean HasExternalEventsNamed([Const] DOMString name);

--- a/GDevelop.js/types/gdproject.js
+++ b/GDevelop.js/types/gdproject.js
@@ -74,6 +74,8 @@ declare class gdProject {
   removeLayout(name: string): void;
   setFirstLayout(name: string): void;
   getFirstLayout(): string;
+  setPreviewLayout(name: string): void;
+  getPreviewLayout(): string;
   getLayoutPosition(name: string): number;
   hasExternalEventsNamed(name: string): boolean;
   getExternalEvents(name: string): gdExternalEvents;

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1236,6 +1236,17 @@ const MainFrame = (props: Props): React.MixedElement => {
           );
         }
 
+        // Apply the preview layout override stored in the project file
+        // (set via "Use this scene to start all previews").
+        const previewLayoutName = project.getPreviewLayout();
+        if (previewLayoutName && project.hasLayoutNamed(previewLayoutName)) {
+          setPreviewOverride({
+            isPreviewOverriden: true,
+            overridenPreviewLayoutName: previewLayoutName,
+            overridenPreviewExternalLayoutName: null,
+          });
+        }
+
         setIsProjectClosedSoAvoidReloadingExtensions(false);
       }
 
@@ -2243,6 +2254,19 @@ const MainFrame = (props: Props): React.MixedElement => {
       overridenPreviewLayoutName,
       overridenPreviewExternalLayoutName,
     }));
+
+    // Persist the preview layout override on the project (like firstLayout),
+    // so it is restored when the project is re-opened.
+    if (currentProject) {
+      const persistedLayoutName =
+        isPreviewOverriden && overridenPreviewLayoutName
+          ? overridenPreviewLayoutName
+          : '';
+      if (currentProject.getPreviewLayout() !== persistedLayoutName) {
+        currentProject.setPreviewLayout(persistedLayoutName);
+        triggerUnsavedChanges();
+      }
+    }
   };
 
   const autosaveProjectIfNeeded = React.useCallback(

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -1240,11 +1240,12 @@ const MainFrame = (props: Props): React.MixedElement => {
         // (set via "Use this scene to start all previews").
         const previewLayoutName = project.getPreviewLayout();
         if (previewLayoutName && project.hasLayoutNamed(previewLayoutName)) {
-          setPreviewOverride({
+          setPreviewState(previewState => ({
+            ...previewState,
             isPreviewOverriden: true,
             overridenPreviewLayoutName: previewLayoutName,
             overridenPreviewExternalLayoutName: null,
-          });
+          }));
         }
 
         setIsProjectClosedSoAvoidReloadingExtensions(false);


### PR DESCRIPTION
Adds a new `previewLayout` string field on `gd::Project` (sibling of
`firstLayout`) that stores the scene used by the IDE to start all
previews. When the user toggles "Use this scene to start all previews"
in the preview menu, the choice is now saved in the project's `.json`
file and restored on next open.

**Behavior**
- Toggling **on**: scene name is written to `previewLayout` in the
  project JSON. Project becomes dirty until saved. After save & reopen
  the override is automatically re-enabled.
- Toggling **off**: `previewLayout` is set to `""`. After reopen, no
  override is applied.
- Old projects without the `previewLayout` field deserialize fine — the
  field defaults to `""`, and the override is simply not enabled.