### PR TITLE
Improvements of the AI unique mode

### DIFF
--- a/newIDE/app/src/AiGeneration/AiRequestChat/AutoEditButton.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/AutoEditButton.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { Trans } from '@lingui/macro';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import Paper from '../../UI/Paper';
 import classes from './AutoEditButton.module.css';
@@ -38,13 +37,14 @@ const AutoEditButton = ({
     style={{ ...styles.paper, opacity: disabled ? 0.5 : 1 }}
   >
     <ButtonBase onClick={onToggle} disabled={disabled} style={styles.button}>
-      <Trans>Auto edit</Trans>
+      {/* Not translated on purpose: keeps the button compact across locales. */}
+      Auto edit
       <span
         className={`${classes.statusPill} ${
           isAutoEditEnabled ? classes.statusPillOn : classes.statusPillOff
         }`}
       >
-        {isAutoEditEnabled ? <Trans>On</Trans> : <Trans>Off</Trans>}
+        {isAutoEditEnabled ? 'On' : 'Off'}
       </span>
     </ButtonBase>
   </Paper>

--- a/newIDE/app/src/AiGeneration/AiRequestChat/ChatMessages.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/ChatMessages.js
@@ -1003,6 +1003,7 @@ export const ChatMessages: React.ComponentType<Props> = React.memo<Props>(
                               existingFunctionCallOutput
                             }
                             editorCallbacks={editorCallbacks}
+                            isRequestStopped={aiRequest.status === 'suspended'}
                           />
                         )
                       )}
@@ -1096,6 +1097,9 @@ export const ChatMessages: React.ComponentType<Props> = React.memo<Props>(
                                     existingFunctionCallOutput
                                   }
                                   editorCallbacks={editorCallbacks}
+                                  isRequestStopped={
+                                    aiRequest.status === 'suspended'
+                                  }
                                 />
                               )
                             )}

--- a/newIDE/app/src/AiGeneration/AiRequestChat/EditApprovalRow.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/EditApprovalRow.js
@@ -11,6 +11,7 @@ import { type EditApprovalRequest } from '../Utils';
 type Props = {|
   pendingEditApproval: EditApprovalRequest,
   onResolveEditApproval: (accepted: boolean) => void,
+  onAcceptAndEnableAutoEdit: () => void,
 |};
 
 const styles = {
@@ -23,14 +24,12 @@ const styles = {
 
 /**
  * Inline confirmation shown in the chat when auto-edit is off and the AI is
- * about to modify the project. The first line ("Apply this change: …", styled
- * like the chat's status line) wraps as needed; the second line holds the
- * No (suspends the request so the user can redirect) / Yes (runs the edit and
- * the rest of that edit agent's tools) buttons.
+ * about to modify the project.
  */
 export const EditApprovalRow = ({
   pendingEditApproval,
   onResolveEditApproval,
+  onAcceptAndEnableAutoEdit,
 }: Props): React.Node => (
   <ColumnStackLayout noMargin>
     <LineStackLayout noMargin alignItems="flex-start">
@@ -39,16 +38,20 @@ export const EditApprovalRow = ({
         <Trans>Apply this change:</Trans> {pendingEditApproval.label}
       </Text>
     </LineStackLayout>
-    <LineStackLayout noMargin alignItems="center">
+    <ColumnStackLayout noMargin alignItems="flex-start">
+      <RaisedButton
+        primary
+        label={<Trans>Yes, just this change</Trans>}
+        onClick={() => onResolveEditApproval(true)}
+      />
+      <FlatButton
+        label={<Trans>Yes, and enable auto-edit</Trans>}
+        onClick={onAcceptAndEnableAutoEdit}
+      />
       <FlatButton
         label={<Trans>No</Trans>}
         onClick={() => onResolveEditApproval(false)}
       />
-      <RaisedButton
-        primary
-        label={<Trans>Yes</Trans>}
-        onClick={() => onResolveEditApproval(true)}
-      />
-    </LineStackLayout>
+    </ColumnStackLayout>
   </ColumnStackLayout>
 );

--- a/newIDE/app/src/AiGeneration/AiRequestChat/FunctionCallRow.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/FunctionCallRow.js
@@ -48,6 +48,7 @@ type Props = {|
   editorFunctionCallResult: ?EditorFunctionCallResult,
   existingFunctionCallOutput: ?AiRequestFunctionCallOutput,
   editorCallbacks: EditorCallbacks,
+  isRequestStopped?: boolean,
 |};
 
 export const FunctionCallRow: React.ComponentType<Props> = React.memo<Props>(
@@ -66,10 +67,16 @@ const EditorFunctionCallRow = ({
   editorFunctionCallResult,
   existingFunctionCallOutput,
   editorCallbacks,
+  isRequestStopped,
 }: Props) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const { exampleShortHeaders } = React.useContext(ExampleStoreContext);
+  const { pendingEditApproval } = React.useContext(AiRequestContext);
+
+  const isAwaitingApproval =
+    !!pendingEditApproval &&
+    pendingEditApproval.callIds.includes(functionCall.call_id);
 
   let existingParsedOutput;
   try {
@@ -82,14 +89,17 @@ const EditorFunctionCallRow = ({
     existingParsedOutput = null;
   }
 
-  const isAborted =
-    (!!editorFunctionCallResult &&
-      editorFunctionCallResult.status === 'aborted') ||
-    (existingParsedOutput && !!existingParsedOutput.stopped);
   const isFinished =
     !!existingFunctionCallOutput ||
     (!!editorFunctionCallResult &&
       editorFunctionCallResult.status === 'finished');
+  const isAborted =
+    (!!editorFunctionCallResult &&
+      editorFunctionCallResult.status === 'aborted') ||
+    (existingParsedOutput && !!existingParsedOutput.stopped) ||
+    // The request was suspended before this call ran (no output): treat it as
+    // aborted rather than leaving a pending spinner.
+    (!!isRequestStopped && !isFinished);
   const functionCallResultIsErrored =
     editorFunctionCallResult &&
     editorFunctionCallResult.status === 'finished' &&
@@ -98,6 +108,7 @@ const EditorFunctionCallRow = ({
     functionCallResultIsErrored ||
     (existingParsedOutput && existingParsedOutput.success === false);
   const isWorking =
+    !isAwaitingApproval &&
     !isFinished &&
     !!editorFunctionCallResult &&
     editorFunctionCallResult.status === 'working';
@@ -170,9 +181,13 @@ const EditorFunctionCallRow = ({
     <div className={classes.functionCallContainer}>
       <div className={classes.functionCallRow}>
         <Tooltip
-          title={JSON.stringify(
+          title={
             existingFunctionCallOutput || editorFunctionCallResult
-          )}
+              ? JSON.stringify(
+                  existingFunctionCallOutput || editorFunctionCallResult
+                )
+              : ''
+          }
         >
           <span className={classes.statusIconContainer}>
             {hasErrored ? (
@@ -279,12 +294,14 @@ const SubAgentFunctionCallRow = ({
   functionCall,
   existingFunctionCallOutput,
   editorCallbacks,
+  isRequestStopped,
 }: Props) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const {
     aiRequestStorage,
     editorFunctionCallResultsStorage,
+    pendingEditApproval,
   } = React.useContext(AiRequestContext);
   const { aiRequests } = aiRequestStorage;
   const { getEditorFunctionCallResults } = editorFunctionCallResultsStorage;
@@ -300,6 +317,10 @@ const SubAgentFunctionCallRow = ({
   } catch (error) {
     existingParsedOutput = null;
   }
+
+  const isAwaitingApproval =
+    !!pendingEditApproval &&
+    pendingEditApproval.aiRequestId === subAgentAiRequestId;
 
   const isStopped = existingParsedOutput && !!existingParsedOutput.stopped;
   const hasErrored =
@@ -327,6 +348,7 @@ const SubAgentFunctionCallRow = ({
       (subAgentRequest.status === 'ready' ||
         subAgentRequest.status === 'error'));
   const isWorking =
+    !isAwaitingApproval &&
     !isFinished &&
     ((subAgentRequest && subAgentRequest.status === 'working') ||
       hasWorkInProgress);
@@ -502,6 +524,9 @@ const SubAgentFunctionCallRow = ({
                 editorFunctionCallResult={item.editorFunctionCallResult}
                 existingFunctionCallOutput={item.existingFunctionCallOutput}
                 editorCallbacks={editorCallbacks}
+                isRequestStopped={
+                  isRequestStopped || !!isStopped || !!hasErrored
+                }
               />
             ) : (
               <SubAgentTextRow

--- a/newIDE/app/src/AiGeneration/AiRequestChat/ReasoningLevelSelector.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/ReasoningLevelSelector.js
@@ -27,6 +27,7 @@ type Props = {|
   setAiConfigurationPresetId: string => void,
   aiConfigurationPresetsWithAvailability: Array<AiConfigurationPresetWithAvailability>,
   disabled?: boolean,
+  showSelectedLabel?: boolean,
 |};
 
 const networkIcons = [NetworkLow, NetworkMedium, NetworkHigh, NetworkMaximum];
@@ -57,6 +58,12 @@ const styles = {
   },
   networkIcon: {
     fontSize: 20,
+  },
+  label: {
+    fontSize: 13,
+    fontFamily: 'var(--gdevelop-modern-font-family)',
+    whiteSpace: 'nowrap',
+    margin: '0 4px',
   },
   chevronIcon: {
     fontSize: 20,
@@ -96,6 +103,7 @@ export const ReasoningLevelSelector = ({
   setAiConfigurationPresetId,
   aiConfigurationPresetsWithAvailability,
   disabled,
+  showSelectedLabel,
 }: Props): React.Node => {
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const networkIconColor =
@@ -166,6 +174,19 @@ export const ReasoningLevelSelector = ({
                   <NetworkIcon
                     style={{ ...styles.networkIcon, color: networkIconColor }}
                   />
+                  {showSelectedLabel && currentPreset && (
+                    <span style={styles.label}>
+                      {currentPreset.reasoningLevelByLocale
+                        ? selectMessageByLocale(
+                            i18n,
+                            currentPreset.reasoningLevelByLocale
+                          )
+                        : selectMessageByLocale(
+                            i18n,
+                            currentPreset.nameByLocale
+                          )}
+                    </span>
+                  )}
                   <ChevronArrowBottom style={styles.chevronIcon} />
                 </ButtonBase>
               </span>

--- a/newIDE/app/src/AiGeneration/AiRequestChat/index.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/index.js
@@ -47,6 +47,7 @@ import { ReasoningLevelSelector } from './ReasoningLevelSelector';
 import { AiRequestContext } from '../AiRequestContext';
 import PreferencesContext from '../../MainFrame/Preferences/PreferencesContext';
 import { useStickyVisibility } from './UseStickyVisibility';
+import { useResponsiveWindowSize } from '../../UI/Responsive/ResponsiveWindowMeasurer';
 import GDevelopThemeContext from '../../UI/Theme/GDevelopThemeContext';
 import CircledInfo from '../../UI/CustomSvgIcons/CircledInfo';
 import Coin from '../../Credits/Icons/Coin';
@@ -62,7 +63,6 @@ import Stop from '../../UI/CustomSvgIcons/Stop';
 import AutoEditButton from './AutoEditButton';
 import { EditApprovalRow } from './EditApprovalRow';
 import { type EditApprovalRequest } from '../Utils';
-import { textEllipsisStyle } from '../../UI/TextEllipsis';
 
 const TOO_MANY_USER_MESSAGES_WARNING_COUNT = 15;
 const TOO_MANY_USER_MESSAGES_ERROR_COUNT = 20;
@@ -90,17 +90,6 @@ const styles = {
     overflow: 'hidden',
     gap: 4,
     width: '100%',
-  },
-  quotaPlaceholderContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    overflow: 'hidden',
-  },
-  quotaPlaceholderTextContainer: {
-    flex: 1,
-    minWidth: 0,
-    textAlign: 'right',
-    ...textEllipsisStyle,
   },
   quotaInfoIconSpan: {
     flexShrink: 0,
@@ -147,6 +136,7 @@ const getPriceAndRequestsTextAndTooltip = ({
   progressBarColor,
   progressTrackColor,
   onOpenSubscriptionDialog,
+  hideLabel,
 }: {|
   quota: Quota | null,
   price: UsagePrice | null,
@@ -156,16 +146,20 @@ const getPriceAndRequestsTextAndTooltip = ({
   progressBarColor: string,
   progressTrackColor: string,
   onOpenSubscriptionDialog: () => void,
+  hideLabel?: boolean,
 |}): React.Node => {
   if (!quota || !price) {
     if (isRefreshingLimits) {
-      // Placeholder to avoid layout shift, while showing the (i) icon.
+      // No value yet: show only the indeterminate bar and the (i) icon, no label.
       return (
-        <div style={styles.quotaPlaceholderContainer}>
-          <div style={styles.quotaPlaceholderTextContainer}>
-            <Text size="body-small" color="secondary" noMargin>
-              <Trans>Calculating...</Trans>
-            </Text>
+        <div style={styles.quotaContainer}>
+          <div style={styles.quotaProgressBarWrapper}>
+            <LinearProgress
+              variant="indeterminate"
+              barColor={progressBarColor}
+              trackColor={progressTrackColor}
+              style={{ ...styles.quotaProgressBar }}
+            />
           </div>
           <span style={styles.quotaInfoIconSpan}>
             <CircledInfo color="inherit" style={styles.quotaInfoIcon} />
@@ -251,25 +245,25 @@ const getPriceAndRequestsTextAndTooltip = ({
 
   return (
     <div style={styles.quotaContainer}>
-      <Text size="body-small" color="secondary" noMargin>
-        {isRefreshingLimits ? (
-          <Trans>Calculating...</Trans>
-        ) : shouldShowCredits ? (
-          <>
-            <span style={styles.quotaCoinSpan}>
-              <Coin fontSize="small" />
-            </span>
-            <Trans>{Math.max(0, availableCredits)} credits available</Trans>
-          </>
-        ) : (
-          <Trans>{percentage}% left</Trans>
-        )}
-      </Text>
-      {!isRefreshingLimits && !shouldShowCredits && (
+      {!hideLabel && (
+        <Text size="body-small" color="secondary" noMargin>
+          {shouldShowCredits ? (
+            <>
+              <span style={styles.quotaCoinSpan}>
+                <Coin fontSize="small" />
+              </span>
+              <Trans>{Math.max(0, availableCredits)} credits available</Trans>
+            </>
+          ) : (
+            <Trans>{percentage}% left</Trans>
+          )}
+        </Text>
+      )}
+      {!shouldShowCredits && (
         <div style={styles.quotaProgressBarWrapper}>
           <LinearProgress
-            variant="determinate"
-            value={percentage}
+            variant={isRefreshingLimits ? 'indeterminate' : 'determinate'}
+            value={isRefreshingLimits ? undefined : percentage}
             barColor={progressBarColor}
             trackColor={progressTrackColor}
             style={{ ...styles.quotaProgressBar }}
@@ -430,74 +424,55 @@ export const AiRequestChat: React.ComponentType<{
     ref
   ) => {
     const project = exceptionallyGuardAgainstDeadObject(nullableProject);
+    const { isMobile } = useResponsiveWindowSize();
     const {
       aiRequestHistory: { handleNavigateHistory, resetNavigation },
       activeSubAgents,
-      autoEditEnabledStorage: { getAutoEditEnabled, setAutoEditEnabled },
     } = React.useContext(AiRequestContext);
     const {
       values: {
         automaticallyUseCreditsForAiRequests,
-        automaticallyApplyAiRequestEdits,
+        automaticallyApplyAiRequestEditsByProjectId,
       },
       setAutomaticallyUseCreditsForAiRequests,
-      setAutomaticallyApplyAiRequestEdits,
+      setAutomaticallyApplyAiRequestEditsForProjectId,
     } = React.useContext(PreferencesContext);
     const selectedMode = 'orchestrator';
     const aiRequestId: string = aiRequest ? aiRequest.id : '';
-    // "Auto edit" default: always on when no project is open (so a no-project
-    // request can create and build a project seamlessly), otherwise the saved
-    // preference. The live value is remembered per request (see the effect
-    // below) so it survives the editor being remounted mid-build.
-    const getDefaultIsAutoEditEnabled = React.useCallback(
-      () =>
-        !hasOpenedProject || !!standAloneForm
-          ? true
-          : automaticallyApplyAiRequestEdits,
-      [hasOpenedProject, standAloneForm, automaticallyApplyAiRequestEdits]
-    );
-    const [isAutoEditEnabled, setIsAutoEditEnabled] = React.useState<boolean>(
-      () => {
-        const stored = aiRequestId ? getAutoEditEnabled(aiRequestId) : null;
-        return stored != null ? stored : getDefaultIsAutoEditEnabled();
-      }
-    );
-    // Once the request id is known, remember its auto-edit value (seeding it
-    // from the default the first time). On later renders — including after a
-    // remount or once a no-project request has created a project — reuse the
-    // remembered value rather than re-deriving it from the preference, so the
-    // toggle never flips on its own while building.
-    React.useEffect(
-      () => {
-        if (!aiRequestId) return;
-        const stored = getAutoEditEnabled(aiRequestId);
-        if (stored != null) {
-          setIsAutoEditEnabled(stored);
-        } else {
-          const initial = getDefaultIsAutoEditEnabled();
-          setAutoEditEnabled(aiRequestId, initial);
-          setIsAutoEditEnabled(initial);
-        }
-      },
-      [
-        aiRequestId,
-        getAutoEditEnabled,
-        setAutoEditEnabled,
-        getDefaultIsAutoEditEnabled,
-      ]
-    );
-    // Toggling is only possible with a project open: persist the choice both as
-    // the global default (for future requests) and for this request.
+    const projectId = project ? project.getProjectUuid() : null;
+    // "Auto edit" defaults to on, unless the user turned it off for this project.
+    const isAutoEditEnabled =
+      !hasOpenedProject ||
+      !!standAloneForm ||
+      projectId == null ||
+      automaticallyApplyAiRequestEditsByProjectId[projectId] !== false;
+    // Persist the choice for the project.
     const toggleAutoEdit = React.useCallback(
       () => {
-        setIsAutoEditEnabled(previous => {
-          const next = !previous;
-          if (aiRequestId) setAutoEditEnabled(aiRequestId, next);
-          setAutomaticallyApplyAiRequestEdits(next);
-          return next;
-        });
+        if (projectId == null) return;
+        setAutomaticallyApplyAiRequestEditsForProjectId(
+          projectId,
+          !isAutoEditEnabled
+        );
       },
-      [aiRequestId, setAutoEditEnabled, setAutomaticallyApplyAiRequestEdits]
+      [
+        projectId,
+        isAutoEditEnabled,
+        setAutomaticallyApplyAiRequestEditsForProjectId,
+      ]
+    );
+    // Accept the pending edit and turn auto-edit on for the project.
+    const acceptEditAndEnableAutoEdit = React.useCallback(
+      () => {
+        if (projectId != null)
+          setAutomaticallyApplyAiRequestEditsForProjectId(projectId, true);
+        if (onResolveEditApproval) onResolveEditApproval(true);
+      },
+      [
+        projectId,
+        setAutomaticallyApplyAiRequestEditsForProjectId,
+        onResolveEditApproval,
+      ]
     );
     const gdevelopTheme = React.useContext(GDevelopThemeContext);
     const progressBarColor =
@@ -684,6 +659,7 @@ export const AiRequestChat: React.ComponentType<{
       isRefreshingLimits: isRefreshingLimitsStable,
       progressBarColor,
       progressTrackColor,
+      hideLabel: isMobile,
       onOpenSubscriptionDialog: () =>
         openSubscriptionDialog({
           analyticsMetadata: {
@@ -1077,6 +1053,7 @@ export const AiRequestChat: React.ComponentType<{
                           aiConfigurationPresetsWithAvailability
                         }
                         disabled={isWorking}
+                        showSelectedLabel={!hasOpenedProject}
                       />
                     </LineStackLayout>
                   )}
@@ -1181,6 +1158,7 @@ export const AiRequestChat: React.ComponentType<{
               <EditApprovalRow
                 pendingEditApproval={pendingEditApproval}
                 onResolveEditApproval={onResolveEditApproval}
+                onAcceptAndEnableAutoEdit={acceptEditAndEnableAutoEdit}
               />
             ) : null}
             {userMessagesCount >= TOO_MANY_USER_MESSAGES_WARNING_COUNT ? (
@@ -1288,6 +1266,7 @@ export const AiRequestChat: React.ComponentType<{
                     aiConfigurationPresetsWithAvailability
                   }
                   disabled={isWorking}
+                  showSelectedLabel={!hasOpenedProject}
                 />
               </LineStackLayout>
               <Column noMargin noOverflowParent>

--- a/newIDE/app/src/AiGeneration/AiRequestContext.js
+++ b/newIDE/app/src/AiGeneration/AiRequestContext.js
@@ -105,36 +105,6 @@ const useEditorFunctionCallResultsStorage = (): EditorFunctionCallResultsStorage
   };
 };
 
-// "Auto edit" is a frontend-only toggle. Its live value is remembered per AI
-// request here (in the app-level provider) so it survives the Ask AI editor
-// being unmounted/remounted — e.g. when a no-project request creates a project
-// and the editor is repositioned from the center to the right pane. Without
-// this, the toggle would re-initialize from the saved preference (and could
-// wrongly switch off mid-build). `null` means "no value remembered yet".
-type AutoEditEnabledStorage = {|
-  getAutoEditEnabled: (aiRequestId: string) => boolean | null,
-  setAutoEditEnabled: (aiRequestId: string, enabled: boolean) => void,
-|};
-
-const useAutoEditEnabledStorage = (): AutoEditEnabledStorage => {
-  const autoEditEnabledPerRequestRef = React.useRef<{
-    [aiRequestId: string]: boolean,
-  }>({});
-
-  return {
-    getAutoEditEnabled: React.useCallback((aiRequestId: string) => {
-      const value = autoEditEnabledPerRequestRef.current[aiRequestId];
-      return value === undefined ? null : value;
-    }, []),
-    setAutoEditEnabled: React.useCallback(
-      (aiRequestId: string, enabled: boolean) => {
-        autoEditEnabledPerRequestRef.current[aiRequestId] = enabled;
-      },
-      []
-    ),
-  };
-};
-
 type AiRequestStorage = {|
   fetchAiRequests: () => Promise<void>,
   onLoadMoreAiRequests: () => Promise<void>,
@@ -498,7 +468,6 @@ export type AiRequestContextState = {|
   aiRequestStorage: AiRequestStorage,
   aiRequestHistory: AiRequestHistory,
   editorFunctionCallResultsStorage: EditorFunctionCallResultsStorage,
-  autoEditEnabledStorage: AutoEditEnabledStorage,
   getAiSettings: () => AiSettings | null,
   isFetchingSuggestions: boolean,
   setIsFetchingSuggestions: (value: boolean) => void,
@@ -563,10 +532,6 @@ export const initialAiRequestContextState: AiRequestContextState = {
     addEditorFunctionCallResults: () => [],
     clearEditorFunctionCallResults: () => {},
   },
-  autoEditEnabledStorage: {
-    getAutoEditEnabled: () => null,
-    setAutoEditEnabled: () => {},
-  },
   getAiSettings: () => null,
   isFetchingSuggestions: false,
   setIsFetchingSuggestions: () => {},
@@ -622,7 +587,6 @@ export const AiRequestProvider = ({
   children,
 }: AiRequestProviderProps): React.MixedElement => {
   const editorFunctionCallResultsStorage = useEditorFunctionCallResultsStorage();
-  const autoEditEnabledStorage = useAutoEditEnabledStorage();
   const aiRequestStorage = useAiRequestsStorage();
   const aiRequestHistory = useAiRequestHistory(aiRequestStorage);
 
@@ -1111,7 +1075,6 @@ export const AiRequestProvider = ({
       aiRequestStorage,
       aiRequestHistory,
       editorFunctionCallResultsStorage,
-      autoEditEnabledStorage,
       getAiSettings,
       isFetchingSuggestions,
       setIsFetchingSuggestions,
@@ -1130,7 +1093,6 @@ export const AiRequestProvider = ({
       aiRequestStorage,
       aiRequestHistory,
       editorFunctionCallResultsStorage,
-      autoEditEnabledStorage,
       getAiSettings,
       isFetchingSuggestions,
       setIsFetchingSuggestions,

--- a/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
+++ b/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
@@ -1099,6 +1099,13 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           title: MessageDescriptor,
           message: MessageDescriptor,
         |}): Promise<boolean> => {
+          if (pendingEditApproval) {
+            // Paused on an inline edit approval (not actively working): leaving
+            // refuses the pending change, which suspends the request. Don't show
+            // the "is working" prompt.
+            resolveEditApproval(false);
+            return true;
+          }
           if (!getHasWorkInProgress()) return true;
           const answer = await showYesNoCancel({
             title,
@@ -1126,7 +1133,14 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           // running in the background.
           return true;
         },
-        [getHasWorkInProgress, showYesNoCancel, upToDateOnStop, isMobile]
+        [
+          pendingEditApproval,
+          resolveEditApproval,
+          getHasWorkInProgress,
+          showYesNoCancel,
+          upToDateOnStop,
+          isMobile,
+        ]
       );
 
       // Called when the AI editor is about to be closed by an explicit user
@@ -1152,6 +1166,13 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           title: MessageDescriptor,
           message: MessageDescriptor,
         |}): Promise<boolean> => {
+          if (pendingEditApproval) {
+            // Paused on an inline edit approval (not actively working): leaving
+            // refuses the pending change, which suspends the request. Don't show
+            // the "is working" prompt.
+            resolveEditApproval(false);
+            return true;
+          }
           if (!getHasWorkInProgress()) return true;
           const shouldStop = await showConfirmation({
             title,
@@ -1163,7 +1184,13 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           await upToDateOnStop.current();
           return true;
         },
-        [getHasWorkInProgress, showConfirmation, upToDateOnStop]
+        [
+          pendingEditApproval,
+          resolveEditApproval,
+          getHasWorkInProgress,
+          showConfirmation,
+          upToDateOnStop,
+        ]
       );
       const upToDateConfirmStopping = useStableUpToDateRef(
         confirmStoppingWorkingRequest

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -241,10 +241,7 @@ export type PreferencesValues = {|
   takeScreenshotOnPreview: boolean,
   showAiAskButtonInTitleBar: boolean,
   automaticallyUseCreditsForAiRequests: boolean,
-  // Default for the AI chat "auto edit" toggle when a project is open. When no
-  // project is open the toggle is always on (so a no-project request can create
-  // and build a project seamlessly), regardless of this value.
-  automaticallyApplyAiRequestEdits: boolean,
+  automaticallyApplyAiRequestEditsByProjectId: { [string]: boolean },
   useBackgroundSerializerForSaving: boolean,
   disableNpmScriptConfirmation: boolean,
   showJsTypeError: boolean,
@@ -370,7 +367,10 @@ export type Preferences = {|
   setTakeScreenshotOnPreview: (enabled: boolean) => void,
   setShowAiAskButtonInTitleBar: (enabled: boolean) => void,
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => void,
-  setAutomaticallyApplyAiRequestEdits: (enabled: boolean) => void,
+  setAutomaticallyApplyAiRequestEditsForProjectId: (
+    projectId: string,
+    enabled: boolean
+  ) => void,
   setUseBackgroundSerializerForSaving: (enabled: boolean) => void,
   setShowJsTypeError: (enabled: boolean) => void,
   setCanonicalEventSerialization: (enabled: boolean) => void,
@@ -436,7 +436,7 @@ export const initialPreferences = {
     takeScreenshotOnPreview: true,
     showAiAskButtonInTitleBar: true,
     automaticallyUseCreditsForAiRequests: false,
-    automaticallyApplyAiRequestEdits: false,
+    automaticallyApplyAiRequestEditsByProjectId: {},
     useBackgroundSerializerForSaving: false,
     disableNpmScriptConfirmation: false,
     showJsTypeError: false,
@@ -525,7 +525,10 @@ export const initialPreferences = {
   setTakeScreenshotOnPreview: (enabled: boolean) => {},
   setShowAiAskButtonInTitleBar: (enabled: boolean) => {},
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => {},
-  setAutomaticallyApplyAiRequestEdits: (enabled: boolean) => {},
+  setAutomaticallyApplyAiRequestEditsForProjectId: (
+    projectId: string,
+    enabled: boolean
+  ) => {},
   setUseBackgroundSerializerForSaving: (enabled: boolean) => {},
   setShowJsTypeError: (enabled: boolean) => {},
   setCanonicalEventSerialization: (enabled: boolean) => {},

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -88,7 +88,7 @@ export const getInitialPreferences = (): {
   autoDisplayChangelog: boolean,
   autoDownloadUpdates: boolean,
   autoOpenMostRecentProject: boolean,
-  automaticallyApplyAiRequestEdits: boolean,
+  automaticallyApplyAiRequestEditsByProjectId: { [string]: boolean },
   automaticallyUseCreditsForAiRequests: boolean,
   autosaveOnPreview: boolean,
   backdropClickBehavior: string,
@@ -403,7 +403,7 @@ export default class PreferencesProvider extends React.Component<Props, State> {
       this
     ): any),
     // $FlowFixMe[method-unbinding]
-    setAutomaticallyApplyAiRequestEdits: (this._setAutomaticallyApplyAiRequestEdits.bind(
+    setAutomaticallyApplyAiRequestEditsForProjectId: (this._setAutomaticallyApplyAiRequestEditsForProjectId.bind(
       this
     ): any),
     // $FlowFixMe[method-unbinding]
@@ -1417,12 +1417,18 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     );
   }
 
-  _setAutomaticallyApplyAiRequestEdits(newValue: boolean) {
+  _setAutomaticallyApplyAiRequestEditsForProjectId(
+    projectId: string,
+    newValue: boolean
+  ) {
     this.setState(
       state => ({
         values: {
           ...state.values,
-          automaticallyApplyAiRequestEdits: newValue,
+          automaticallyApplyAiRequestEditsByProjectId: {
+            ...state.values.automaticallyApplyAiRequestEditsByProjectId,
+            [projectId]: newValue,
+          },
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/stories/componentStories/AiGeneration/AiRequestChat/Orchestrator.stories.js
+++ b/newIDE/app/src/stories/componentStories/AiGeneration/AiRequestChat/Orchestrator.stories.js
@@ -26,6 +26,7 @@ import PreferencesContext, {
   initialPreferences,
 } from '../../../../MainFrame/Preferences/PreferencesContext';
 import { CreditsPackageStoreStateProvider } from '../../../../AssetStore/CreditsPackages/CreditsPackageStoreContext';
+import { testProject } from '../../../GDevelopJsInitializerDecorator';
 
 // Chat and Agent modes were merged into a single "orchestrator" mode: these
 // stories exercise that unique mode (the conversational replies, the function
@@ -127,8 +128,9 @@ export const commonProps = {
 };
 
 // Wraps AiRequestChat with all the contexts it needs. Stories can drive the
-// "Auto edit" toggle through the `automaticallyApplyAiRequestEdits` preference
-// (with a project opened, so it isn't forced on like in the no-project flow).
+// "Auto edit" toggle through the `automaticallyApplyAiRequestEdits` boolean,
+// turned into a per-project override keyed by the chat's project UUID (the
+// stories pass a real project so it isn't forced on like in the no-project flow).
 const WrappedChatComponent = (allProps: any) => {
   const {
     authenticatedUser,
@@ -141,10 +143,14 @@ const WrappedChatComponent = (allProps: any) => {
   const [automaticallyUseCredits, setAutomaticallyUseCredits] = React.useState(
     automaticallyUseCreditsForAiRequests || false
   );
-  const applyEdits =
+  const chatProjectId = chatProps.project
+    ? chatProps.project.getProjectUuid()
+    : null;
+  const automaticallyApplyAiRequestEditsByProjectId =
+    chatProjectId != null &&
     typeof automaticallyApplyAiRequestEdits === 'boolean'
-      ? automaticallyApplyAiRequestEdits
-      : initialPreferences.values.automaticallyApplyAiRequestEdits;
+      ? { [chatProjectId]: automaticallyApplyAiRequestEdits }
+      : {};
   return (
     <FixedHeightFlexContainer height={800}>
       <FixedWidthFlexContainer width={600}>
@@ -156,7 +162,7 @@ const WrappedChatComponent = (allProps: any) => {
             values: {
               ...initialPreferences.values,
               automaticallyUseCreditsForAiRequests: automaticallyUseCredits,
-              automaticallyApplyAiRequestEdits: applyEdits,
+              automaticallyApplyAiRequestEditsByProjectId,
             },
             setAutomaticallyUseCreditsForAiRequests: (value: boolean) => {
               setAutomaticallyUseCredits(value);
@@ -657,6 +663,7 @@ export const LongReadyAiRequestWithFunctionCallToDo = (): React.Node => (
 
 export const AutoEditEnabledWithWorkingFunctionCall = (): React.Node => (
   <WrappedChatComponent
+    project={testProject.project}
     automaticallyApplyAiRequestEdits={true}
     aiRequest={aiRequestWithModifyingFunctionCall}
     editorFunctionCallResults={[
@@ -670,6 +677,7 @@ export const AutoEditEnabledWithWorkingFunctionCall = (): React.Node => (
 
 export const AutoEditDisabledWithPendingEditApproval = (): React.Node => (
   <WrappedChatComponent
+    project={testProject.project}
     automaticallyApplyAiRequestEdits={false}
     aiRequest={aiRequestWithModifyingFunctionCall}
     pendingEditApproval={{
@@ -684,6 +692,7 @@ export const AutoEditDisabledWithPendingEditApproval = (): React.Node => (
 
 export const AutoEditDisabledWithPendingEditApprovalForTool = (): React.Node => (
   <WrappedChatComponent
+    project={testProject.project}
     automaticallyApplyAiRequestEdits={false}
     aiRequest={aiRequestWithModifyingFunctionCall}
     pendingEditApproval={{


### PR DESCRIPTION
  - ReasoningLevelSelector now shows the selected label when no project open.
  - Auto-edit defaults to on, remembering an explicit off per-project.
  - Edit approval shows three vertical buttons (yes / yes+auto / no).
  - Auto-edit button label no longer translated, keeping it compact.
  - Credits label hidden on mobile to save space.
  - Credits bar always shown, animating as an indeterminate loader while
  loading.
  - Tool awaiting approval shows a determinate icon, not a spinner.
  - Sub-agent shows the pending icon when its call awaits approval.
  - Closing a tab awaiting approval refuses the edit without prompting.
  - Suspended request's never-run calls show a cross, not a spinner.