### PR TITLE
Fix property title layout in the extension editor on mobile

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsBasedBehaviorOrObjectEditor/EventsBasedBehaviorOrObjectPropertiesEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsBasedBehaviorOrObjectEditor/EventsBasedBehaviorOrObjectPropertiesEditor.js
@@ -7,7 +7,7 @@ import { Column, Line } from '../../UI/Grid';
 import SelectOption from '../../UI/SelectOption';
 import { mapFor, mapVector } from '../../Utils/MapFor';
 import newNameGenerator from '../../Utils/NewNameGenerator';
-import { ResponsiveLineStackLayout, ColumnStackLayout } from '../../UI/Layout';
+import { LineStackLayout, ColumnStackLayout } from '../../UI/Layout';
 import ChoicesEditor, { type Choice } from '../../ChoicesEditor';
 import { CompactColorField } from '../../UI/CompactColorField';
 import CompactBehaviorTypeSelector from '../../BehaviorTypeSelector/CompactBehaviorTypeSelector';
@@ -346,11 +346,7 @@ export const EventsBasedBehaviorOrObjectPropertiesEditor: React.ComponentType<{
                             }}
                           >
                             <Column expand noOverflowParent>
-                              <ResponsiveLineStackLayout
-                                expand
-                                noOverflowParent
-                                noMargin
-                              >
+                              <LineStackLayout expand noMargin>
                                 <Line noMargin expand alignItems="center">
                                   <CompactSemiControlledTextField
                                     commitOnBlur
@@ -457,7 +453,7 @@ export const EventsBasedBehaviorOrObjectPropertiesEditor: React.ComponentType<{
                                     />
                                   </CompactSelectField>
                                 </Line>
-                              </ResponsiveLineStackLayout>
+                              </LineStackLayout>
                             </Column>
                           </div>
                           <Line expand>

--- a/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/CompactEventsFunctionParametersEditor.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/EventsFunctionConfigurationEditor/CompactEventsFunctionParametersEditor.js
@@ -14,11 +14,7 @@ import CompactSemiControlledTextField from '../../UI/CompactSemiControlledTextFi
 import { type CompactTextFieldInterface } from '../../UI/CompactTextField';
 import { ParametersIndexOffsets } from '../../EventsFunctionsExtensionsLoader';
 import DismissableAlertMessage from '../../UI/DismissableAlertMessage';
-import {
-  ResponsiveLineStackLayout,
-  ColumnStackLayout,
-  LineStackLayout,
-} from '../../UI/Layout';
+import { ColumnStackLayout, LineStackLayout } from '../../UI/Layout';
 import { getLastObjectParameterObjectType } from '../../EventsSheet/ParameterFields/ParameterMetadataTools';
 import newNameGenerator from '../../Utils/NewNameGenerator';
 import CompactValueTypeEditor from './CompactValueTypeEditor';
@@ -774,46 +770,39 @@ const CompactEventsFunctionParametersEditor: React.ComponentType<{
                                         </Column>
                                       </span>
                                     )}
-                                    <ResponsiveLineStackLayout
-                                      expand
-                                      noOverflowParent
+                                    <LineStackLayout
                                       noMargin
+                                      expand
+                                      alignItems="center"
                                     >
-                                      <LineStackLayout
-                                        noMargin
-                                        expand
-                                        alignItems="center"
+                                      <Text
+                                        color="secondary"
+                                        style={{
+                                          whiteSpace: 'nowrap',
+                                        }}
                                       >
-                                        <Text
-                                          color="secondary"
-                                          style={{
-                                            whiteSpace: 'nowrap',
-                                          }}
-                                        >
-                                          <Trans>
-                                            Parameter #
-                                            {i + parametersIndexOffset}
-                                          </Trans>
-                                        </Text>
-                                        <CompactSemiControlledTextField
-                                          ref={ref => {
-                                            parameterNameFieldRefs.current.set(
-                                              parameter.getName(),
-                                              ref
-                                            );
-                                          }}
-                                          commitOnBlur
-                                          placeholder={i18n._(
-                                            t`Enter the parameter name (mandatory)`
-                                          )}
-                                          value={parameter.getName()}
-                                          onChange={newName =>
-                                            renameParameter(parameter, newName)
-                                          }
-                                          disabled={isParameterDisabled(i)}
-                                        />
-                                      </LineStackLayout>
-                                    </ResponsiveLineStackLayout>
+                                        <Trans>
+                                          Parameter #{i + parametersIndexOffset}
+                                        </Trans>
+                                      </Text>
+                                      <CompactSemiControlledTextField
+                                        ref={ref => {
+                                          parameterNameFieldRefs.current.set(
+                                            parameter.getName(),
+                                            ref
+                                          );
+                                        }}
+                                        commitOnBlur
+                                        placeholder={i18n._(
+                                          t`Enter the parameter name (mandatory)`
+                                        )}
+                                        value={parameter.getName()}
+                                        onChange={newName =>
+                                          renameParameter(parameter, newName)
+                                        }
+                                        disabled={isParameterDisabled(i)}
+                                      />
+                                    </LineStackLayout>
                                     <ElementWithMenu
                                       element={
                                         <IconButton size="small">


### PR DESCRIPTION
Fixes https://forum.gdevelop.io/t/make-the-behavior-properties-easier-to-read/77207/