### PR TITLE
Use -O2 instead of -O3 when linking libGD.js/wasm to speed up CI builds

### DIFF
--- a/GDevelop.js/CMakeLists.txt
+++ b/GDevelop.js/CMakeLists.txt
@@ -117,7 +117,11 @@ elseif("${GDEVELOPJS_BUILD_VARIANT}" STREQUAL "debug-sanitizers")
 	target_link_libraries(GD "-fsanitize=return") # Uncomment to auto-detect occurences of undefined behavior - also enable compiling above!
 else()
 	# Production: link time optimizations and full optimization.
-	target_link_libraries(GD "-O3 -flto")
+	# Use -O2 (rather than -O3) at link time: this drastically reduces the
+	# wasm-opt pass time (~3 min -> ~15 s on CI) while only growing the
+	# gzipped wasm by ~0.2% and leaving runtime performance unchanged on
+	# the GDevelop.js test suite.
+	target_link_libraries(GD "-O2 -flto")
 endif()
 
 # Even if we're building an "executable", prefix it by lib as it's used as a library.


### PR DESCRIPTION
## Summary

Lower the optimization level applied during the final Emscripten link of `libGD.js` / `libGD.wasm` from `-O3` to `-O2`. The link step (specifically the `wasm-opt` pass over the ~3.4 MB wasm output) is the bottleneck of the `build-gdevelop_js-wasm-only` CircleCI job — even with ccache speeding up the compile phase, linking still takes 3–4 minutes.

## Benchmarks

Measured on a 4-vCPU Linux box with emsdk 3.1.21 (same version as CI), `emmake make -j 8`, `release` variant. The CI runner (`medium+`, 3 vCPU) should see a comparable speedup.

### Link / build time

| Phase | `-O3` (current) | `-O2` (this PR) | Δ |
|---|---:|---:|---:|
| Pure relink (delete `libGD.*`, re-make) | 2m52s | **0m14.7s** | **~11.7× faster** |
| Recompile 4 bindings + link | 3m18s | **0m56s** | **~3.5× faster** |

The wasm-opt `-O3` pass over the ~3.4 MB wasm dominates link cost. `-O2` skips the most expensive passes (aggressive inlining, full code-flow optimizations) and finishes in ~15 s instead of ~170 s.

### Output size

| Artifact | `-O3` (current) | `-O2` (this PR) | Δ |
|---|---:|---:|---:|
| `libGD.js` | 2,087,516 B | 2,254,690 B | +167 KB (+8.0%) |
| `libGD.wasm` | 3,394,768 B | 3,629,500 B | +235 KB (+6.9%) |
| `libGD.js` (gzip -9) | 172,210 B | 178,256 B | +5.9 KB (+3.5%) |
| `libGD.wasm` (gzip -9) | 797,415 B | 799,275 B | **+1.8 KB (+0.2%)** |

Uncompressed grows ~7%, but the **gzipped wasm** (what actually goes over the wire) is essentially unchanged (+0.2%). Gzipped JS is +3.5% (~6 KB).

### `npm test` runtime (3 runs each, `--runInBand`)

| Build | jest reported | real time (avg) |
|---|---|---:|
| `-O3` (current) | 9.63 / 9.30 / 9.07 s (avg 9.33 s) | 10.09 s |
| `-O2` (this PR) | 9.51 / 8.60 / 8.18 s (avg 8.76 s) | 9.63 s |

1162 tests pass. Test runtime is unchanged (slight noise if anything favors `-O2`).

## Notes

- Only the link-time `-O` level is changed. Compile-time `-O3 -flto` is kept, so all `.cpp` files are still compiled with full optimizations.
- Other variants (`dev`, `debug`, `debug-assertions`, `debug-sanitizers`) are unaffected.
- I separately confirmed that dropping `-flto` does almost nothing here (only the 4 `Bindings/*.cpp` files are scoped to it via the `GDevelop.js/CMakeLists.txt`-local `add_compile_options`; `GDCore`, `GDJS`, and Extensions are not), so it's left in place for now — the meaningful win is the link-time `-O` level.

## Test plan

- [ ] CI `build-gdevelop_js-wasm-only` job completes noticeably faster (look at the "Build GDevelop.js" step duration)
- [ ] CI `npm test` step still passes (1162 tests)
- [ ] Manually open a few projects in newIDE built with the resulting `libGD.js`/`libGD.wasm` and confirm no perceptible perf regression


---
_Generated by [Claude Code](https://claude.ai/code/session_01QrPZoDgvkpa7Cb9JihqQ68)_