### PR TITLE
Add missing override specifiers to event classes

### DIFF
--- a/Core/GDCore/Events/Builtin/ElseEvent.h
+++ b/Core/GDCore/Events/Builtin/ElseEvent.h
@@ -21,17 +21,17 @@ class GD_CORE_API ElseEvent : public gd::BaseEvent {
  public:
   ElseEvent();
   virtual ~ElseEvent();
-  virtual gd::ElseEvent* Clone() const { return new ElseEvent(*this); }
+  virtual gd::ElseEvent* Clone() const override { return new ElseEvent(*this); }
 
-  virtual bool IsExecutable() const { return true; }
+  virtual bool IsExecutable() const override { return true; }
 
-  virtual bool CanHaveSubEvents() const { return true; }
-  virtual const gd::EventsList& GetSubEvents() const { return events; };
-  virtual gd::EventsList& GetSubEvents() { return events; };
+  virtual bool CanHaveSubEvents() const override { return true; }
+  virtual const gd::EventsList& GetSubEvents() const override { return events; };
+  virtual gd::EventsList& GetSubEvents() override { return events; };
 
-  virtual bool CanHaveVariables() const { return true; }
-  virtual const gd::VariablesContainer& GetVariables() const { return variables; };
-  virtual gd::VariablesContainer& GetVariables() { return variables; };
+  virtual bool CanHaveVariables() const override { return true; }
+  virtual const gd::VariablesContainer& GetVariables() const override { return variables; };
+  virtual gd::VariablesContainer& GetVariables() override { return variables; };
 
   const gd::InstructionsList& GetConditions() const { return conditions; };
   gd::InstructionsList& GetConditions() { return conditions; };
@@ -42,14 +42,14 @@ class GD_CORE_API ElseEvent : public gd::BaseEvent {
   virtual gd::InstructionsList* GetInstructionList(const gd::String& label) override;
   virtual const gd::InstructionsList* GetInstructionList(const gd::String& label) const override;
 
-  virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors() const;
-  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
-  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
-  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
+  virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors() const override;
+  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const override;
+  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors() override;
+  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors() override;
 
-  virtual void SerializeTo(SerializerElement& element) const;
+  virtual void SerializeTo(SerializerElement& element) const override;
   virtual void UnserializeFrom(gd::Project& project,
-                               const SerializerElement& element);
+                               const SerializerElement& element) override;
 
  private:
   gd::InstructionsList conditions;

--- a/Core/GDCore/Events/Builtin/ForEachChildVariableEvent.h
+++ b/Core/GDCore/Events/Builtin/ForEachChildVariableEvent.h
@@ -25,21 +25,21 @@ class GD_CORE_API ForEachChildVariableEvent : public gd::BaseEvent {
  public:
   ForEachChildVariableEvent();
   virtual ~ForEachChildVariableEvent(){};
-  virtual gd::ForEachChildVariableEvent* Clone() const {
+  virtual gd::ForEachChildVariableEvent* Clone() const override {
     return new ForEachChildVariableEvent(*this);
   }
 
-  virtual bool IsExecutable() const { return true; }
+  virtual bool IsExecutable() const override { return true; }
 
-  virtual bool CanHaveSubEvents() const { return true; }
-  virtual const gd::EventsList& GetSubEvents() const { return events; };
-  virtual gd::EventsList& GetSubEvents() { return events; };
+  virtual bool CanHaveSubEvents() const override { return true; }
+  virtual const gd::EventsList& GetSubEvents() const override { return events; };
+  virtual gd::EventsList& GetSubEvents() override { return events; };
 
-  virtual bool CanHaveVariables() const { return true; }
-  virtual const gd::VariablesContainer& GetVariables() const {
+  virtual bool CanHaveVariables() const override { return true; }
+  virtual const gd::VariablesContainer& GetVariables() const override {
     return variables;
   };
-  virtual gd::VariablesContainer& GetVariables() { return variables; };
+  virtual gd::VariablesContainer& GetVariables() override { return variables; };
 
   const gd::InstructionsList& GetConditions() const { return conditions; };
   gd::InstructionsList& GetConditions() { return conditions; };
@@ -100,20 +100,20 @@ class GD_CORE_API ForEachChildVariableEvent : public gd::BaseEvent {
   void SetLoopIndexVariableName(const gd::String& name) { loopIndexVariableName = name; }
 
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
-      const;
-  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
+      const override;
+  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const override;
 
-  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
-  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
+  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors() override;
+  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors() override;
 
   virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
-        GetAllExpressionsWithMetadata() const;
+        GetAllExpressionsWithMetadata() const override;
   virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
-        GetAllExpressionsWithMetadata();
+        GetAllExpressionsWithMetadata() override;
 
-  virtual void SerializeTo(SerializerElement& element) const;
+  virtual void SerializeTo(SerializerElement& element) const override;
   virtual void UnserializeFrom(gd::Project& project,
-                               const SerializerElement& element);
+                               const SerializerElement& element) override;
 
  private:
   gd::Expression valueIteratorVariableName;

--- a/Core/GDCore/Events/Builtin/ForEachEvent.h
+++ b/Core/GDCore/Events/Builtin/ForEachEvent.h
@@ -29,19 +29,19 @@ class GD_CORE_API ForEachEvent : public gd::BaseEvent {
  public:
   ForEachEvent();
   virtual ~ForEachEvent(){};
-  virtual gd::ForEachEvent* Clone() const { return new ForEachEvent(*this); }
+  virtual gd::ForEachEvent* Clone() const override { return new ForEachEvent(*this); }
 
-  virtual bool IsExecutable() const { return true; }
+  virtual bool IsExecutable() const override { return true; }
 
-  virtual bool CanHaveSubEvents() const { return true; }
-  virtual const gd::EventsList& GetSubEvents() const { return events; };
-  virtual gd::EventsList& GetSubEvents() { return events; };
+  virtual bool CanHaveSubEvents() const override { return true; }
+  virtual const gd::EventsList& GetSubEvents() const override { return events; };
+  virtual gd::EventsList& GetSubEvents() override { return events; };
 
-  virtual bool CanHaveVariables() const { return true; }
-  virtual const gd::VariablesContainer& GetVariables() const {
+  virtual bool CanHaveVariables() const override { return true; }
+  virtual const gd::VariablesContainer& GetVariables() const override {
     return variables;
   };
-  virtual gd::VariablesContainer& GetVariables() { return variables; };
+  virtual gd::VariablesContainer& GetVariables() override { return variables; };
 
   const gd::InstructionsList& GetConditions() const { return conditions; };
   gd::InstructionsList& GetConditions() { return conditions; };
@@ -82,19 +82,19 @@ class GD_CORE_API ForEachEvent : public gd::BaseEvent {
   const gd::Expression& GetLimitExpression() const { return limit; };
 
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
-      const;
-  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
+      const override;
+  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const override;
   virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
-      GetAllExpressionsWithMetadata() const;
+      GetAllExpressionsWithMetadata() const override;
 
-  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
-  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
+  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors() override;
+  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors() override;
   virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
-      GetAllExpressionsWithMetadata();
+      GetAllExpressionsWithMetadata() override;
 
-  virtual void SerializeTo(SerializerElement& element) const;
+  virtual void SerializeTo(SerializerElement& element) const override;
   virtual void UnserializeFrom(gd::Project& project,
-                               const SerializerElement& element);
+                               const SerializerElement& element) override;
 
  private:
   gd::Expression objectsToPick;

--- a/Core/GDCore/Events/Builtin/RepeatEvent.h
+++ b/Core/GDCore/Events/Builtin/RepeatEvent.h
@@ -23,19 +23,19 @@ class GD_CORE_API RepeatEvent : public gd::BaseEvent {
  public:
   RepeatEvent();
   virtual ~RepeatEvent(){};
-  virtual gd::RepeatEvent* Clone() const { return new RepeatEvent(*this); }
+  virtual gd::RepeatEvent* Clone() const override { return new RepeatEvent(*this); }
 
-  virtual bool IsExecutable() const { return true; }
+  virtual bool IsExecutable() const override { return true; }
 
-  virtual bool CanHaveSubEvents() const { return true; }
-  virtual const gd::EventsList& GetSubEvents() const { return events; };
-  virtual gd::EventsList& GetSubEvents() { return events; };
+  virtual bool CanHaveSubEvents() const override { return true; }
+  virtual const gd::EventsList& GetSubEvents() const override { return events; };
+  virtual gd::EventsList& GetSubEvents() override { return events; };
 
-  virtual bool CanHaveVariables() const { return true; }
-  virtual const gd::VariablesContainer& GetVariables() const {
+  virtual bool CanHaveVariables() const override { return true; }
+  virtual const gd::VariablesContainer& GetVariables() const override {
     return variables;
   };
-  virtual gd::VariablesContainer& GetVariables() { return variables; };
+  virtual gd::VariablesContainer& GetVariables() override { return variables; };
 
   const gd::InstructionsList& GetConditions() const { return conditions; };
   gd::InstructionsList& GetConditions() { return conditions; };
@@ -56,20 +56,20 @@ class GD_CORE_API RepeatEvent : public gd::BaseEvent {
   const gd::String& GetLoopIndexVariableName() const { return loopIndexVariableName; }
   void SetLoopIndexVariableName(const gd::String& name) { loopIndexVariableName = name; }
 
-  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
-  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
+  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors() override;
+  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors() override;
   virtual std::vector<std::pair<gd::Expression*, gd::ParameterMetadata> >
-      GetAllExpressionsWithMetadata();
+      GetAllExpressionsWithMetadata() override;
 
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
-      const;
-  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
+      const override;
+  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const override;
   virtual std::vector<std::pair<const gd::Expression*, const gd::ParameterMetadata> >
-      GetAllExpressionsWithMetadata() const;
+      GetAllExpressionsWithMetadata() const override;
 
-  virtual void SerializeTo(SerializerElement& element) const;
+  virtual void SerializeTo(SerializerElement& element) const override;
   virtual void UnserializeFrom(gd::Project& project,
-                               const SerializerElement& element);
+                               const SerializerElement& element) override;
 
  private:
   gd::Expression repeatNumberExpression;

--- a/Core/GDCore/Events/Builtin/StandardEvent.h
+++ b/Core/GDCore/Events/Builtin/StandardEvent.h
@@ -25,17 +25,17 @@ class GD_CORE_API StandardEvent : public gd::BaseEvent {
  public:
   StandardEvent();
   virtual ~StandardEvent();
-  virtual gd::StandardEvent* Clone() const { return new StandardEvent(*this); }
+  virtual gd::StandardEvent* Clone() const override { return new StandardEvent(*this); }
 
-  virtual bool IsExecutable() const { return true; }
+  virtual bool IsExecutable() const override { return true; }
 
-  virtual bool CanHaveSubEvents() const { return true; }
-  virtual const gd::EventsList& GetSubEvents() const { return events; };
-  virtual gd::EventsList& GetSubEvents() { return events; };
+  virtual bool CanHaveSubEvents() const override { return true; }
+  virtual const gd::EventsList& GetSubEvents() const override { return events; };
+  virtual gd::EventsList& GetSubEvents() override { return events; };
 
-  virtual bool CanHaveVariables() const { return true; }
-  virtual const gd::VariablesContainer& GetVariables() const { return variables; };
-  virtual gd::VariablesContainer& GetVariables() { return variables; };
+  virtual bool CanHaveVariables() const override { return true; }
+  virtual const gd::VariablesContainer& GetVariables() const override { return variables; };
+  virtual gd::VariablesContainer& GetVariables() override { return variables; };
 
   const gd::InstructionsList& GetConditions() const { return conditions; };
   gd::InstructionsList& GetConditions() { return conditions; };
@@ -47,14 +47,14 @@ class GD_CORE_API StandardEvent : public gd::BaseEvent {
   virtual const gd::InstructionsList* GetInstructionList(const gd::String& label) const override;
 
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
-      const;
-  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
-  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
-  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
+      const override;
+  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const override;
+  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors() override;
+  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors() override;
 
-  virtual void SerializeTo(SerializerElement& element) const;
+  virtual void SerializeTo(SerializerElement& element) const override;
   virtual void UnserializeFrom(gd::Project& project,
-                               const SerializerElement& element);
+                               const SerializerElement& element) override;
 
  private:
   gd::InstructionsList conditions;

--- a/Core/GDCore/Events/Builtin/WhileEvent.h
+++ b/Core/GDCore/Events/Builtin/WhileEvent.h
@@ -31,19 +31,19 @@ class GD_CORE_API WhileEvent : public gd::BaseEvent {
         justCreatedByTheUser(true),
         variables(gd::VariablesContainer::SourceType::Local){};
   virtual ~WhileEvent(){};
-  virtual gd::WhileEvent* Clone() const { return new WhileEvent(*this); }
+  virtual gd::WhileEvent* Clone() const override { return new WhileEvent(*this); }
 
-  virtual bool IsExecutable() const { return true; }
+  virtual bool IsExecutable() const override { return true; }
 
-  virtual bool CanHaveSubEvents() const { return true; }
-  virtual const gd::EventsList& GetSubEvents() const { return events; };
-  virtual gd::EventsList& GetSubEvents() { return events; };
+  virtual bool CanHaveSubEvents() const override { return true; }
+  virtual const gd::EventsList& GetSubEvents() const override { return events; };
+  virtual gd::EventsList& GetSubEvents() override { return events; };
 
-  virtual bool CanHaveVariables() const { return true; }
-  virtual const gd::VariablesContainer& GetVariables() const {
+  virtual bool CanHaveVariables() const override { return true; }
+  virtual const gd::VariablesContainer& GetVariables() const override {
     return variables;
   };
-  virtual gd::VariablesContainer& GetVariables() { return variables; };
+  virtual gd::VariablesContainer& GetVariables() override { return variables; };
 
   const gd::InstructionsList& GetConditions() const { return conditions; };
   gd::InstructionsList& GetConditions() { return conditions; };
@@ -67,15 +67,15 @@ class GD_CORE_API WhileEvent : public gd::BaseEvent {
   const gd::String& GetLoopIndexVariableName() const { return loopIndexVariableName; }
   void SetLoopIndexVariableName(const gd::String& name) { loopIndexVariableName = name; }
 
-  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors();
-  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors();
+  virtual std::vector<gd::InstructionsList*> GetAllConditionsVectors() override;
+  virtual std::vector<gd::InstructionsList*> GetAllActionsVectors() override;
   virtual std::vector<const gd::InstructionsList*> GetAllConditionsVectors()
-      const;
-  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const;
+      const override;
+  virtual std::vector<const gd::InstructionsList*> GetAllActionsVectors() const override;
 
-  virtual void SerializeTo(SerializerElement& element) const;
+  virtual void SerializeTo(SerializerElement& element) const override;
   virtual void UnserializeFrom(gd::Project& project,
-                               const SerializerElement& element);
+                               const SerializerElement& element) override;
 
  private:
   gd::InstructionsList whileConditions;


### PR DESCRIPTION
Every virtual method that overrides a BaseEvent member is now explicitly marked with override.