### PR TITLE
Fix 3D physics and rendering issues with object centers

### DIFF
--- a/Extensions/3D/Cube3DRuntimeObject.ts
+++ b/Extensions/3D/Cube3DRuntimeObject.ts
@@ -505,6 +505,7 @@ namespace gdjs {
           newObjectData.content.originLocation || 'TopLeft'
         );
         this._renderer.updateOriginAndCenter();
+        this.invalidateHitboxes();
       }
       if (
         oldObjectData.content.centerLocation !==
@@ -514,6 +515,7 @@ namespace gdjs {
           newObjectData.content.centerLocation || 'ObjectCenter'
         );
         this._renderer.updateOriginAndCenter();
+        this.invalidateHitboxes();
       }
       if (
         oldObjectData.content.materialType !==
@@ -577,10 +579,12 @@ namespace gdjs {
       if (networkSyncData.op !== undefined) {
         this._originPoint = networkSyncData.op;
         this._renderer.updateOriginAndCenter();
+        this.invalidateHitboxes();
       }
       if (networkSyncData.cp !== undefined) {
         this._centerPoint = networkSyncData.cp;
         this._renderer.updateOriginAndCenter();
+        this.invalidateHitboxes();
       }
       if (networkSyncData.vfb !== undefined) {
         // If it is different, update all the faces.

--- a/Extensions/3D/JsExtension.js
+++ b/Extensions/3D/JsExtension.js
@@ -2678,10 +2678,6 @@ module.exports = {
       _defaultHeight;
       /** @type {number} */
       _defaultDepth;
-      /** @type {number} */
-      _centerX = 0;
-      /** @type {number} */
-      _centerY = 0;
       /** @type {[number, number, number]} */
       _originPoint = [0, 0, 0];
       /** @type {[number, number, number]} */
@@ -2798,8 +2794,6 @@ module.exports = {
             textureName
           );
           this._pixiTexturedObject.texture = texture;
-          this._centerX = texture.frame.width / 2;
-          this._centerY = texture.frame.height / 2;
           this._renderedResourceName = textureName;
 
           if (!texture.baseTexture.valid) {

--- a/Extensions/Physics3DBehavior/Physics3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/Physics3DRuntimeBehavior.ts
@@ -1090,6 +1090,11 @@ namespace gdjs {
       this._objectOldWidth = this.owner3D.getWidth();
       this._objectOldHeight = this.owner3D.getHeight();
       this._objectOldDepth = this.owner3D.getDepth();
+      // The old center must NOT be refreshed here: when the center moved,
+      // the body position (which is the object center) must still be updated
+      // by `bodyUpdater.updateBodyFromObject` which relies on
+      // `_hasObjectCenterChanged`. It's refreshed by `updateObjectFromBody`
+      // after the physics step.
     }
 
     getShapeScale(): float {
@@ -1268,13 +1273,16 @@ namespace gdjs {
       // The width has changed and there is no custom dimension A (box: width, circle: radius, edge: length) or
       // The height has changed, the shape is not an edge (edges doesn't have height),
       // it isn't a box with custom height or a circle with custom radius
+      // The shape automatic offset depends on the object center,
+      // so the shape must be recreated when the center moved
+      // (even when shapes have custom dimensions).
       if (
         this._needToRecreateShape ||
+        this._hasObjectCenterChanged() ||
         (!this.hasCustomShapeDimension() &&
           (this._objectOldWidth !== this.owner3D.getWidth() ||
             this._objectOldHeight !== this.owner3D.getHeight() ||
-            this._objectOldDepth !== this.owner3D.getDepth() ||
-            this._hasObjectCenterChanged()))
+            this._objectOldDepth !== this.owner3D.getDepth()))
       ) {
         this._needToRecreateShape = false;
         this._recreateShape();

--- a/Extensions/Physics3DBehavior/PhysicsCar3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/PhysicsCar3DRuntimeBehavior.ts
@@ -348,6 +348,11 @@ namespace gdjs {
         return result;
       }
       const { behavior } = physics3D;
+      // Same as for characters:
+      // - the body is at the object center on X and Y (the shape is offset
+      //   when the object center is not the geometric center of the object)
+      // - the origin is used for Z because, when the car is made smaller,
+      //   it must stay on the ground and not fall from its old size.
       result.Set(
         this.owner3D.getCenterXInScene() * this._sharedData.worldInvScale,
         this.owner3D.getCenterYInScene() * this._sharedData.worldInvScale,

--- a/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
+++ b/Extensions/Physics3DBehavior/PhysicsCharacter3DRuntimeBehavior.ts
@@ -396,6 +396,10 @@ namespace gdjs {
         return result;
       }
       const { behavior } = physics3D;
+      // The body is at the object center on X and Y (the shape is offset
+      // when the object center is not the geometric center of the object).
+      // The character origin is at its feet on Z: when the character is made
+      // smaller, it must stay on the ground and not fall from its old size.
       result.Set(
         this.owner3D.getCenterXInScene() * this._sharedData.worldInvScale,
         this.owner3D.getCenterYInScene() * this._sharedData.worldInvScale,

--- a/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
+++ b/GDJS/Runtime/pixi-renderers/pixi-image-manager.ts
@@ -26,7 +26,8 @@ namespace gdjs {
 
   const applyThreeTextureSettings = (
     threeTexture: THREE.Texture,
-    resourceData: ResourceData | null
+    resourceData: ResourceData | null,
+    useMipmaps: boolean
   ) => {
     if (resourceData && resourceData.smoothed === false) {
       threeTexture.magFilter = THREE.NearestFilter;
@@ -34,8 +35,10 @@ namespace gdjs {
       threeTexture.generateMipmaps = false;
     } else {
       threeTexture.magFilter = THREE.LinearFilter;
-      threeTexture.minFilter = THREE.LinearMipmapLinearFilter;
-      threeTexture.generateMipmaps = true;
+      threeTexture.minFilter = useMipmaps
+        ? THREE.LinearMipmapLinearFilter
+        : THREE.LinearFilter;
+      threeTexture.generateMipmaps = useMipmaps;
     }
   };
 
@@ -205,7 +208,7 @@ namespace gdjs {
 
       const resource = this._getImageResource(resourceName);
 
-      applyThreeTextureSettings(threeTexture, resource);
+      applyThreeTextureSettings(threeTexture, resource, true);
       threeTexture.needsUpdate = true;
       this._loadedThreeTextures.put(resourceName, threeTexture);
 
@@ -275,12 +278,12 @@ namespace gdjs {
       cubeTexture.images[5] = this._getImageSource(zNegativeResourceName);
       // The images also need to be mirrored horizontally by users.
 
-      // Skyboxes/cube maps should keep the previous non-mipmapped filtering:
-      // mip chains add memory pressure and can blur horizons between faces.
-      cubeTexture.magFilter = THREE.LinearFilter;
-      cubeTexture.minFilter = THREE.LinearFilter;
-      cubeTexture.generateMipmaps = false;
       cubeTexture.colorSpace = THREE.SRGBColorSpace;
+
+      const resource = this._getImageResource(xPositiveResourceName);
+      // Skyboxes/cube maps are never minified enough to need mipmaps and
+      // mip chains can create visible seams between faces.
+      applyThreeTextureSettings(cubeTexture, resource, false);
       cubeTexture.needsUpdate = true;
       this._loadedThreeCubeTextures.set(key, cubeTexture);
       this._loadedThreeCubeTextureKeysByResourceName.add(


### PR DESCRIPTION
## Summary
This PR fixes several issues related to object center handling in 3D physics behaviors and rendering, particularly around shape recreation, hitbox invalidation, and texture mipmapping.

## Key Changes

- **Physics3D Shape Recreation**: Modified shape recreation logic to properly account for object center changes. The shape must now be recreated whenever the object center changes, even when custom dimensions are set, since the automatic shape offset depends on the object center position.

- **Hitbox Invalidation**: Added `invalidateHitboxes()` calls in `Cube3DRuntimeObject` when origin or center locations change (both from property updates and network sync), ensuring collision detection remains accurate after these changes.

- **Texture Mipmapping Control**: Refactored `applyThreeTextureSettings` to accept a `useMipmaps` parameter, allowing fine-grained control over mipmap generation. Regular textures use mipmaps (true), while cube map textures disable mipmaps (false) to avoid visible seams between faces and reduce memory pressure.

- **Center Point Cleanup**: Removed unused `_centerX` and `_centerY` fields from the 3D object renderer, as these values are now properly derived from texture dimensions when needed.

- **Documentation**: Added clarifying comments in physics behaviors explaining why body positions use object centers on X/Y axes and origin points on Z axis, improving code maintainability.

## Notable Implementation Details

- The shape recreation now checks `_hasObjectCenterChanged()` independently before checking dimension changes, ensuring proper physics updates when only the center moves.
- Cube textures explicitly disable mipmaps via the new `useMipmaps` parameter to prevent visual artifacts at face boundaries.
- Physics character and car behaviors now have consistent documentation about their coordinate system choices.

https://claude.ai/code/session_01CyM3GmR2wqRU7EggbuPjM6