### PR TITLE
Fix decimal values not updating number fields

### DIFF
--- a/newIDE/app/src/UI/CompactSemiControlledNumberField/CompactSemiControlledNumberField.spec.js
+++ b/newIDE/app/src/UI/CompactSemiControlledNumberField/CompactSemiControlledNumberField.spec.js
@@ -1,0 +1,61 @@
+// @flow
+
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import renderer from 'react-test-renderer';
+import CompactSemiControlledNumberField from '.';
+import CompactTextField from '../CompactTextField';
+
+describe('CompactSemiControlledNumberField', () => {
+  describe('onChange called on value change', () => {
+    // Regression: the containsMathCharacters regex /[+-/*^()%]/ used to match
+    // '.' (decimal point) via the ASCII range +-/ (chars 43-47), causing
+    // decimal values to be treated as math expressions and skipping onChange
+    // during keyInput/wheel events. Fixed by escaping: /[+\-/*^()%]/.
+
+    it('calls onChange when scrolling up on a field with a decimal value', () => {
+      const onChange: (value: number) => void = jest.fn();
+      const component = renderer.create(
+        <CompactSemiControlledNumberField value={92.12} onChange={onChange} />
+      );
+
+      const compactTextField = component.root.findByType(CompactTextField);
+      act(() => {
+        compactTextField.props.onWheel({
+          deltaY: -1,
+          preventDefault: () => {},
+        });
+      });
+
+      expect(onChange).toHaveBeenCalledWith(93.12);
+    });
+
+    it('calls onChange when pressing ArrowUp on a field with a decimal value', () => {
+      const onChange: (value: number) => void = jest.fn();
+      const component = renderer.create(
+        <CompactSemiControlledNumberField value={92.12} onChange={onChange} />
+      );
+
+      const input = component.root.findByType('input');
+      act(() => {
+        input.props.onKeyDown({ key: 'ArrowUp', preventDefault: () => {} });
+      });
+
+      expect(onChange).toHaveBeenCalledWith(93.12);
+    });
+
+    it('calls onChange when a decimal number is typed in a field', () => {
+      const onChange: (value: number) => void = jest.fn();
+      const component = renderer.create(
+        <CompactSemiControlledNumberField value={1.3} onChange={onChange} />
+      );
+
+      const input = component.root.findByType('input');
+      act(() => {
+        input.props.onChange({ currentTarget: { value: '1.35' } });
+      });
+
+      expect(onChange).toHaveBeenCalledWith(1.35);
+    });
+  });
+});

--- a/newIDE/app/src/UI/CompactSemiControlledNumberField/index.js
+++ b/newIDE/app/src/UI/CompactSemiControlledNumberField/index.js
@@ -102,7 +102,7 @@ const CompactSemiControlledNumberField = ({
         const isValueWithLeadingSign = /[+-]\s*\d+/.test(newValueAsString);
         // parseFloat correctly parses '12+' as '12' so we need to check
         // for math characters ourselves.
-        const containsMathCharacters = /[+-/*^()%]/.test(newValueAsString);
+        const containsMathCharacters = /[+\-/*^()%]/.test(newValueAsString);
         const isNewValueAsFloatValidOrStartsWithSign =
           newValueAsValidFloat !== null &&
           (!containsMathCharacters ||


### PR DESCRIPTION
Fix https://forum.gdevelop.io/t/3d-model-resize-not-updating-with-mouse-scroll-wheel/75795

The regex was too strong and was considering a decimal as if a math expression was being written

https://github.com/user-attachments/assets/c864373c-7882-4af1-aa47-6957550ce014

