### PR TITLE
Remove redundant gd::String expression member from ExpressionParser2

### DIFF
--- a/Core/GDCore/Events/Parsers/ExpressionParser2.cpp
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.cpp
@@ -29,8 +29,7 @@ namespace gd {
 gd::String ExpressionParser2::NAMESPACE_SEPARATOR = "::";
 
 ExpressionParser2::ExpressionParser2()
-    : expression(""),
-      currentPosition(0) {}
+    : currentPosition(0) {}
 
 std::unique_ptr<TextNode> ExpressionParser2::ReadText() {
   size_t textStartPosition = GetCurrentPosition();

--- a/Core/GDCore/Events/Parsers/ExpressionParser2.h
+++ b/Core/GDCore/Events/Parsers/ExpressionParser2.h
@@ -54,15 +54,15 @@ class GD_CORE_API ExpressionParser2 {
    * \return The node representing the expression as a parsed tree.
    */
   std::unique_ptr<ExpressionNode> ParseExpression(
-      const gd::String &expression_) {
-    expression = expression_;
+      const gd::String &expression) {
     // Parse over a UTF-32 (fixed-width) copy of the expression: gd::String is
     // UTF-8, so indexing it by character position (operator[]) and computing
     // its size() are both O(position)/O(length). Doing that for every
     // character would make parsing O(N^2) in the expression length (which is
     // catastrophic for very large expressions). std::u32string gives O(1)
-    // random access and size.
-    expressionUtf32 = expression_.ToUTF32();
+    // random access and size, while keeping the same character indices (and so
+    // the same node locations) as gd::String.
+    expressionUtf32 = expression.ToUTF32();
 
     currentPosition = 0;
     return Start();
@@ -629,8 +629,8 @@ class GD_CORE_API ExpressionParser2 {
 
   bool IsNamespaceSeparator() {
     // Namespace separator is a special kind of delimiter as it is 2 characters
-    // long
-    const std::u32string separator = NAMESPACE_SEPARATOR.ToUTF32();
+    // long. Computed once as the separator is a compile-time constant ("::").
+    static const std::u32string separator = NAMESPACE_SEPARATOR.ToUTF32();
     return (currentPosition + separator.size() <= expressionUtf32.size() &&
             expressionUtf32.compare(
                 currentPosition, separator.size(), separator) == 0);
@@ -741,8 +741,9 @@ class GD_CORE_API ExpressionParser2 {
   }
   ///@}
 
-  gd::String expression;
-  // UTF-32 view of `expression`, used for O(1) character access during parsing.
+  // The expression being parsed, stored as UTF-32 (fixed-width) so that
+  // character access (operator[]) and size() are O(1). See ParseExpression for
+  // the rationale.
   std::u32string expressionUtf32;
   std::size_t currentPosition;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Follow-up code review of the "Speed up expression parsing" commit, which introduced a UTF-32 copy (`expressionUtf32`) of the input so that character access (`operator[]`) and `size()` are O(1) instead of `gd::String`'s O(position)/O(length) (UTF-8) cost.

## Problem

After that change, **all** parsing reads from `expressionUtf32`. The original `gd::String expression` member was still assigned in `ParseExpression` but never read again. That left two representations of the same input which had to be kept in sync — a footgun: a future edit touching one but not the other (or relying on the now-stale UTF-8 member) would introduce subtle, hard-to-find bugs.

This is safe because `gd::String` indexing is **codepoint-based** (`value_type` is `char32_t`, `size()` returns the number of characters), so a character index into `expressionUtf32` is identical to the same index into the old `gd::String`. Node locations (`ExpressionParserLocation`) are therefore unchanged.

## Changes

- Remove the dead `gd::String expression` member, its assignment in `ParseExpression`, and its constructor initializer. The `ParseExpression` parameter is renamed back from `expression_` to `expression` now that there's no member to shadow.
- Cache the namespace separator's UTF-32 conversion as a function-local `static const` instead of recomputing `NAMESPACE_SEPARATOR.ToUTF32()` on every `IsNamespaceSeparator()` call (it's the compile-time constant `"::"`).
- Clarify the related comments.

## Testing

- `GDCore_tests` full suite: all 73 test cases pass (8159 assertions).
- All 8 expression test cases (parser, node printer, code generator, completion finder, node location finder, syntax coloring, naughty strings, benchmarks) pass — including 712 unicode "naughty string" inputs that exercise the UTF-32 path.
- Re-ran the expression suite under AddressSanitizer + UndefinedBehaviorSanitizer (Debug build) with no errors, confirming the UTF-32 indexing path is memory-safe.

## Other code review notes (not addressed here)

- `ParseExpression` allocates a full UTF-32 copy on every call; this is the intended trade-off for O(1) access and is fine. Worth keeping in mind if parsers are created in very hot loops.
- The profiling/logging additions in `ExporterHelper.cpp` and `bench-parse.js` from the speedup commit look like temporary instrumentation; consider whether they should remain in the final merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65cc68fc-2ef8-473b-9120-4161a4292ae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65cc68fc-2ef8-473b-9120-4161a4292ae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

