### PR TITLE
feat: tree-shake unused extension free functions from export

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionsLoader/index.js
@@ -107,8 +107,11 @@ const loadProjectEventsFunctionsExtension = (
 };
 
 /**
- * Get the list of mandatory include files when using the
- * extension.
+ * Get include files for extension lifecycle functions (onFirstSceneLoaded,
+ * onSceneLoaded, etc.) that self-register at load time and are never
+ * referenced via event sheet instructions. Non-lifecycle free functions
+ * are included only when actually referenced (transitive deps resolved
+ * during code generation).
  */
 const getExtensionIncludeFiles = (
   project: gdProject,
@@ -118,6 +121,14 @@ const getExtensionIncludeFiles = (
   const freeEventsFunctions = eventsFunctionsExtension.getEventsFunctions();
   return mapFor(0, freeEventsFunctions.getEventsFunctionsCount(), i => {
     const eventsFunction = freeEventsFunctions.getEventsFunctionAt(i);
+
+    if (
+      !gd.MetadataDeclarationHelper.isExtensionLifecycleEventsFunction(
+        eventsFunction.getName()
+      )
+    ) {
+      return null;
+    }
 
     const functionName = gd.MetadataDeclarationHelper.getFreeFunctionCodeName(
       eventsFunctionsExtension,
@@ -401,7 +412,7 @@ const generateFreeFunctionMetadata = (
   );
   instructionOrExpression.addIncludeFile(functionFile);
 
-  // Always include the extension include files when using a free function.
+  // Include lifecycle function files so they self-register when the extension is loaded.
   codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
     instructionOrExpression.addIncludeFile(includeFile);
   });
@@ -511,7 +522,7 @@ function generateBehaviorMetadata(
 
   behaviorMetadata.addIncludeFile(includeFile);
 
-  // Always include the extension include files when using a behavior.
+  // Include lifecycle function files so they self-register when the extension is loaded.
   codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
     behaviorMetadata.addIncludeFile(includeFile);
   });
@@ -615,7 +626,7 @@ function generateObjectMetadata(
   // Objects may already have included files for 3D for instance.
   objectMetadata.addIncludeFile(includeFile);
 
-  // Always include the extension include files when using an object.
+  // Include lifecycle function files so they self-register when the extension is loaded.
   codeGenerationContext.extensionIncludeFiles.forEach(includeFile => {
     objectMetadata.addIncludeFile(includeFile);
   });


### PR DESCRIPTION
- Only include lifecycle function `.js` files (`onFirstSceneLoaded`, `onSceneLoaded`, etc.) as mandatory extension-wide includes.
- Non-lifecycle free functions are now included only when actually referenced by event sheets.

Previously, using any single free function (or behavior/object) from an extension pulled ALL free function `.js` files into the build via `extensionIncludeFiles`. This was a conservative safety net that is redundant - the code generation pass already records transitive include dependencies per-function.

## Why this is safe
1. **Transitive deps already handled** - when function A's events call function B, the code generator adds B's include to A's metadata during the second-pass compilation.
2. **Lifecycle functions preserved** - `onFirstSceneLoaded`, `onScenePreEvents`, etc. self-register via `gdjs._registerCallback()` at load time and are never referenced through event instructions; they remain in the mandatory include list.
3. **Behaviors/objects unaffected** - their `.js` is included via their own metadata when the type is present in the project.
4. **Validated empirically** - static analysis of multiple production projects confirmed that top-level free functions have no implicit invocation paths beyond event sheet instructions and lifecycle registration.