### PR TITLE
Add tile scale property to 3D Box object

### DIFF
--- a/Extensions/3D/Cube3DRuntimeObject.ts
+++ b/Extensions/3D/Cube3DRuntimeObject.ts
@@ -21,6 +21,7 @@ namespace gdjs {
       rightFaceResourceRepeat: boolean | undefined;
       topFaceResourceRepeat: boolean | undefined;
       bottomFaceResourceRepeat: boolean | undefined;
+      tileScale: number | undefined;
       frontFaceVisible: boolean;
       backFaceVisible: boolean;
       leftFaceVisible: boolean;
@@ -48,6 +49,7 @@ namespace gdjs {
     bfu: 'X' | 'Y';
     vfb: integer;
     trfb: integer;
+    ts: number;
     frn: [string, string, string, string, string, string];
     mt: number;
     tint: string;
@@ -68,6 +70,7 @@ namespace gdjs {
     // `_rotationZ` is `angle` from `gdjs.RuntimeObject`.
     private _visibleFacesBitmask: integer;
     private _textureRepeatFacesBitmask: integer;
+    private _tileScale: number;
     private _faceResourceNames: [
       string,
       string,
@@ -118,6 +121,7 @@ namespace gdjs {
       if (objectData.content.bottomFaceResourceRepeat)
         this._textureRepeatFacesBitmask |=
           1 << faceNameToBitmaskIndex['bottom'];
+      this._tileScale = objectData.content.tileScale || 1;
       this._backFaceUpThroughWhichAxisRotation =
         objectData.content.backFaceUpThroughWhichAxisRotation || 'X';
       this._faceResourceNames = [
@@ -251,6 +255,23 @@ namespace gdjs {
     setBackFaceUpThroughWhichAxisRotation(axis: 'X' | 'Y'): void {
       this._backFaceUpThroughWhichAxisRotation = axis;
       this._renderer.updateFace(faceNameToBitmaskIndex['back']);
+    }
+
+    /**
+     * Returns the scale applied to the textures when they are tiled
+     * (repeated) over the faces of the cube. A scale of 1 means the texture
+     * is displayed at the same size as in 2D.
+     */
+    getTileScale(): number {
+      return this._tileScale;
+    }
+
+    setTileScale(tileScale: number): void {
+      if (this._tileScale === tileScale) {
+        return;
+      }
+      this._tileScale = tileScale;
+      this._renderer.updateTextureUvMapping();
     }
 
     getFacesOrientation(): 'Y' | 'Z' {
@@ -435,6 +456,9 @@ namespace gdjs {
       ) {
         this.setFacesOrientation(newObjectData.content.facesOrientation || 'Y');
       }
+      if (oldObjectData.content.tileScale !== newObjectData.content.tileScale) {
+        this.setTileScale(newObjectData.content.tileScale || 1);
+      }
       if (
         oldObjectData.content.materialType !==
         newObjectData.content.materialType
@@ -467,6 +491,7 @@ namespace gdjs {
         bfu: this._backFaceUpThroughWhichAxisRotation,
         vfb: this._visibleFacesBitmask,
         trfb: this._textureRepeatFacesBitmask,
+        ts: this._tileScale,
         frn: this._faceResourceNames,
         tint: this._tint,
       };
@@ -508,6 +533,9 @@ namespace gdjs {
             this._renderer.updateFace(i);
           }
         }
+      }
+      if (networkSyncData.ts !== undefined) {
+        this.setTileScale(networkSyncData.ts);
       }
       if (networkSyncData.frn !== undefined) {
         // If one element is different, update all the faces.

--- a/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
+++ b/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
@@ -161,6 +161,7 @@ namespace gdjs {
         faceIndex === undefined
           ? 23
           : faceIndexToMaterialIndex[faceIndex] * 4 + 3;
+      const tileScale = this._cube3DRuntimeObject.getTileScale() || 1;
       for (
         let vertexIndex = startIndex;
         vertexIndex <= endIndex;
@@ -325,6 +326,12 @@ namespace gdjs {
             break;
           default:
             [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
+        }
+        // When the texture is tiled, the tile scale enlarges (or shrinks) each
+        // tile, which means fewer (or more) repetitions over the face.
+        if (shouldRepeatTexture && tileScale !== 1) {
+          x /= tileScale;
+          y /= tileScale;
         }
         uvMapping.setXY(vertexIndex, x, y);
       }

--- a/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
+++ b/Extensions/3D/Cube3DRuntimeObjectPixiRenderer.ts
@@ -327,8 +327,6 @@ namespace gdjs {
           default:
             [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
         }
-        // When the texture is tiled, the tile scale enlarges (or shrinks) each
-        // tile, which means fewer (or more) repetitions over the face.
         if (shouldRepeatTexture && tileScale !== 1) {
           x /= tileScale;
           y /= tileScale;

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -964,6 +964,12 @@ module.exports = {
         objectContent[propertyName] = parseFloat(newValue);
         return true;
       }
+      if (propertyName === 'tileScale') {
+        const newTileScale = parseFloat(newValue);
+        objectContent.tileScale =
+          isNaN(newTileScale) || newTileScale <= 0 ? 1 : newTileScale;
+        return true;
+      }
       if (propertyName === 'facesOrientation') {
         const normalizedValue = newValue.toUpperCase();
         if (normalizedValue === 'Y' || normalizedValue === 'Z') {
@@ -1194,6 +1200,18 @@ module.exports = {
         .setGroup(_('Textures'));
 
       objectProperties
+        .getOrCreate('tileScale')
+        .setValue((objectContent.tileScale || 1).toString())
+        .setType('number')
+        .setLabel(_('Tile scale'))
+        .setDescription(
+          _(
+            'The scale applied to tiled textures. A value of 1 displays them at the same size as in 2D.'
+          )
+        )
+        .setGroup(_('Textures'));
+
+      objectProperties
         .getOrCreate('frontFaceVisible')
         .setValue(objectContent.frontFaceVisible ? 'true' : 'false')
         .setType('boolean')
@@ -1294,6 +1312,7 @@ module.exports = {
       rightFaceResourceRepeat: false,
       topFaceResourceRepeat: false,
       bottomFaceResourceRepeat: false,
+      tileScale: 1,
       materialType: 'StandardWithoutMetalness',
       tint: '255;255;255',
       isCastingShadow: true,
@@ -2822,6 +2841,7 @@ module.exports = {
       _faceResourceNames = new Array(6).fill(null);
       _faceVisibilities = new Array(6).fill(null);
       _shouldRepeatTextureOnFace = new Array(6).fill(null);
+      _tileScale = 1;
       _facesOrientation = 'Y';
       _backFaceUpThroughWhichAxisRotation = 'X';
       _shouldUseTransparentTexture = false;
@@ -3028,6 +3048,12 @@ module.exports = {
           uvMappingDirty = true;
         }
 
+        const tileScale = object.content.tileScale || 1;
+        if (tileScale !== this._tileScale) {
+          this._tileScale = tileScale;
+          uvMappingDirty = true;
+        }
+
         const backFaceUpThroughWhichAxisRotation =
           object.content.backFaceUpThroughWhichAxisRotation || 'X';
         if (
@@ -3077,6 +3103,7 @@ module.exports = {
         const uvMapping = this._threeObject.geometry.getAttribute('uv');
         const startIndex = 0;
         const endIndex = 23;
+        const tileScale = this._tileScale || 1;
         for (
           let vertexIndex = startIndex;
           vertexIndex <= endIndex;
@@ -3267,6 +3294,12 @@ module.exports = {
               break;
             default:
               [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
+          }
+          // When the texture is tiled, the tile scale enlarges (or shrinks)
+          // each tile, which means fewer (or more) repetitions over the face.
+          if (shouldRepeatTexture && tileScale !== 1) {
+            x /= tileScale;
+            y /= tileScale;
           }
           uvMapping.setXY(vertexIndex, x, y);
         }

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -3295,8 +3295,6 @@ module.exports = {
             default:
               [x, y] = noRepeatTextureVertexIndexToUvMapping[vertexIndex % 4];
           }
-          // When the texture is tiled, the tile scale enlarges (or shrinks)
-          // each tile, which means fewer (or more) repetitions over the face.
           if (shouldRepeatTexture && tileScale !== 1) {
             x /= tileScale;
             y /= tileScale;


### PR DESCRIPTION
Add a single 'Tile scale' property to Scene3D::Cube3DObject that scales tiled textures across all faces. Defaults to 1 (same size as in 2D).

Tile scale of 0.2:
<img width="747" height="668" alt="image" src="https://github.com/user-attachments/assets/86d13c87-5306-4bf8-8e54-69c2a43f1c5a" />

Versus the default:
<img width="754" height="683" alt="image" src="https://github.com/user-attachments/assets/b2eab533-4162-4d37-82fe-0301d7217668" />

(and the floor scale is 0.15 in both images)


As a reminder, a tilescale of 1 gives the same rendering as a 2D game when mixing 2D and 3D: 
<img width="1083" height="697" alt="image" src="https://github.com/user-attachments/assets/4944e113-5587-4151-80bc-83b62fb5c6f6" />
