### PR TITLE
Add configurable custom resource properties via gdevelop-settings.yaml

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -212,7 +212,10 @@ import { QuickCustomizationDialog } from '../QuickCustomization/QuickCustomizati
 import { type ObjectWithContext } from '../ObjectsList/EnumerateObjects';
 import useGamesList from '../GameDashboard/UseGamesList';
 import useCapturesManager from './UseCapturesManager';
-import { readProjectSettings } from '../Utils/ProjectSettingsReader';
+import {
+  readProjectSettings,
+  type ResourcePropertyConfig,
+} from '../Utils/ProjectSettingsReader';
 import useNpmScriptRunner from './NpmScriptRunner/useNpmScriptRunner';
 import { applyProjectPreferences } from '../Utils/ApplyProjectPreferences';
 import {
@@ -406,6 +409,10 @@ const MainFrame = (props: Props): React.MixedElement => {
       toolbarButtons: [],
     }: State)
   );
+  const [
+    resourcePropertiesSchema,
+    setResourcePropertiesSchema,
+  ] = React.useState<Array<ResourcePropertyConfig>>([]);
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const [
     cloudProjectFileMetadataToRecover,
@@ -1126,6 +1133,7 @@ const MainFrame = (props: Props): React.MixedElement => {
         editorTabs: closeProjectTabs(state.editorTabs, currentProject),
         toolbarButtons: [],
       }));
+      setResourcePropertiesSchema([]);
 
       // Delete the project from memory. All references to it have been dropped previously
       // by the setState.
@@ -1248,6 +1256,9 @@ const MainFrame = (props: Props): React.MixedElement => {
               ...currentState,
               toolbarButtons: parsedProjectSettings.toolbarButtons || [],
             }));
+            setResourcePropertiesSchema(
+              parsedProjectSettings.resourceProperties || []
+            );
           }
         } catch (error) {
           console.warn(
@@ -5062,6 +5073,7 @@ const MainFrame = (props: Props): React.MixedElement => {
       canInstallPrivateAsset,
       onNewResourcesAdded,
       onResourceUsageChanged,
+      resourcePropertiesSchema,
     }),
     [
       resourceSources,
@@ -5073,6 +5085,7 @@ const MainFrame = (props: Props): React.MixedElement => {
       canInstallPrivateAsset,
       onNewResourcesAdded,
       onResourceUsageChanged,
+      resourcePropertiesSchema,
     ]
   );
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -409,10 +409,9 @@ const MainFrame = (props: Props): React.MixedElement => {
       toolbarButtons: [],
     }: State)
   );
-  const [
-    resourcePropertiesSchema,
-    setResourcePropertiesSchema,
-  ] = React.useState<Array<ResourcePropertyConfig>>([]);
+  const [resourcePropertyConfigs, setResourcePropertyConfigs] = React.useState<
+    Array<ResourcePropertyConfig>
+  >([]);
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const [
     cloudProjectFileMetadataToRecover,
@@ -1133,7 +1132,7 @@ const MainFrame = (props: Props): React.MixedElement => {
         editorTabs: closeProjectTabs(state.editorTabs, currentProject),
         toolbarButtons: [],
       }));
-      setResourcePropertiesSchema([]);
+      setResourcePropertyConfigs([]);
 
       // Delete the project from memory. All references to it have been dropped previously
       // by the setState.
@@ -1256,8 +1255,8 @@ const MainFrame = (props: Props): React.MixedElement => {
               ...currentState,
               toolbarButtons: parsedProjectSettings.toolbarButtons || [],
             }));
-            setResourcePropertiesSchema(
-              parsedProjectSettings.resourceProperties || []
+            setResourcePropertyConfigs(
+              parsedProjectSettings.resourceCustomProperties || []
             );
           }
         } catch (error) {
@@ -5073,7 +5072,7 @@ const MainFrame = (props: Props): React.MixedElement => {
       canInstallPrivateAsset,
       onNewResourcesAdded,
       onResourceUsageChanged,
-      resourcePropertiesSchema,
+      resourcePropertyConfigs,
     }),
     [
       resourceSources,
@@ -5085,7 +5084,7 @@ const MainFrame = (props: Props): React.MixedElement => {
       canInstallPrivateAsset,
       onNewResourcesAdded,
       onResourceUsageChanged,
-      resourcePropertiesSchema,
+      resourcePropertyConfigs,
     ]
   );
 

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -214,7 +214,7 @@ import useGamesList from '../GameDashboard/UseGamesList';
 import useCapturesManager from './UseCapturesManager';
 import {
   readProjectSettings,
-  type ResourcePropertyConfig,
+  type ResourceCustomPropertyConfig,
 } from '../Utils/ProjectSettingsReader';
 import useNpmScriptRunner from './NpmScriptRunner/useNpmScriptRunner';
 import { applyProjectPreferences } from '../Utils/ApplyProjectPreferences';
@@ -409,9 +409,10 @@ const MainFrame = (props: Props): React.MixedElement => {
       toolbarButtons: [],
     }: State)
   );
-  const [resourcePropertyConfigs, setResourcePropertyConfigs] = React.useState<
-    Array<ResourcePropertyConfig>
-  >([]);
+  const [
+    resourceCustomPropertyConfigs,
+    setResourceCustomPropertyConfigs,
+  ] = React.useState<Array<ResourceCustomPropertyConfig>>([]);
   const authenticatedUser = React.useContext(AuthenticatedUserContext);
   const [
     cloudProjectFileMetadataToRecover,
@@ -1132,7 +1133,7 @@ const MainFrame = (props: Props): React.MixedElement => {
         editorTabs: closeProjectTabs(state.editorTabs, currentProject),
         toolbarButtons: [],
       }));
-      setResourcePropertyConfigs([]);
+      setResourceCustomPropertyConfigs([]);
 
       // Delete the project from memory. All references to it have been dropped previously
       // by the setState.
@@ -1255,7 +1256,7 @@ const MainFrame = (props: Props): React.MixedElement => {
               ...currentState,
               toolbarButtons: parsedProjectSettings.toolbarButtons || [],
             }));
-            setResourcePropertyConfigs(
+            setResourceCustomPropertyConfigs(
               parsedProjectSettings.resourceCustomProperties || []
             );
           }
@@ -5072,7 +5073,7 @@ const MainFrame = (props: Props): React.MixedElement => {
       canInstallPrivateAsset,
       onNewResourcesAdded,
       onResourceUsageChanged,
-      resourcePropertyConfigs,
+      resourceCustomPropertyConfigs,
     }),
     [
       resourceSources,
@@ -5084,7 +5085,7 @@ const MainFrame = (props: Props): React.MixedElement => {
       canInstallPrivateAsset,
       onNewResourcesAdded,
       onResourceUsageChanged,
-      resourcePropertyConfigs,
+      resourceCustomPropertyConfigs,
     ]
   );
 

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -20,7 +20,7 @@ import {
 } from '../../ResourcesList/ResourceSource';
 import { type ResourcePropertyConfig } from '../../Utils/ProjectSettingsReader';
 import {
-  type CustomPropertyValue,
+  type ResourceCustomPropertyValue,
   getResourceCustomPropertyValue,
   setResourceCustomPropertyValue,
 } from '../../ResourcesList/ResourceUtils';
@@ -43,16 +43,18 @@ type Props = {|
 
 export type ResourcePropertiesEditorInterface = {| forceUpdate: () => void |};
 
-const coerceToBoolean = (value: ?CustomPropertyValue): boolean =>
+const coerceToBoolean = (value: ?ResourceCustomPropertyValue): boolean =>
   value === true || value === 'true' || value === 1;
 
-const coerceToNumber = (value: ?CustomPropertyValue): number | null => {
+const coerceToNumberOrNull = (
+  value: ?ResourceCustomPropertyValue
+): number | null => {
   if (value == null || value === '') return null;
   const numberValue = Number(value);
   return Number.isNaN(numberValue) ? null : numberValue;
 };
 
-const coerceToString = (value: ?CustomPropertyValue): string =>
+const coerceToString = (value: ?ResourceCustomPropertyValue): string =>
   value == null ? '' : String(value);
 
 const buildCustomPropertyField = (
@@ -63,9 +65,12 @@ const buildCustomPropertyField = (
   const defaultValue = configDefault == null ? null : configDefault;
   const getLabel = () => label;
   const getDescription = () => description || '';
-  const readValue = (resource: gdResource): ?CustomPropertyValue =>
+  const readValue = (resource: gdResource): ?ResourceCustomPropertyValue =>
     getResourceCustomPropertyValue(resource, name, defaultValue);
-  const setValue = (resource: gdResource, newValue: CustomPropertyValue) => {
+  const setValue = (
+    resource: gdResource,
+    newValue: ResourceCustomPropertyValue
+  ) => {
     setResourceCustomPropertyValue(resource, name, newValue);
     forceUpdate();
   };
@@ -76,7 +81,8 @@ const buildCustomPropertyField = (
       getLabel,
       getDescription,
       valueType: 'number',
-      getValue: (resource: gdResource) => coerceToNumber(readValue(resource)),
+      getValue: (resource: gdResource) =>
+        coerceToNumberOrNull(readValue(resource)),
       setValue,
     };
   }
@@ -103,11 +109,11 @@ const buildCustomPropertyField = (
 };
 
 const buildCustomPropertiesSchema = (
-  resourcePropertiesSchema: Array<ResourcePropertyConfig>,
+  resourcePropertyConfigs: Array<ResourcePropertyConfig>,
   resourceKind: string,
   forceUpdate: () => void
 ): Schema =>
-  resourcePropertiesSchema
+  resourcePropertyConfigs
     .filter(
       config =>
         !config.resourceKinds ||
@@ -263,15 +269,17 @@ const ResourcePropertiesEditor: React.ComponentType<{
         });
 
         const resourceKind = resources[0].getKind();
-        const customSchema = buildCustomPropertiesSchema(
-          resourceManagementProps.resourcePropertiesSchema,
+        const customPropertiesSchema = buildCustomPropertiesSchema(
+          resourceManagementProps.resourcePropertyConfigs,
           resourceKind,
           forceUpdate
         );
 
         return (
           <PropertiesEditor
-            schema={schema.concat(resourceSchema).concat(customSchema)}
+            schema={schema
+              .concat(resourceSchema)
+              .concat(customPropertiesSchema)}
             instances={resources}
           />
         );

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -18,7 +18,7 @@ import {
   type ResourceSource,
   type ResourceManagementProps,
 } from '../../ResourcesList/ResourceSource';
-import { type ResourcePropertyConfig } from '../../Utils/ProjectSettingsReader';
+import { type ResourceCustomPropertyConfig } from '../../Utils/ProjectSettingsReader';
 import {
   type ResourceCustomPropertyValue,
   getResourceCustomPropertyValue,
@@ -58,7 +58,7 @@ const coerceToString = (value: ?ResourceCustomPropertyValue): string =>
   value == null ? '' : String(value);
 
 const buildCustomPropertyField = (
-  config: ResourcePropertyConfig,
+  config: ResourceCustomPropertyConfig,
   forceUpdate: () => void
 ): Field => {
   const { name, label, description, default: configDefault } = config;
@@ -109,11 +109,11 @@ const buildCustomPropertyField = (
 };
 
 const buildCustomPropertiesSchema = (
-  resourcePropertyConfigs: Array<ResourcePropertyConfig>,
+  resourceCustomPropertyConfigs: Array<ResourceCustomPropertyConfig>,
   resourceKind: string,
   forceUpdate: () => void
 ): Schema =>
-  resourcePropertyConfigs
+  resourceCustomPropertyConfigs
     .filter(
       config =>
         !config.resourceKinds ||
@@ -270,7 +270,7 @@ const ResourcePropertiesEditor: React.ComponentType<{
 
         const resourceKind = resources[0].getKind();
         const customPropertiesSchema = buildCustomPropertiesSchema(
-          resourceManagementProps.resourcePropertyConfigs,
+          resourceManagementProps.resourceCustomPropertyConfigs,
           resourceKind,
           forceUpdate
         );

--- a/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
+++ b/newIDE/app/src/ResourcesEditor/ResourcePropertiesEditor/index.js
@@ -9,12 +9,21 @@ import PropertiesEditor from '../../PropertiesEditor';
 import ResourcePreview from '../../ResourcesList/ResourcePreview';
 import ResourcesLoader from '../../ResourcesLoader';
 import propertiesMapToSchema from '../../PropertiesEditor/PropertiesMapToSchema';
-import { type Schema } from '../../PropertiesEditor/PropertiesEditorSchema';
+import {
+  type Schema,
+  type Field,
+} from '../../PropertiesEditor/PropertiesEditorSchema';
 
 import {
   type ResourceSource,
   type ResourceManagementProps,
 } from '../../ResourcesList/ResourceSource';
+import { type ResourcePropertyConfig } from '../../Utils/ProjectSettingsReader';
+import {
+  type CustomPropertyValue,
+  getResourceCustomPropertyValue,
+  setResourceCustomPropertyValue,
+} from '../../ResourcesList/ResourceUtils';
 import useForceUpdate from '../../Utils/UseForceUpdate';
 import { EmbeddedResourcesMappingTable } from './EmbeddedResourcesMappingTable';
 import { Spacer } from '../../UI/Grid';
@@ -33,6 +42,79 @@ type Props = {|
 |};
 
 export type ResourcePropertiesEditorInterface = {| forceUpdate: () => void |};
+
+const coerceToBoolean = (value: ?CustomPropertyValue): boolean =>
+  value === true || value === 'true' || value === 1;
+
+const coerceToNumber = (value: ?CustomPropertyValue): number | null => {
+  if (value == null || value === '') return null;
+  const numberValue = Number(value);
+  return Number.isNaN(numberValue) ? null : numberValue;
+};
+
+const coerceToString = (value: ?CustomPropertyValue): string =>
+  value == null ? '' : String(value);
+
+const buildCustomPropertyField = (
+  config: ResourcePropertyConfig,
+  forceUpdate: () => void
+): Field => {
+  const { name, label, description, default: configDefault } = config;
+  const defaultValue = configDefault == null ? null : configDefault;
+  const getLabel = () => label;
+  const getDescription = () => description || '';
+  const readValue = (resource: gdResource): ?CustomPropertyValue =>
+    getResourceCustomPropertyValue(resource, name, defaultValue);
+  const setValue = (resource: gdResource, newValue: CustomPropertyValue) => {
+    setResourceCustomPropertyValue(resource, name, newValue);
+    forceUpdate();
+  };
+
+  if (config.type === 'number') {
+    return {
+      name,
+      getLabel,
+      getDescription,
+      valueType: 'number',
+      getValue: (resource: gdResource) => coerceToNumber(readValue(resource)),
+      setValue,
+    };
+  }
+
+  if (config.type === 'boolean') {
+    return {
+      name,
+      getLabel,
+      getDescription,
+      valueType: 'boolean',
+      getValue: (resource: gdResource) => coerceToBoolean(readValue(resource)),
+      setValue,
+    };
+  }
+
+  return {
+    name,
+    getLabel,
+    getDescription,
+    valueType: 'string',
+    getValue: (resource: gdResource) => coerceToString(readValue(resource)),
+    setValue,
+  };
+};
+
+const buildCustomPropertiesSchema = (
+  resourcePropertiesSchema: Array<ResourcePropertyConfig>,
+  resourceKind: string,
+  forceUpdate: () => void
+): Schema =>
+  resourcePropertiesSchema
+    .filter(
+      config =>
+        !config.resourceKinds ||
+        config.resourceKinds.length === 0 ||
+        config.resourceKinds.includes(resourceKind)
+    )
+    .map(config => buildCustomPropertyField(config, forceUpdate));
 
 const renderEmpty = () => {
   return (
@@ -180,14 +262,21 @@ const ResourcePropertiesEditor: React.ComponentType<{
           layersContainer: null,
         });
 
+        const resourceKind = resources[0].getKind();
+        const customSchema = buildCustomPropertiesSchema(
+          resourceManagementProps.resourcePropertiesSchema,
+          resourceKind,
+          forceUpdate
+        );
+
         return (
           <PropertiesEditor
-            schema={schema.concat(resourceSchema)}
+            schema={schema.concat(resourceSchema).concat(customSchema)}
             instances={resources}
           />
         );
       },
-      [resources, schema, forceUpdate]
+      [resources, schema, forceUpdate, resourceManagementProps]
     );
 
     const renderPreview = () => {

--- a/newIDE/app/src/ResourcesList/ResourceSource.js
+++ b/newIDE/app/src/ResourcesList/ResourceSource.js
@@ -14,6 +14,7 @@ import {
 } from '../Utils/GDevelopServices/Asset';
 import { type ResourceExternalEditor } from './ResourceExternalEditor';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
+import { type ResourcePropertyConfig } from '../Utils/ProjectSettingsReader';
 
 const gd: libGDevelop = global.gd;
 
@@ -205,6 +206,7 @@ export type ResourceManagementProps = {|
   canInstallPrivateAsset: () => boolean,
   onNewResourcesAdded: () => void,
   onResourceUsageChanged: () => void,
+  resourcePropertiesSchema: Array<ResourcePropertyConfig>,
 |};
 
 export type ResourceStoreChooserProps = {|

--- a/newIDE/app/src/ResourcesList/ResourceSource.js
+++ b/newIDE/app/src/ResourcesList/ResourceSource.js
@@ -14,7 +14,7 @@ import {
 } from '../Utils/GDevelopServices/Asset';
 import { type ResourceExternalEditor } from './ResourceExternalEditor';
 import { type OnFetchNewlyAddedResourcesFunction } from '../ProjectsStorage/ResourceFetcher';
-import { type ResourcePropertyConfig } from '../Utils/ProjectSettingsReader';
+import { type ResourceCustomPropertyConfig } from '../Utils/ProjectSettingsReader';
 
 const gd: libGDevelop = global.gd;
 
@@ -206,7 +206,7 @@ export type ResourceManagementProps = {|
   canInstallPrivateAsset: () => boolean,
   onNewResourcesAdded: () => void,
   onResourceUsageChanged: () => void,
-  resourcePropertyConfigs: Array<ResourcePropertyConfig>,
+  resourceCustomPropertyConfigs: Array<ResourceCustomPropertyConfig>,
 |};
 
 export type ResourceStoreChooserProps = {|

--- a/newIDE/app/src/ResourcesList/ResourceSource.js
+++ b/newIDE/app/src/ResourcesList/ResourceSource.js
@@ -206,7 +206,7 @@ export type ResourceManagementProps = {|
   canInstallPrivateAsset: () => boolean,
   onNewResourcesAdded: () => void,
   onResourceUsageChanged: () => void,
-  resourcePropertiesSchema: Array<ResourcePropertyConfig>,
+  resourcePropertyConfigs: Array<ResourcePropertyConfig>,
 |};
 
 export type ResourceStoreChooserProps = {|

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -243,9 +243,10 @@ export const updateResourceJsonMetadata = (
 // (defined in gdevelop-settings.yaml) are stored inside the resource metadata
 // JSON. Kept separate from other metadata keys (e.g. localFilePath) to avoid
 // collisions.
-export const CUSTOM_PROPERTIES_METADATA_KEY = 'customProperties';
+export const RESOURCE_CUSTOM_PROPERTIES_METADATA_KEY =
+  'resourceCustomProperties';
 
-export type CustomPropertyValue = string | number | boolean;
+export type ResourceCustomPropertyValue = string | number | boolean;
 
 /**
  * Returns the map of custom property values stored on a resource, or an empty
@@ -253,7 +254,7 @@ export type CustomPropertyValue = string | number | boolean;
  */
 export const getResourceCustomProperties = (
   resource: gdResource
-): { [string]: CustomPropertyValue } => {
+): { [string]: ResourceCustomPropertyValue } => {
   const metadataAsString = resource.getMetadata();
   if (!metadataAsString) return {};
   try {
@@ -261,10 +262,10 @@ export const getResourceCustomProperties = (
     if (
       metadata &&
       typeof metadata === 'object' &&
-      metadata[CUSTOM_PROPERTIES_METADATA_KEY] &&
-      typeof metadata[CUSTOM_PROPERTIES_METADATA_KEY] === 'object'
+      metadata[RESOURCE_CUSTOM_PROPERTIES_METADATA_KEY] &&
+      typeof metadata[RESOURCE_CUSTOM_PROPERTIES_METADATA_KEY] === 'object'
     ) {
-      return metadata[CUSTOM_PROPERTIES_METADATA_KEY];
+      return metadata[RESOURCE_CUSTOM_PROPERTIES_METADATA_KEY];
     }
   } catch (error) {
     // Malformed metadata: treat as if no custom properties were set.
@@ -279,30 +280,30 @@ export const getResourceCustomProperties = (
 export const getResourceCustomPropertyValue = (
   resource: gdResource,
   name: string,
-  defaultValue: ?CustomPropertyValue
-): ?CustomPropertyValue => {
-  const customProperties = getResourceCustomProperties(resource);
-  if (customProperties[name] !== undefined) {
-    return customProperties[name];
+  defaultValue: ?ResourceCustomPropertyValue
+): ?ResourceCustomPropertyValue => {
+  const resourceCustomProperties = getResourceCustomProperties(resource);
+  if (resourceCustomProperties[name] !== undefined) {
+    return resourceCustomProperties[name];
   }
   return defaultValue == null ? null : defaultValue;
 };
 
 /**
  * Sets (or merges) a single custom property value on a resource, storing it in
- * the resource metadata JSON under CUSTOM_PROPERTIES_METADATA_KEY.
+ * the resource metadata JSON under RESOURCE_CUSTOM_PROPERTIES_METADATA_KEY.
  */
 export const setResourceCustomPropertyValue = (
   resource: gdResource,
   name: string,
-  value: CustomPropertyValue
+  value: ResourceCustomPropertyValue
 ) => {
-  const customProperties = {
+  const resourceCustomProperties = {
     ...getResourceCustomProperties(resource),
     [name]: value,
   };
   updateResourceJsonMetadata(resource, {
-    [CUSTOM_PROPERTIES_METADATA_KEY]: customProperties,
+    [RESOURCE_CUSTOM_PROPERTIES_METADATA_KEY]: resourceCustomProperties,
   });
 };
 

--- a/newIDE/app/src/ResourcesList/ResourceUtils.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.js
@@ -239,6 +239,73 @@ export const updateResourceJsonMetadata = (
   resource.setMetadata(JSON.stringify(newMetadata));
 };
 
+// Key under which the project-configurable custom resource properties
+// (defined in gdevelop-settings.yaml) are stored inside the resource metadata
+// JSON. Kept separate from other metadata keys (e.g. localFilePath) to avoid
+// collisions.
+export const CUSTOM_PROPERTIES_METADATA_KEY = 'customProperties';
+
+export type CustomPropertyValue = string | number | boolean;
+
+/**
+ * Returns the map of custom property values stored on a resource, or an empty
+ * object if none are set or the metadata is malformed.
+ */
+export const getResourceCustomProperties = (
+  resource: gdResource
+): { [string]: CustomPropertyValue } => {
+  const metadataAsString = resource.getMetadata();
+  if (!metadataAsString) return {};
+  try {
+    const metadata = JSON.parse(metadataAsString);
+    if (
+      metadata &&
+      typeof metadata === 'object' &&
+      metadata[CUSTOM_PROPERTIES_METADATA_KEY] &&
+      typeof metadata[CUSTOM_PROPERTIES_METADATA_KEY] === 'object'
+    ) {
+      return metadata[CUSTOM_PROPERTIES_METADATA_KEY];
+    }
+  } catch (error) {
+    // Malformed metadata: treat as if no custom properties were set.
+  }
+  return {};
+};
+
+/**
+ * Returns the stored value for a single custom property, falling back to the
+ * provided default value (typically from the YAML schema) if it is not set.
+ */
+export const getResourceCustomPropertyValue = (
+  resource: gdResource,
+  name: string,
+  defaultValue: ?CustomPropertyValue
+): ?CustomPropertyValue => {
+  const customProperties = getResourceCustomProperties(resource);
+  if (customProperties[name] !== undefined) {
+    return customProperties[name];
+  }
+  return defaultValue == null ? null : defaultValue;
+};
+
+/**
+ * Sets (or merges) a single custom property value on a resource, storing it in
+ * the resource metadata JSON under CUSTOM_PROPERTIES_METADATA_KEY.
+ */
+export const setResourceCustomPropertyValue = (
+  resource: gdResource,
+  name: string,
+  value: CustomPropertyValue
+) => {
+  const customProperties = {
+    ...getResourceCustomProperties(resource),
+    [name]: value,
+  };
+  updateResourceJsonMetadata(resource, {
+    [CUSTOM_PROPERTIES_METADATA_KEY]: customProperties,
+  });
+};
+
 export const isFetchableUrl = (url: string): boolean => {
   return (
     url.startsWith('http://') ||

--- a/newIDE/app/src/ResourcesList/ResourceUtils.spec.js
+++ b/newIDE/app/src/ResourcesList/ResourceUtils.spec.js
@@ -3,6 +3,9 @@ import {
   parseLocalFilePathOrExtensionFromMetadata,
   renameResourcesInProject,
   updateResourceJsonMetadata,
+  getResourceCustomProperties,
+  getResourceCustomPropertyValue,
+  setResourceCustomPropertyValue,
 } from './ResourceUtils';
 const gd: libGDevelop = global.gd;
 
@@ -221,6 +224,56 @@ describe('ResourceUtils', () => {
           "localFilePath": null,
         }
       `);
+    });
+  });
+
+  describe('Resource custom properties', () => {
+    let resource = null;
+    afterEach(() => {
+      if (resource) resource.delete();
+      resource = null;
+    });
+
+    it('returns an empty object when no custom properties are set', () => {
+      const r = (resource = new gd.Resource());
+      expect(getResourceCustomProperties(r)).toEqual({});
+    });
+
+    it('can set and read custom property values of different types', () => {
+      const r = (resource = new gd.Resource());
+      setResourceCustomPropertyValue(r, 'scale-multiplier', 0.3);
+      setResourceCustomPropertyValue(r, 'no-resize', true);
+      setResourceCustomPropertyValue(r, 'no-atlas', false);
+
+      expect(getResourceCustomProperties(r)).toEqual({
+        'scale-multiplier': 0.3,
+        'no-resize': true,
+        'no-atlas': false,
+      });
+      expect(getResourceCustomPropertyValue(r, 'scale-multiplier', null)).toBe(
+        0.3
+      );
+      expect(getResourceCustomPropertyValue(r, 'no-resize', null)).toBe(true);
+      expect(getResourceCustomPropertyValue(r, 'no-atlas', null)).toBe(false);
+    });
+
+    it('falls back to the provided default when a property is not set', () => {
+      const r = (resource = new gd.Resource());
+      expect(getResourceCustomPropertyValue(r, 'scale-multiplier', 1)).toBe(1);
+      expect(getResourceCustomPropertyValue(r, 'missing', null)).toBeNull();
+    });
+
+    it('does not collide with other metadata keys', () => {
+      const r = (resource = new gd.Resource());
+      updateResourceJsonMetadata(r, { localFilePath: 'test' });
+      setResourceCustomPropertyValue(r, 'no-atlas', true);
+
+      // $FlowFixMe[incompatible-type]
+      expect(parseLocalFilePathOrExtensionFromMetadata(r)).toEqual({
+        extension: null,
+        localFilePath: 'test',
+      });
+      expect(getResourceCustomProperties(r)).toEqual({ 'no-atlas': true });
     });
   });
 });

--- a/newIDE/app/src/Utils/ProjectSettingsReader.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.js
@@ -9,12 +9,12 @@ const fs = optionalRequire('fs');
 const fsPromises = fs ? fs.promises : null;
 const path = optionalRequire('path');
 
-export type ResourcePropertyType = 'string' | 'boolean' | 'number';
+export type ResourceCustomPropertyType = 'string' | 'boolean' | 'number';
 
-export type ResourcePropertyConfig = {|
+export type ResourceCustomPropertyConfig = {|
   name: string,
   label: string,
-  type: ResourcePropertyType,
+  type: ResourceCustomPropertyType,
   description?: string,
   resourceKinds?: Array<string>,
   default?: string | number | boolean,
@@ -24,18 +24,18 @@ export type ParsedProjectSettings = {
   preferences?: { [string]: boolean | string | number },
   toolbarButtons?: Array<ToolbarButtonConfig>,
   shortcuts?: { [string]: string },
-  resourceCustomProperties?: Array<ResourcePropertyConfig>,
+  resourceCustomProperties?: Array<ResourceCustomPropertyConfig>,
 };
 
-const ALLOWED_RESOURCE_PROPERTY_TYPES: Array<ResourcePropertyType> = [
+const ALLOWED_RESOURCE_CUSTOM_PROPERTY_TYPES: Array<ResourceCustomPropertyType> = [
   'string',
   'boolean',
   'number',
 ];
 
-// Only allow safe characters in property names so they stay clean keys in the
-// resource metadata JSON.
-const SAFE_PROPERTY_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+// Only allow safe characters in custom property names so they stay clean keys
+// in the resource metadata JSON.
+const SAFE_CUSTOM_PROPERTY_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 const SETTINGS_FILE_NAME = 'gdevelop-settings.yaml';
 
@@ -109,56 +109,59 @@ export const parseToolbarButtons = (
 
 /**
  * Parses raw `resourceCustomProperties` entries from YAML into validated
- * ResourcePropertyConfig objects. Invalid entries are skipped with a warning.
+ * ResourceCustomPropertyConfig objects. Invalid entries are skipped with a warning.
  * Exported for unit testing; file system is not needed.
  */
 export const parseResourceCustomProperties = (
   rawResourceCustomProperties: Array<mixed>
-): Array<ResourcePropertyConfig> => {
-  const resourceCustomProperties: Array<ResourcePropertyConfig> = [];
+): Array<ResourceCustomPropertyConfig> => {
+  const resourceCustomProperties: Array<ResourceCustomPropertyConfig> = [];
   const seenNames: Set<string> = new Set();
 
-  for (const rawProperty of rawResourceCustomProperties) {
-    const name = SafeExtractor.extractStringProperty(rawProperty, 'name');
-    const type = SafeExtractor.extractStringProperty(rawProperty, 'type');
+  for (const rawCustomProperty of rawResourceCustomProperties) {
+    const name = SafeExtractor.extractStringProperty(rawCustomProperty, 'name');
+    const type = SafeExtractor.extractStringProperty(rawCustomProperty, 'type');
 
     if (!name) {
       console.warn(
-        '[ProjectSettingsReader] Skipping resource property without a name.'
+        '[ProjectSettingsReader] Skipping resource custom property without a name.'
       );
       continue;
     }
-    if (!SAFE_PROPERTY_NAME_PATTERN.test(name)) {
+    if (!SAFE_CUSTOM_PROPERTY_NAME_PATTERN.test(name)) {
       console.warn(
-        `[ProjectSettingsReader] Skipping resource property "${name}": name must match ${SAFE_PROPERTY_NAME_PATTERN.toString()}.`
+        `[ProjectSettingsReader] Skipping resource custom property "${name}": name must match ${SAFE_CUSTOM_PROPERTY_NAME_PATTERN.toString()}.`
       );
       continue;
     }
-    if (!type || !ALLOWED_RESOURCE_PROPERTY_TYPES.includes((type: any))) {
+    if (
+      !type ||
+      !ALLOWED_RESOURCE_CUSTOM_PROPERTY_TYPES.includes((type: any))
+    ) {
       console.warn(
-        `[ProjectSettingsReader] Skipping resource property "${name}": invalid type "${type ||
+        `[ProjectSettingsReader] Skipping resource custom property "${name}": invalid type "${type ||
           ''}".`
       );
       continue;
     }
     // $FlowFixMe[incompatible-type] - type is checked against the allowed list above.
-    const propertyType: ResourcePropertyType = type;
+    const customPropertyType: ResourceCustomPropertyType = type;
 
     const label =
-      SafeExtractor.extractStringProperty(rawProperty, 'label') || name;
+      SafeExtractor.extractStringProperty(rawCustomProperty, 'label') || name;
     const description =
-      SafeExtractor.extractStringProperty(rawProperty, 'description') ||
+      SafeExtractor.extractStringProperty(rawCustomProperty, 'description') ||
       undefined;
 
-    const config: ResourcePropertyConfig = {
+    const config: ResourceCustomPropertyConfig = {
       name,
       label,
-      type: propertyType,
+      type: customPropertyType,
     };
     if (description) config.description = description;
 
     const rawResourceKinds = SafeExtractor.extractArrayProperty(
-      rawProperty,
+      rawCustomProperty,
       'resourceKinds'
     );
     if (rawResourceKinds) {
@@ -169,17 +172,17 @@ export const parseResourceCustomProperties = (
     }
 
     const defaultValue = SafeExtractor.extractNumberOrStringOrBooleanProperty(
-      rawProperty,
+      rawCustomProperty,
       'default'
     );
     if (defaultValue !== null) config.default = defaultValue;
 
     if (seenNames.has(name)) {
       console.warn(
-        `[ProjectSettingsReader] Duplicate resource property "${name}": the last definition wins.`
+        `[ProjectSettingsReader] Duplicate resource custom property "${name}": the last definition wins.`
       );
       const existingIndex = resourceCustomProperties.findIndex(
-        property => property.name === name
+        customProperty => customProperty.name === name
       );
       if (existingIndex !== -1)
         resourceCustomProperties.splice(existingIndex, 1);

--- a/newIDE/app/src/Utils/ProjectSettingsReader.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.js
@@ -24,7 +24,7 @@ export type ParsedProjectSettings = {
   preferences?: { [string]: boolean | string | number },
   toolbarButtons?: Array<ToolbarButtonConfig>,
   shortcuts?: { [string]: string },
-  resourceProperties?: Array<ResourcePropertyConfig>,
+  resourceCustomProperties?: Array<ResourcePropertyConfig>,
 };
 
 const ALLOWED_RESOURCE_PROPERTY_TYPES: Array<ResourcePropertyType> = [
@@ -108,17 +108,17 @@ export const parseToolbarButtons = (
 };
 
 /**
- * Parses raw `resourceProperties` entries from YAML into validated
+ * Parses raw `resourceCustomProperties` entries from YAML into validated
  * ResourcePropertyConfig objects. Invalid entries are skipped with a warning.
  * Exported for unit testing; file system is not needed.
  */
-export const parseResourceProperties = (
-  rawResourceProperties: Array<mixed>
+export const parseResourceCustomProperties = (
+  rawResourceCustomProperties: Array<mixed>
 ): Array<ResourcePropertyConfig> => {
-  const resourceProperties: Array<ResourcePropertyConfig> = [];
+  const resourceCustomProperties: Array<ResourcePropertyConfig> = [];
   const seenNames: Set<string> = new Set();
 
-  for (const rawProperty of rawResourceProperties) {
+  for (const rawProperty of rawResourceCustomProperties) {
     const name = SafeExtractor.extractStringProperty(rawProperty, 'name');
     const type = SafeExtractor.extractStringProperty(rawProperty, 'type');
 
@@ -178,16 +178,17 @@ export const parseResourceProperties = (
       console.warn(
         `[ProjectSettingsReader] Duplicate resource property "${name}": the last definition wins.`
       );
-      const existingIndex = resourceProperties.findIndex(
+      const existingIndex = resourceCustomProperties.findIndex(
         property => property.name === name
       );
-      if (existingIndex !== -1) resourceProperties.splice(existingIndex, 1);
+      if (existingIndex !== -1)
+        resourceCustomProperties.splice(existingIndex, 1);
     }
     seenNames.add(name);
-    resourceProperties.push(config);
+    resourceCustomProperties.push(config);
   }
 
-  return resourceProperties;
+  return resourceCustomProperties;
 };
 
 /**
@@ -289,13 +290,13 @@ export const readProjectSettings = async (
       }
     }
 
-    // Parse resourceProperties section
-    const rawResourceProperties = SafeExtractor.extractArrayProperty(
+    // Parse resourceCustomProperties section
+    const rawResourceCustomProperties = SafeExtractor.extractArrayProperty(
       parsed,
-      'resourceProperties'
+      'resourceCustomProperties'
     );
-    const resourceProperties = rawResourceProperties
-      ? parseResourceProperties(rawResourceProperties)
+    const resourceCustomProperties = rawResourceCustomProperties
+      ? parseResourceCustomProperties(rawResourceCustomProperties)
       : [];
 
     console.info(
@@ -303,7 +304,9 @@ export const readProjectSettings = async (
         Object.keys(preferences).length
       } preferences, ${toolbarButtons.length} buttons, ${
         Object.keys(shortcuts).length
-      } shortcuts, ${resourceProperties.length} resource properties`
+      } shortcuts, ${
+        resourceCustomProperties.length
+      } resource custom properties`
     );
 
     const result: ParsedProjectSettings = {};
@@ -316,8 +319,8 @@ export const readProjectSettings = async (
     if (Object.keys(shortcuts).length > 0) {
       result.shortcuts = shortcuts;
     }
-    if (resourceProperties.length > 0) {
-      result.resourceProperties = resourceProperties;
+    if (resourceCustomProperties.length > 0) {
+      result.resourceCustomProperties = resourceCustomProperties;
     }
     return result;
   } catch (error) {

--- a/newIDE/app/src/Utils/ProjectSettingsReader.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.js
@@ -9,11 +9,33 @@ const fs = optionalRequire('fs');
 const fsPromises = fs ? fs.promises : null;
 const path = optionalRequire('path');
 
+export type ResourcePropertyType = 'string' | 'boolean' | 'number';
+
+export type ResourcePropertyConfig = {|
+  name: string,
+  label: string,
+  type: ResourcePropertyType,
+  description?: string,
+  resourceKinds?: Array<string>,
+  default?: string | number | boolean,
+|};
+
 export type ParsedProjectSettings = {
   preferences?: { [string]: boolean | string | number },
   toolbarButtons?: Array<ToolbarButtonConfig>,
   shortcuts?: { [string]: string },
+  resourceProperties?: Array<ResourcePropertyConfig>,
 };
+
+const ALLOWED_RESOURCE_PROPERTY_TYPES: Array<ResourcePropertyType> = [
+  'string',
+  'boolean',
+  'number',
+];
+
+// Only allow safe characters in property names so they stay clean keys in the
+// resource metadata JSON.
+const SAFE_PROPERTY_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 const SETTINGS_FILE_NAME = 'gdevelop-settings.yaml';
 
@@ -83,6 +105,89 @@ export const parseToolbarButtons = (
   }
 
   return toolbarButtons;
+};
+
+/**
+ * Parses raw `resourceProperties` entries from YAML into validated
+ * ResourcePropertyConfig objects. Invalid entries are skipped with a warning.
+ * Exported for unit testing; file system is not needed.
+ */
+export const parseResourceProperties = (
+  rawResourceProperties: Array<mixed>
+): Array<ResourcePropertyConfig> => {
+  const resourceProperties: Array<ResourcePropertyConfig> = [];
+  const seenNames: Set<string> = new Set();
+
+  for (const rawProperty of rawResourceProperties) {
+    const name = SafeExtractor.extractStringProperty(rawProperty, 'name');
+    const type = SafeExtractor.extractStringProperty(rawProperty, 'type');
+
+    if (!name) {
+      console.warn(
+        '[ProjectSettingsReader] Skipping resource property without a name.'
+      );
+      continue;
+    }
+    if (!SAFE_PROPERTY_NAME_PATTERN.test(name)) {
+      console.warn(
+        `[ProjectSettingsReader] Skipping resource property "${name}": name must match ${SAFE_PROPERTY_NAME_PATTERN.toString()}.`
+      );
+      continue;
+    }
+    if (!type || !ALLOWED_RESOURCE_PROPERTY_TYPES.includes((type: any))) {
+      console.warn(
+        `[ProjectSettingsReader] Skipping resource property "${name}": invalid type "${type ||
+          ''}".`
+      );
+      continue;
+    }
+    // $FlowFixMe[incompatible-type] - type is checked against the allowed list above.
+    const propertyType: ResourcePropertyType = type;
+
+    const label =
+      SafeExtractor.extractStringProperty(rawProperty, 'label') || name;
+    const description =
+      SafeExtractor.extractStringProperty(rawProperty, 'description') ||
+      undefined;
+
+    const config: ResourcePropertyConfig = {
+      name,
+      label,
+      type: propertyType,
+    };
+    if (description) config.description = description;
+
+    const rawResourceKinds = SafeExtractor.extractArrayProperty(
+      rawProperty,
+      'resourceKinds'
+    );
+    if (rawResourceKinds) {
+      const resourceKinds = rawResourceKinds
+        .map(rawKind => (typeof rawKind === 'string' ? rawKind : null))
+        .filter(Boolean);
+      if (resourceKinds.length > 0) config.resourceKinds = resourceKinds;
+    }
+
+    const defaultValue = SafeExtractor.extractNumberOrStringOrBooleanProperty(
+      rawProperty,
+      'default'
+    );
+    if (defaultValue !== null) config.default = defaultValue;
+
+    if (seenNames.has(name)) {
+      console.warn(
+        `[ProjectSettingsReader] Duplicate resource property "${name}": the last definition wins.`
+      );
+      const existingIndex = resourceProperties.findIndex(
+        property => property.name === name
+      );
+      if (existingIndex !== -1) resourceProperties.splice(existingIndex, 1);
+    }
+    seenNames.add(name);
+    resourceProperties.push(config);
+  }
+
+  return resourceProperties;
 };
 
 /**
@@ -184,12 +289,21 @@ export const readProjectSettings = async (
       }
     }
 
+    // Parse resourceProperties section
+    const rawResourceProperties = SafeExtractor.extractArrayProperty(
+      parsed,
+      'resourceProperties'
+    );
+    const resourceProperties = rawResourceProperties
+      ? parseResourceProperties(rawResourceProperties)
+      : [];
+
     console.info(
       `[ProjectSettingsReader] Loaded: ${
         Object.keys(preferences).length
       } preferences, ${toolbarButtons.length} buttons, ${
         Object.keys(shortcuts).length
-      } shortcuts`
+      } shortcuts, ${resourceProperties.length} resource properties`
     );
 
     const result: ParsedProjectSettings = {};
@@ -201,6 +315,9 @@ export const readProjectSettings = async (
     }
     if (Object.keys(shortcuts).length > 0) {
       result.shortcuts = shortcuts;
+    }
+    if (resourceProperties.length > 0) {
+      result.resourceProperties = resourceProperties;
     }
     return result;
   } catch (error) {

--- a/newIDE/app/src/Utils/ProjectSettingsReader.spec.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.spec.js
@@ -3,7 +3,10 @@ import {
   filterAllowedPreferences,
   applyProjectPreferences,
 } from './ApplyProjectPreferences';
-import { parseToolbarButtons } from './ProjectSettingsReader';
+import {
+  parseToolbarButtons,
+  parseResourceProperties,
+} from './ProjectSettingsReader';
 import YAML from 'yaml';
 import { type Preferences } from '../MainFrame/Preferences/PreferencesContext';
 
@@ -270,6 +273,117 @@ preferences:
       const raw = ([{ name: 'Lint', icon: '🔍', npmScript: 'lint' }]: any);
       const result = parseToolbarButtons(raw, {});
       expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('parseResourceProperties', () => {
+    test('parses string, number and boolean properties', () => {
+      // $FlowFixMe[incompatible-call]
+      const raw = ([
+        { name: 'packTag', label: 'Packing tag', type: 'string' },
+        { name: 'customScale', type: 'number', resourceKinds: ['image'] },
+        { name: 'noResize', label: 'Do not resize', type: 'boolean' },
+      ]: any);
+      const result = parseResourceProperties(raw);
+      expect(result).toEqual([
+        { name: 'packTag', label: 'Packing tag', type: 'string' },
+        {
+          name: 'customScale',
+          label: 'customScale',
+          type: 'number',
+          resourceKinds: ['image'],
+        },
+        { name: 'noResize', label: 'Do not resize', type: 'boolean' },
+      ]);
+    });
+
+    test('parses no-atlas, no-resize and scale-multiplier properties', () => {
+      // $FlowFixMe[incompatible-call]
+      const raw = ([
+        { name: 'no-atlas', label: 'No atlas', type: 'boolean' },
+        { name: 'no-resize', label: 'No resize', type: 'boolean' },
+        {
+          name: 'scale-multiplier',
+          label: 'Scale multiplier',
+          type: 'number',
+          resourceKinds: ['image'],
+        },
+      ]: any);
+      const result = parseResourceProperties(raw);
+      expect(result).toEqual([
+        { name: 'no-atlas', label: 'No atlas', type: 'boolean' },
+        { name: 'no-resize', label: 'No resize', type: 'boolean' },
+        {
+          name: 'scale-multiplier',
+          label: 'Scale multiplier',
+          type: 'number',
+          resourceKinds: ['image'],
+        },
+      ]);
+    });
+
+    test('parses a property with a default value', () => {
+      // $FlowFixMe[incompatible-call]
+      const raw = ([
+        {
+          name: 'scale-multiplier',
+          label: 'Scale multiplier',
+          type: 'number',
+          resourceKinds: ['image'],
+          default: 0.5,
+        },
+      ]: any);
+      const result = parseResourceProperties(raw);
+      expect(result).toEqual([
+        {
+          name: 'scale-multiplier',
+          label: 'Scale multiplier',
+          type: 'number',
+          resourceKinds: ['image'],
+          default: 0.5,
+        },
+      ]);
+    });
+
+    test('skips a property without a name', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // $FlowFixMe[incompatible-call]
+      const raw = ([{ label: 'No name', type: 'string' }]: any);
+      expect(parseResourceProperties(raw)).toHaveLength(0);
+      warnSpy.mockRestore();
+    });
+
+    test('skips a property with an invalid type', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // $FlowFixMe[incompatible-call]
+      const raw = ([{ name: 'weird', type: 'object' }]: any);
+      expect(parseResourceProperties(raw)).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type "object"')
+      );
+      warnSpy.mockRestore();
+    });
+
+    test('skips a property with an unsafe name', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // $FlowFixMe[incompatible-call]
+      const raw = ([{ name: 'bad name!', type: 'string' }]: any);
+      expect(parseResourceProperties(raw)).toHaveLength(0);
+      warnSpy.mockRestore();
+    });
+
+    test('deduplicates by name, last definition wins', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // $FlowFixMe[incompatible-call]
+      const raw = ([
+        { name: 'tag', label: 'First', type: 'string' },
+        { name: 'tag', label: 'Second', type: 'number' },
+      ]: any);
+      const result = parseResourceProperties(raw);
+      expect(result).toEqual([
+        { name: 'tag', label: 'Second', type: 'number' },
+      ]);
+      warnSpy.mockRestore();
     });
   });
 });

--- a/newIDE/app/src/Utils/ProjectSettingsReader.spec.js
+++ b/newIDE/app/src/Utils/ProjectSettingsReader.spec.js
@@ -5,7 +5,7 @@ import {
 } from './ApplyProjectPreferences';
 import {
   parseToolbarButtons,
-  parseResourceProperties,
+  parseResourceCustomProperties,
 } from './ProjectSettingsReader';
 import YAML from 'yaml';
 import { type Preferences } from '../MainFrame/Preferences/PreferencesContext';
@@ -276,7 +276,7 @@ preferences:
     });
   });
 
-  describe('parseResourceProperties', () => {
+  describe('parseResourceCustomProperties', () => {
     test('parses string, number and boolean properties', () => {
       // $FlowFixMe[incompatible-call]
       const raw = ([
@@ -284,7 +284,7 @@ preferences:
         { name: 'customScale', type: 'number', resourceKinds: ['image'] },
         { name: 'noResize', label: 'Do not resize', type: 'boolean' },
       ]: any);
-      const result = parseResourceProperties(raw);
+      const result = parseResourceCustomProperties(raw);
       expect(result).toEqual([
         { name: 'packTag', label: 'Packing tag', type: 'string' },
         {
@@ -309,7 +309,7 @@ preferences:
           resourceKinds: ['image'],
         },
       ]: any);
-      const result = parseResourceProperties(raw);
+      const result = parseResourceCustomProperties(raw);
       expect(result).toEqual([
         { name: 'no-atlas', label: 'No atlas', type: 'boolean' },
         { name: 'no-resize', label: 'No resize', type: 'boolean' },
@@ -333,7 +333,7 @@ preferences:
           default: 0.5,
         },
       ]: any);
-      const result = parseResourceProperties(raw);
+      const result = parseResourceCustomProperties(raw);
       expect(result).toEqual([
         {
           name: 'scale-multiplier',
@@ -349,7 +349,7 @@ preferences:
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       // $FlowFixMe[incompatible-call]
       const raw = ([{ label: 'No name', type: 'string' }]: any);
-      expect(parseResourceProperties(raw)).toHaveLength(0);
+      expect(parseResourceCustomProperties(raw)).toHaveLength(0);
       warnSpy.mockRestore();
     });
 
@@ -357,7 +357,7 @@ preferences:
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       // $FlowFixMe[incompatible-call]
       const raw = ([{ name: 'weird', type: 'object' }]: any);
-      expect(parseResourceProperties(raw)).toHaveLength(0);
+      expect(parseResourceCustomProperties(raw)).toHaveLength(0);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid type "object"')
       );
@@ -368,7 +368,7 @@ preferences:
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       // $FlowFixMe[incompatible-call]
       const raw = ([{ name: 'bad name!', type: 'string' }]: any);
-      expect(parseResourceProperties(raw)).toHaveLength(0);
+      expect(parseResourceCustomProperties(raw)).toHaveLength(0);
       warnSpy.mockRestore();
     });
 
@@ -379,7 +379,7 @@ preferences:
         { name: 'tag', label: 'First', type: 'string' },
         { name: 'tag', label: 'Second', type: 'number' },
       ]: any);
-      const result = parseResourceProperties(raw);
+      const result = parseResourceCustomProperties(raw);
       expect(result).toEqual([
         { name: 'tag', label: 'Second', type: 'number' },
       ]);

--- a/newIDE/app/src/stories/FakeResourceManagement.js
+++ b/newIDE/app/src/stories/FakeResourceManagement.js
@@ -20,7 +20,7 @@ const fakeResourceManagementProps: ResourceManagementProps = {
   canInstallPrivateAsset: () => false,
   onNewResourcesAdded: () => {},
   onResourceUsageChanged: () => {},
-  resourcePropertiesSchema: [],
+  resourcePropertyConfigs: [],
 };
 
 export default fakeResourceManagementProps;

--- a/newIDE/app/src/stories/FakeResourceManagement.js
+++ b/newIDE/app/src/stories/FakeResourceManagement.js
@@ -20,7 +20,7 @@ const fakeResourceManagementProps: ResourceManagementProps = {
   canInstallPrivateAsset: () => false,
   onNewResourcesAdded: () => {},
   onResourceUsageChanged: () => {},
-  resourcePropertyConfigs: [],
+  resourceCustomPropertyConfigs: [],
 };
 
 export default fakeResourceManagementProps;

--- a/newIDE/app/src/stories/FakeResourceManagement.js
+++ b/newIDE/app/src/stories/FakeResourceManagement.js
@@ -20,6 +20,7 @@ const fakeResourceManagementProps: ResourceManagementProps = {
   canInstallPrivateAsset: () => false,
   onNewResourcesAdded: () => {},
   onResourceUsageChanged: () => {},
+  resourcePropertiesSchema: [],
 };
 
 export default fakeResourceManagementProps;

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
@@ -150,7 +150,7 @@ export const withoutEffectsForA2DLayer = (): React.Node => (
           canInstallPrivateAsset: () => false,
           onNewResourcesAdded: () => {},
           onResourceUsageChanged: () => {},
-          resourcePropertyConfigs: [],
+          resourceCustomPropertyConfigs: [],
         }}
         projectScopedContainersAccessor={
           testProject.testSceneProjectScopedContainersAccessor
@@ -181,7 +181,7 @@ export const withoutEffectsForA3DLayer = (): React.Node => (
           canInstallPrivateAsset: () => false,
           onNewResourcesAdded: () => {},
           onResourceUsageChanged: () => {},
-          resourcePropertyConfigs: [],
+          resourceCustomPropertyConfigs: [],
         }}
         projectScopedContainersAccessor={
           testProject.testSceneProjectScopedContainersAccessor

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
@@ -150,6 +150,7 @@ export const withoutEffectsForA2DLayer = (): React.Node => (
           canInstallPrivateAsset: () => false,
           onNewResourcesAdded: () => {},
           onResourceUsageChanged: () => {},
+          resourcePropertiesSchema: [],
         }}
         projectScopedContainersAccessor={
           testProject.testSceneProjectScopedContainersAccessor
@@ -180,6 +181,7 @@ export const withoutEffectsForA3DLayer = (): React.Node => (
           canInstallPrivateAsset: () => false,
           onNewResourcesAdded: () => {},
           onResourceUsageChanged: () => {},
+          resourcePropertiesSchema: [],
         }}
         projectScopedContainersAccessor={
           testProject.testSceneProjectScopedContainersAccessor

--- a/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
+++ b/newIDE/app/src/stories/componentStories/ObjectEditor/EffectsList.stories.js
@@ -150,7 +150,7 @@ export const withoutEffectsForA2DLayer = (): React.Node => (
           canInstallPrivateAsset: () => false,
           onNewResourcesAdded: () => {},
           onResourceUsageChanged: () => {},
-          resourcePropertiesSchema: [],
+          resourcePropertyConfigs: [],
         }}
         projectScopedContainersAccessor={
           testProject.testSceneProjectScopedContainersAccessor
@@ -181,7 +181,7 @@ export const withoutEffectsForA3DLayer = (): React.Node => (
           canInstallPrivateAsset: () => false,
           onNewResourcesAdded: () => {},
           onResourceUsageChanged: () => {},
-          resourcePropertiesSchema: [],
+          resourcePropertyConfigs: [],
         }}
         projectScopedContainersAccessor={
           testProject.testSceneProjectScopedContainersAccessor

--- a/newIDE/app/src/stories/componentStories/ResourcesList/CompactResourceSelectorWithThumbnail.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/CompactResourceSelectorWithThumbnail.stories.js
@@ -73,7 +73,7 @@ export const Default = (): React.Node => {
             canInstallPrivateAsset: () => false,
             onNewResourcesAdded: () => {},
             onResourceUsageChanged: () => {},
-            resourcePropertyConfigs: [],
+            resourceCustomPropertyConfigs: [],
           }}
           resourceName="icon128.png"
           onChange={action('on change')}

--- a/newIDE/app/src/stories/componentStories/ResourcesList/CompactResourceSelectorWithThumbnail.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/CompactResourceSelectorWithThumbnail.stories.js
@@ -73,7 +73,7 @@ export const Default = (): React.Node => {
             canInstallPrivateAsset: () => false,
             onNewResourcesAdded: () => {},
             onResourceUsageChanged: () => {},
-            resourcePropertiesSchema: [],
+            resourcePropertyConfigs: [],
           }}
           resourceName="icon128.png"
           onChange={action('on change')}

--- a/newIDE/app/src/stories/componentStories/ResourcesList/CompactResourceSelectorWithThumbnail.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/CompactResourceSelectorWithThumbnail.stories.js
@@ -73,6 +73,7 @@ export const Default = (): React.Node => {
             canInstallPrivateAsset: () => false,
             onNewResourcesAdded: () => {},
             onResourceUsageChanged: () => {},
+            resourcePropertiesSchema: [],
           }}
           resourceName="icon128.png"
           onChange={action('on change')}

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
@@ -74,6 +74,7 @@ export const ImageWithMultipleExternalEditors = (): React.Node => (
       canInstallPrivateAsset: () => false,
       onNewResourcesAdded: () => {},
       onResourceUsageChanged: () => {},
+      resourcePropertiesSchema: [],
     }}
     initialResourceName=""
     onChange={action('on change')}

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
@@ -74,7 +74,7 @@ export const ImageWithMultipleExternalEditors = (): React.Node => (
       canInstallPrivateAsset: () => false,
       onNewResourcesAdded: () => {},
       onResourceUsageChanged: () => {},
-      resourcePropertiesSchema: [],
+      resourcePropertyConfigs: [],
     }}
     initialResourceName=""
     onChange={action('on change')}

--- a/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
+++ b/newIDE/app/src/stories/componentStories/ResourcesList/ResourceSelector.stories.js
@@ -74,7 +74,7 @@ export const ImageWithMultipleExternalEditors = (): React.Node => (
       canInstallPrivateAsset: () => false,
       onNewResourcesAdded: () => {},
       onResourceUsageChanged: () => {},
-      resourcePropertyConfigs: [],
+      resourceCustomPropertyConfigs: [],
     }}
     initialResourceName=""
     onChange={action('on change')}


### PR DESCRIPTION
## Summary

Adds support for **configurable custom resource properties**. Projects can now declare extra, editable metadata fields for their resources via a new `resourceProperties` section in `gdevelop-settings.yaml`. These fields render in the Resource Properties editor and persist into the resource's metadata JSON.

Supported field types: `string`, `boolean`, and `number`.

## What's included

- **Settings schema (`ProjectSettingsReader.js`)**
  - New `resourceProperties` section parsing with validation: required `name` (restricted to safe characters), valid `type` (`string` / `boolean` / `number`), optional `label`, `description`, `resourceKinds`, and `default`.
  - Invalid entries are skipped with a warning; duplicate names are de-duplicated (last definition wins).
- **Resource metadata helpers (`ResourceUtils.js`)**
  - `getResourceCustomProperties`, `getResourceCustomPropertyValue`, and `setResourceCustomPropertyValue` store values under a dedicated `customProperties` metadata key to avoid collisions with existing metadata (e.g. `localFilePath`).
- **Editor integration (`ResourcePropertiesEditor/index.js`)**
  - Builds editor fields from the configured schema, filtered by resource kind, and writes changes back to resource metadata.
- **Plumbing**
  - `resourcePropertiesSchema` threaded through `ResourceManagementProps` and `MainFrame` (loaded on project open, cleared on close), plus story/test fixtures updated.

## Configuration example

```yaml
resourceCustomProperties:
  - name: "some-name-0"
    label: "Some Name 0"
    type: "boolean"
    description: "Some description related resource processing"
    resourceKinds: ["image"]
  - name: "some-name-1"
    label: "Some Name 1"
    type: "boolean"
    resourceKinds: ["image"]
  - name: "some-number-name"
    label: "Some Number Name"
    type: "number"
    resourceKinds: ["image"]
```


