### PR TITLE
Fix TypeScript error in submit-appx-to-microsoft-store.js

### DIFF
--- a/newIDE/app/scripts/submit-appx-to-microsoft-store.js
+++ b/newIDE/app/scripts/submit-appx-to-microsoft-store.js
@@ -48,7 +48,7 @@ const os = require('os');
 const path = require('path');
 const https = require('https');
 const shell = require('shelljs');
-const axios = require('axios');
+const { default: axios } = require('axios');
 const AdmZip = require('adm-zip');
 const args = require('minimist')(process.argv.slice(2));
 


### PR DESCRIPTION
Import axios via its default export, matching the other scripts, so that `npm run check-script-types` passes.