### PR TITLE
Close terminal on success for toolbar npm scripts

### DIFF
--- a/newIDE/app/src/MainFrame/CustomToolbarButton.js
+++ b/newIDE/app/src/MainFrame/CustomToolbarButton.js
@@ -14,6 +14,7 @@ export type ToolbarButtonConfig = {|
   icon: string,
   npmScript: string,
   hook?: ToolbarButtonHooksNames,
+  keepTerminalOpen?: boolean,
 |};
 
 type Props = {|

--- a/newIDE/app/src/MainFrame/NpmScriptRunner/useNpmScriptRunner.js
+++ b/newIDE/app/src/MainFrame/NpmScriptRunner/useNpmScriptRunner.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PreferencesContext from '../Preferences/PreferencesContext';
 import { runNpmScript } from '../../Utils/NpmScriptExecutor';
+import type { ScriptEntry } from '../../Utils/NpmScriptExecutor';
 import type {
   ToolbarButtonConfig,
   ToolbarButtonHooksNames,
@@ -20,18 +21,13 @@ type Props = {|
   previewCount: number,
 |};
 
-export type TriggerNpmScript = (
-  npmScript: string,
-  keepTerminalOpen?: boolean
-) => void;
+export type TriggerNpmScript = (entry: ScriptEntry) => void;
 
 type ReturnType = {|
   triggerNpmScript: TriggerNpmScript,
   renderNpmScriptConfirmDialog: () => React.Node,
   projectPath: ?string,
 |};
-
-type ScriptEntry = {| script: string, keepTerminalOpen: boolean |};
 
 const getScriptsByHookName = (
   toolbarButtons: Array<ToolbarButtonConfig>,
@@ -41,7 +37,7 @@ const getScriptsByHookName = (
     if (btn.hook === hookName)
       entries.push({
         script: btn.npmScript,
-        keepTerminalOpen: btn.keepTerminalOpen === true,
+        keepTerminalOpen: btn.keepTerminalOpen,
       });
     return entries;
   }, []);
@@ -89,7 +85,7 @@ const useNpmScriptRunner = ({
         setConfirmDialogOpen(true);
         return;
       }
-      entries.forEach(e => runNpmScript(path, e.script, e.keepTerminalOpen));
+      entries.forEach(e => runNpmScript(path, e));
     },
     [disableNpmScriptConfirmation]
   );
@@ -107,12 +103,9 @@ const useNpmScriptRunner = ({
   );
 
   const triggerNpmScript = React.useCallback(
-    (npmScript: string, keepTerminalOpen?: boolean) => {
+    (entry: ScriptEntry) => {
       if (!projectPath) return;
-      scheduleOrRunRef.current(
-        [{ script: npmScript, keepTerminalOpen: keepTerminalOpen === true }],
-        projectPath
-      );
+      scheduleOrRunRef.current([entry], projectPath);
     },
     [projectPath]
   );
@@ -122,9 +115,7 @@ const useNpmScriptRunner = ({
       setConfirmDialogOpen(false);
       if (dontShowAgain) setDisableNpmScriptConfirmation(true);
       if (pending) {
-        pending.entries.forEach(e =>
-          runNpmScript(pending.path, e.script, e.keepTerminalOpen)
-        );
+        pending.entries.forEach(e => runNpmScript(pending.path, e));
       }
       setPending(null);
     },

--- a/newIDE/app/src/MainFrame/NpmScriptRunner/useNpmScriptRunner.js
+++ b/newIDE/app/src/MainFrame/NpmScriptRunner/useNpmScriptRunner.js
@@ -20,7 +20,10 @@ type Props = {|
   previewCount: number,
 |};
 
-export type TriggerNpmScript = (npmScript: string) => void;
+export type TriggerNpmScript = (
+  npmScript: string,
+  keepTerminalOpen?: boolean
+) => void;
 
 type ReturnType = {|
   triggerNpmScript: TriggerNpmScript,
@@ -28,13 +31,19 @@ type ReturnType = {|
   projectPath: ?string,
 |};
 
+type ScriptEntry = {| script: string, keepTerminalOpen: boolean |};
+
 const getScriptsByHookName = (
   toolbarButtons: Array<ToolbarButtonConfig>,
   hookName: ToolbarButtonHooksNames
-): Array<string> => {
-  return toolbarButtons.reduce((scripts, btn) => {
-    if (btn.hook === hookName) scripts.push(btn.npmScript);
-    return scripts;
+): Array<ScriptEntry> => {
+  return toolbarButtons.reduce((entries, btn) => {
+    if (btn.hook === hookName)
+      entries.push({
+        script: btn.npmScript,
+        keepTerminalOpen: btn.keepTerminalOpen === true,
+      });
+    return entries;
   }, []);
 };
 
@@ -63,24 +72,24 @@ const useNpmScriptRunner = ({
 
   const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
   const [pending, setPending] = React.useState<{|
-    scripts: Array<string>,
+    entries: Array<ScriptEntry>,
     path: string,
     hookName?: ToolbarButtonHooksNames,
   |} | null>(null);
 
   const scheduleOrRun = React.useCallback(
     (
-      scripts: Array<string>,
+      entries: Array<ScriptEntry>,
       path: string,
       hookName?: ToolbarButtonHooksNames
     ) => {
-      if (!scripts.length) return;
+      if (!entries.length) return;
       if (!disableNpmScriptConfirmation) {
-        setPending({ scripts, path, hookName });
+        setPending({ entries, path, hookName });
         setConfirmDialogOpen(true);
         return;
       }
-      scripts.forEach(s => runNpmScript(path, s));
+      entries.forEach(e => runNpmScript(path, e.script, e.keepTerminalOpen));
     },
     [disableNpmScriptConfirmation]
   );
@@ -91,16 +100,19 @@ const useNpmScriptRunner = ({
   const callHook = React.useCallback(
     (hookName: ToolbarButtonHooksNames) => {
       if (!projectPath) return;
-      const scripts = getScriptsByHookName(toolbarButtons, hookName);
-      scheduleOrRunRef.current(scripts, projectPath, hookName);
+      const entries = getScriptsByHookName(toolbarButtons, hookName);
+      scheduleOrRunRef.current(entries, projectPath, hookName);
     },
     [toolbarButtons, projectPath]
   );
 
   const triggerNpmScript = React.useCallback(
-    (npmScript: string) => {
+    (npmScript: string, keepTerminalOpen?: boolean) => {
       if (!projectPath) return;
-      scheduleOrRunRef.current([npmScript], projectPath);
+      scheduleOrRunRef.current(
+        [{ script: npmScript, keepTerminalOpen: keepTerminalOpen === true }],
+        projectPath
+      );
     },
     [projectPath]
   );
@@ -110,7 +122,9 @@ const useNpmScriptRunner = ({
       setConfirmDialogOpen(false);
       if (dontShowAgain) setDisableNpmScriptConfirmation(true);
       if (pending) {
-        pending.scripts.forEach(s => runNpmScript(pending.path, s));
+        pending.entries.forEach(e =>
+          runNpmScript(pending.path, e.script, e.keepTerminalOpen)
+        );
       }
       setPending(null);
     },
@@ -144,7 +158,7 @@ const useNpmScriptRunner = ({
 
   const isAutoRun = !!(pending && pending.hookName);
   const scriptNames = pending
-    ? pending.scripts.join(', ')
+    ? pending.entries.map(e => e.script).join(', ')
     : toolbarButtons.map(b => b.npmScript).join(', ');
   const callingHookName =
     pending && pending.hookName ? pending.hookName : undefined;

--- a/newIDE/app/src/MainFrame/Toolbar/index.js
+++ b/newIDE/app/src/MainFrame/Toolbar/index.js
@@ -83,7 +83,9 @@ const LeftButtonsToolbarGroup = React.memo<LeftButtonsToolbarGroupProps>(
               key={index}
               name={button.name}
               icon={button.icon}
-              onClick={() => triggerNpmScript(button.npmScript)}
+              onClick={() =>
+                triggerNpmScript(button.npmScript, button.keepTerminalOpen)
+              }
             />
           ))}
           {props.checkedOutVersionStatus && (

--- a/newIDE/app/src/MainFrame/Toolbar/index.js
+++ b/newIDE/app/src/MainFrame/Toolbar/index.js
@@ -84,7 +84,10 @@ const LeftButtonsToolbarGroup = React.memo<LeftButtonsToolbarGroupProps>(
               name={button.name}
               icon={button.icon}
               onClick={() =>
-                triggerNpmScript(button.npmScript, button.keepTerminalOpen)
+                triggerNpmScript({
+                  script: button.npmScript,
+                  keepTerminalOpen: button.keepTerminalOpen,
+                })
               }
             />
           ))}

--- a/newIDE/app/src/Utils/NpmScriptExecutor.js
+++ b/newIDE/app/src/Utils/NpmScriptExecutor.js
@@ -11,13 +11,18 @@ const ipcRenderer = electron ? electron.ipcRenderer : null;
  */
 export const runNpmScript = (
   projectPath: string,
-  npmScript: string
+  npmScript: string,
+  keepTerminalOpen: boolean = false
 ): boolean => {
   if (!ipcRenderer) {
     console.warn('npm scripts are only supported in the desktop app');
     return false;
   }
 
-  ipcRenderer.send('run-npm-script', { projectPath, npmScript });
+  ipcRenderer.send('run-npm-script', {
+    projectPath,
+    npmScript,
+    keepTerminalOpen,
+  });
   return true;
 };

--- a/newIDE/app/src/Utils/NpmScriptExecutor.js
+++ b/newIDE/app/src/Utils/NpmScriptExecutor.js
@@ -1,6 +1,8 @@
 // @flow
 import optionalRequire from './OptionalRequire';
 
+export type ScriptEntry = {| script: string, keepTerminalOpen?: boolean |};
+
 const electron = optionalRequire('electron');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
 
@@ -11,8 +13,7 @@ const ipcRenderer = electron ? electron.ipcRenderer : null;
  */
 export const runNpmScript = (
   projectPath: string,
-  npmScript: string,
-  keepTerminalOpen: boolean = false
+  entry: ScriptEntry
 ): boolean => {
   if (!ipcRenderer) {
     console.warn('npm scripts are only supported in the desktop app');
@@ -21,8 +22,8 @@ export const runNpmScript = (
 
   ipcRenderer.send('run-npm-script', {
     projectPath,
-    npmScript,
-    keepTerminalOpen,
+    npmScript: entry.script,
+    keepTerminalOpen: !!entry.keepTerminalOpen,
   });
   return true;
 };

--- a/newIDE/app/src/Utils/ProjectSettingsReader.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.js
@@ -71,6 +71,13 @@ export const parseToolbarButtons = (
       if (matchedHook) {
         toolbarButtonConfig.hook = matchedHook;
       }
+      const keepTerminalOpen = SafeExtractor.extractBooleanProperty(
+        rawButton,
+        'keepTerminalOpen'
+      );
+      if (keepTerminalOpen === true) {
+        toolbarButtonConfig.keepTerminalOpen = true;
+      }
       toolbarButtons.push(toolbarButtonConfig);
     }
   }

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -797,70 +797,80 @@ app.on('ready', function() {
 
   setUpDiscordRichPresence(ipcMain);
 
+  const NPM_SCRIPT_COMMAND_FAILED_MESSAGE = 'Command failed!';
+
   // npm script execution in external terminal (cross-platform)
-  ipcMain.on('run-npm-script', (event, { projectPath, npmScript }) => {
-    log.info(`Running npm script "${npmScript}" in ${projectPath}`);
+  ipcMain.on(
+    'run-npm-script',
+    (event, { projectPath, npmScript, keepTerminalOpen }) => {
+      log.info(`Running npm script "${npmScript}" in ${projectPath}`);
 
-    const platform = process.platform;
-    const npmCommand = `npm run ${npmScript}`;
+      const platform = process.platform;
+      const npmCommand = `npm run ${npmScript}`;
+      const keepOpen = !!keepTerminalOpen;
 
-    try {
-      if (platform === 'win32') {
-        // Windows: open cmd window that stays open after npm command
-        child_process
-          .spawn(
-            'cmd.exe',
-            [
-              '/c',
-              'start',
+      try {
+        if (platform === 'win32') {
+          const innerCmd = keepOpen
+            ? `cd /d ${projectPath} && ${npmCommand}`
+            : `cd /d ${projectPath} && ${npmCommand} || (echo. & echo ${NPM_SCRIPT_COMMAND_FAILED_MESSAGE} & pause)`;
+          const cmdCloseFlag = keepOpen ? '/k' : '/c';
+          child_process
+            .spawn(
               'cmd.exe',
-              '/k',
-              `cd /d ${projectPath} && ${npmCommand}`,
-            ],
-            {
-              detached: true,
-              stdio: 'ignore',
-            }
-          )
-          .unref();
-      } else if (platform === 'darwin') {
-        const escapedPath = projectPath.replace(/'/g, "'\\''");
-        const script = `tell application "Terminal" to do script "cd '${escapedPath}' && ${npmCommand}"`;
-        child_process.spawn('osascript', ['-e', script], {
-          detached: true,
-          stdio: 'ignore',
-        });
-      } else {
-        // Linux: try common terminal emulators
-        const bashCommand = `cd "${projectPath}" && ${npmCommand}; exec bash`;
-        const terminals = [
-          {
-            cmd: 'x-terminal-emulator',
-            args: ['-e', 'bash', '-c', bashCommand],
-          },
-          { cmd: 'gnome-terminal', args: ['--', 'bash', '-c', bashCommand] },
-          { cmd: 'konsole', args: ['-e', 'bash', '-c', bashCommand] },
-          { cmd: 'xterm', args: ['-e', 'bash', '-c', bashCommand] },
-        ];
-
-        const tryTerminal = index => {
-          if (index >= terminals.length) {
-            log.error('No terminal emulator found');
-            return;
-          }
-          const terminal = terminals[index];
-          const proc = child_process.spawn(terminal.cmd, terminal.args, {
+              ['/c', 'start', 'cmd.exe', cmdCloseFlag, innerCmd],
+              {
+                detached: true,
+                stdio: 'ignore',
+              }
+            )
+            .unref();
+        } else if (platform === 'darwin') {
+          const escapedPath = projectPath.replace(/'/g, "'\\''");
+          const shellCommand = keepOpen
+            ? `cd '${escapedPath}' && ${npmCommand}`
+            : `cd '${escapedPath}' && ${npmCommand} && exit || echo "${NPM_SCRIPT_COMMAND_FAILED_MESSAGE}"`;
+          const script = `tell application "Terminal" to do script "${shellCommand.replace(
+            /"/g,
+            '\\"'
+          )}"`;
+          child_process.spawn('osascript', ['-e', script], {
             detached: true,
             stdio: 'ignore',
           });
-          proc.on('error', () => tryTerminal(index + 1));
-          proc.unref();
-        };
+        } else {
+          const bashCommand = keepOpen
+            ? `cd "${projectPath}" && ${npmCommand}; exec bash`
+            : `cd "${projectPath}" && ${npmCommand} || { echo "${NPM_SCRIPT_COMMAND_FAILED_MESSAGE}"; exec bash; }`;
+          const terminals = [
+            {
+              cmd: 'x-terminal-emulator',
+              args: ['-e', 'bash', '-c', bashCommand],
+            },
+            { cmd: 'gnome-terminal', args: ['--', 'bash', '-c', bashCommand] },
+            { cmd: 'konsole', args: ['-e', 'bash', '-c', bashCommand] },
+            { cmd: 'xterm', args: ['-e', 'bash', '-c', bashCommand] },
+          ];
 
-        tryTerminal(0);
+          const tryTerminal = index => {
+            if (index >= terminals.length) {
+              log.error('No terminal emulator found');
+              return;
+            }
+            const terminal = terminals[index];
+            const proc = child_process.spawn(terminal.cmd, terminal.args, {
+              detached: true,
+              stdio: 'ignore',
+            });
+            proc.on('error', () => tryTerminal(index + 1));
+            proc.unref();
+          };
+
+          tryTerminal(0);
+        }
+      } catch (err) {
+        log.error('Failed to run npm script:', err);
       }
-    } catch (err) {
-      log.error('Failed to run npm script:', err);
     }
-  });
+  );
 });


### PR DESCRIPTION
External terminal opened by toolbar buttons now closes automatically on success. On failure it stays open with "Command failed!" message.
Per-button `keepTerminalOpen: true` in `gdevelop-settings.yaml` restores old always-open behavior.
### Changes
- `CustomToolbarButton.js` - added optional `keepTerminalOpen` to button config type
- `ProjectSettingsReader.js` - parse `keepTerminalOpen` per toolbar button entry
- `useNpmScriptRunner.js` - pass per-button flag through to executor
- `NpmScriptExecutor.js` - forward `keepTerminalOpen` via IPC
- `electron-app/main.js` - terminal uses `/c` (Windows) or conditional `exit` (macOS/Linux) by default; falls back to `/k` / `exec bash` when `keepTerminalOpen` is set
### YAML example
```yaml
toolbarButtons:
  - name: Build
    icon: '🔨'
    npmScript: build
  - name: Dev Server
    icon: '🖥️'
    npmScript: dev
    keepTerminalOpen: true