### PR TITLE
Clean up temporary instances and references before deletion

### DIFF
--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -215,10 +215,14 @@ export default class InstancesAdder {
   };
 
   /**
-   * Return the temporary instances currently added on the scene.
+   * Check if the given instance is one of the temporary instances added while
+   * an object is being dragged over the scene.
    */
-  getTemporaryInstances(): Array<gdInitialInstance> {
-    return this._temporaryInstances;
+  isTemporaryInstance(instance: ?gdInitialInstance): boolean {
+    if (!instance) return false;
+    return this._temporaryInstances.some(
+      temporaryInstance => temporaryInstance.ptr === instance.ptr
+    );
   }
 
   /**

--- a/newIDE/app/src/InstancesEditor/InstancesAdder.js
+++ b/newIDE/app/src/InstancesEditor/InstancesAdder.js
@@ -215,6 +215,13 @@ export default class InstancesAdder {
   };
 
   /**
+   * Return the temporary instances currently added on the scene.
+   */
+  getTemporaryInstances(): Array<gdInitialInstance> {
+    return this._temporaryInstances;
+  }
+
+  /**
    * Delete the temporary instances.
    */
   deleteTemporaryInstances() {

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -1581,6 +1581,32 @@ export default class InstancesEditor extends Component<Props, State> {
     this.highlightedInstance.setInstance(null);
   };
 
+  /**
+   * Delete the temporary instances added while an object is dragged over the
+   * canvas. Before they are deleted (and their underlying C++ object freed),
+   * any reference kept by the UI must be cleared - otherwise a dangling
+   * reference would be read while rendering, showing a corrupted tooltip and a
+   * "phantom" instance rendered with a default texture.
+   */
+  _deleteTemporaryInstances = () => {
+    const temporaryInstances = this._instancesAdder.getTemporaryInstances();
+    if (temporaryInstances.length) {
+      const highlightedInstance = this.highlightedInstance.getInstance();
+      if (
+        highlightedInstance &&
+        temporaryInstances.some(
+          instance => instance.ptr === highlightedInstance.ptr
+        )
+      ) {
+        this.highlightedInstance.setInstance(null);
+      }
+      temporaryInstances.forEach(instance => {
+        this.props.instancesSelection.unselectInstance(instance);
+      });
+    }
+    this._instancesAdder.deleteTemporaryInstances();
+  };
+
   // Debounce function to avoid storing history for each pixel move when user
   // keeps pressing an arrow key.
   // $FlowFixMe[missing-local-annot]
@@ -1896,7 +1922,7 @@ export default class InstancesEditor extends Component<Props, State> {
           if (monitor.didDrop()) {
             // Drop was done somewhere else (in a child of the canvas:
             // should not happen, but still handling this case).
-            _instancesAdder.deleteTemporaryInstances();
+            this._deleteTemporaryInstances();
             return;
           }
 
@@ -1918,7 +1944,7 @@ export default class InstancesEditor extends Component<Props, State> {
           // take this opportunity to delete any temporary instances
           // if the dragging is not done anymore over the canvas.
           if (this._instancesAdder && !isOver) {
-            this._instancesAdder.deleteTemporaryInstances();
+            this._deleteTemporaryInstances();
           }
 
           return connectDropTarget(

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -1582,15 +1582,16 @@ export default class InstancesEditor extends Component<Props, State> {
   };
 
   /**
-   * Delete the temporary instances added while an object is dragged over the
-   * canvas. Before they are deleted (and their underlying C++ object freed),
-   * any reference kept by the UI must be cleared - otherwise a dangling
-   * reference would be read while rendering, showing a corrupted tooltip and a
-   * "phantom" instance rendered with a default texture.
+   * Delete the temporary instances added while an object is dragged - ensuring
+   * no reference to it is kept.
    */
   _deleteTemporaryInstances = () => {
     const temporaryInstances = this._instancesAdder.getTemporaryInstances();
     if (temporaryInstances.length) {
+      // A temporary instance can be the highlighted one (it gets highlighted on
+      // hover while being dragged over the canvas). Clear the reference before
+      // it's deleted, otherwise the rendering would read the freed instance and
+      // show a corrupted tooltip and a "phantom" default-texture instance.
       const highlightedInstance = this.highlightedInstance.getInstance();
       if (
         highlightedInstance &&
@@ -1600,6 +1601,9 @@ export default class InstancesEditor extends Component<Props, State> {
       ) {
         this.highlightedInstance.setInstance(null);
       }
+      // Out of caution: a temporary instance is not expected to be selected
+      // (selection only happens on a click on the canvas), but make sure the
+      // selection never keeps a reference to a soon-to-be-freed instance.
       temporaryInstances.forEach(instance => {
         this.props.instancesSelection.unselectInstance(instance);
       });

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -1586,28 +1586,28 @@ export default class InstancesEditor extends Component<Props, State> {
    * no reference to it is kept.
    */
   _deleteTemporaryInstances = () => {
-    const temporaryInstances = this._instancesAdder.getTemporaryInstances();
-    if (temporaryInstances.length) {
-      // A temporary instance can be the highlighted one (it gets highlighted on
-      // hover while being dragged over the canvas). Clear the reference before
-      // it's deleted, otherwise the rendering would read the freed instance and
-      // show a corrupted tooltip and a "phantom" default-texture instance.
-      const highlightedInstance = this.highlightedInstance.getInstance();
-      if (
-        highlightedInstance &&
-        temporaryInstances.some(
-          instance => instance.ptr === highlightedInstance.ptr
-        )
-      ) {
-        this.highlightedInstance.setInstance(null);
-      }
-      // Out of caution: a temporary instance is not expected to be selected
-      // (selection only happens on a click on the canvas), but make sure the
-      // selection never keeps a reference to a soon-to-be-freed instance.
-      temporaryInstances.forEach(instance => {
-        this.props.instancesSelection.unselectInstance(instance);
-      });
+    // A temporary instance can be the highlighted one (it gets highlighted on
+    // hover while being dragged over the canvas). Clear the reference before
+    // it's deleted, otherwise the rendering would read the freed instance and
+    // show a corrupted tooltip and a "phantom" default-texture instance.
+    if (
+      this._instancesAdder.isTemporaryInstance(
+        this.highlightedInstance.getInstance()
+      )
+    ) {
+      this.highlightedInstance.setInstance(null);
     }
+    // Out of caution: a temporary instance is not expected to be selected
+    // (selection only happens on a click on the canvas), but make sure the
+    // selection never keeps a reference to a soon-to-be-freed instance.
+    this.props.instancesSelection
+      .getSelectedInstances()
+      .slice()
+      .forEach(instance => {
+        if (this._instancesAdder.isTemporaryInstance(instance)) {
+          this.props.instancesSelection.unselectInstance(instance);
+        }
+      });
     this._instancesAdder.deleteTemporaryInstances();
   };
 


### PR DESCRIPTION
Fix bug where temporary instances (created during drag operations) could remain referenced as the highlighted instance.