### PR TITLE
Better metrics

### DIFF
--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -163,6 +163,7 @@ import {
   sendInAppTutorialStarted,
   sendEventsExtractedAsFunction,
   sendPreviewStarted,
+  sendProjectOpened,
 } from '../Utils/Analytics/EventSender';
 import { useLeaderboardReplacer } from '../Leaderboard/UseLeaderboardReplacer';
 import useAlertDialog from '../UI/Alert/useAlertDialog';
@@ -1315,6 +1316,10 @@ const MainFrame = (props: Props): React.MixedElement => {
       options?: {|
         openingMessage?: ?MessageDescriptor,
         ignoreAutoSave?: boolean,
+        // Set when this "open" is really the first step of creating a new project
+        // (loading a template/example that will be re-stamped with a new UUID).
+        // In that case we must not report it as the user re-opening a project.
+        doNotTrackAsProjectOpened?: boolean,
       |}
     ): Promise<?State> => {
       const storageProviderOperations = getStorageProviderOperations();
@@ -1435,13 +1440,31 @@ const MainFrame = (props: Props): React.MixedElement => {
         const serializedProject = gd.Serializer.fromJSObject(content);
 
         try {
-          const state = loadFromSerializedProject(
+          const state = await loadFromSerializedProject(
             serializedProject,
             // Note that fileMetadata is the original, unchanged one, even if we're loading
             // an autosave. If we're for some reason loading an autosave, we still consider
             // that we're opening the file that was originally requested by the user.
             fileMetadata
           );
+
+          // Report that the user opened an existing project, so we can tell apart
+          // people coming back to the same project from people creating new ones.
+          // Skipped when this "open" is just loading a template to create a new project.
+          if (
+            state.currentProject &&
+            !(options && options.doNotTrackAsProjectOpened)
+          ) {
+            const lastModifiedDate = fileMetadata.lastModifiedDate;
+            sendProjectOpened({
+              projectUuid: state.currentProject.getProjectUuid(),
+              storageProviderName: getStorageProvider().internalName,
+              timeSinceLastModified: lastModifiedDate
+                ? Date.now() - lastModifiedDate
+                : null,
+            });
+          }
+
           return state;
         } finally {
           sealUnsavedChanges();
@@ -1467,6 +1490,7 @@ const MainFrame = (props: Props): React.MixedElement => {
     [
       i18n,
       getStorageProviderOperations,
+      getStorageProvider,
       loadFromSerializedProject,
       showConfirmation,
       showAlert,
@@ -2512,6 +2536,7 @@ const MainFrame = (props: Props): React.MixedElement => {
 
         if (!isForInGameEdition)
           sendPreviewStarted({
+            projectUuid: currentProject.getProjectUuid(),
             quickCustomizationGameId:
               quickCustomizationDialogOpenedFromGameId || null,
             networkPreview: !!networkPreview,

--- a/newIDE/app/src/ProjectCreation/CreateProject.js
+++ b/newIDE/app/src/ProjectCreation/CreateProject.js
@@ -2,7 +2,6 @@
 import { t } from '@lingui/macro';
 import { type StorageProvider, type FileMetadata } from '../ProjectsStorage';
 import { getExample } from '../Utils/GDevelopServices/Example';
-import { sendNewGameCreated } from '../Utils/Analytics/EventSender';
 import UrlStorageProvider from '../ProjectsStorage/UrlStorageProvider';
 import { showErrorBox } from '../UI/Messages/MessageBox';
 import {
@@ -12,20 +11,34 @@ import {
 import { retryIfFailed } from '../Utils/RetryIfFailed';
 const gd: libGDevelop = global.gd;
 
+// Metadata for the `new_game_creation` analytics event. The event itself is sent
+// later (from `useCreateProject`), once the project has its final UUID assigned.
+export type NewProjectAnalyticsMetadata = {|
+  exampleUrl: string,
+  exampleSlug: string,
+  exampleCompositeSlug: string,
+  creationSource: NewProjectCreationSource,
+|};
+
 export type NewProjectSource = {|
   project: ?gdProject,
   storageProvider: ?StorageProvider,
   fileMetadata: ?FileMetadata,
   templateSlug?: ?string,
+  analyticsMetadata: NewProjectAnalyticsMetadata,
 |};
 
-const getNewProjectSourceFromUrl = (projectUrl: string): NewProjectSource => {
+const getNewProjectSourceFromUrl = (
+  projectUrl: string,
+  analyticsMetadata: NewProjectAnalyticsMetadata
+): NewProjectSource => {
   return {
     project: null,
     storageProvider: UrlStorageProvider,
     fileMetadata: {
       fileIdentifier: projectUrl,
     },
+    analyticsMetadata,
   };
 };
 
@@ -88,16 +101,16 @@ export const createNewEmptyProject = ({
 
   const exampleSlug = 'empty-project';
 
-  sendNewGameCreated({
-    exampleUrl: '',
-    exampleSlug,
-    creationSource,
-    exampleCompositeSlug: getCompositeSlug(creationSource, exampleSlug),
-  });
   return {
     project,
     storageProvider: null,
     fileMetadata: null,
+    analyticsMetadata: {
+      exampleUrl: '',
+      exampleSlug,
+      creationSource,
+      exampleCompositeSlug: getCompositeSlug(creationSource, exampleSlug),
+    },
   };
 };
 
@@ -105,13 +118,12 @@ export const createNewProjectFromTutorialTemplate = (
   tutorialTemplateUrl: string,
   tutorialId: string
 ): NewProjectSource => {
-  sendNewGameCreated({
+  const newProjectSource = getNewProjectSourceFromUrl(tutorialTemplateUrl, {
     exampleUrl: tutorialTemplateUrl,
     exampleSlug: tutorialId,
     creationSource: 'in-app-tutorial',
     exampleCompositeSlug: getCompositeSlug('in-app-tutorial', tutorialId),
   });
-  const newProjectSource = getNewProjectSourceFromUrl(tutorialTemplateUrl);
   newProjectSource.templateSlug = tutorialId;
   return newProjectSource;
 };
@@ -120,13 +132,12 @@ export const createNewProjectFromCourseChapterTemplate = (
   templateUrl: string,
   courseChapterId: string
 ): NewProjectSource => {
-  sendNewGameCreated({
+  const newProjectSource = getNewProjectSourceFromUrl(templateUrl, {
     exampleUrl: templateUrl,
     exampleSlug: courseChapterId,
     creationSource: 'course-chapter',
     exampleCompositeSlug: getCompositeSlug('course-chapter', courseChapterId),
   });
-  const newProjectSource = getNewProjectSourceFromUrl(templateUrl);
   newProjectSource.templateSlug = courseChapterId;
   return newProjectSource;
 };
@@ -135,13 +146,12 @@ export const createNewProjectFromPrivateGameTemplate = (
   privateGameTemplateUrl: string,
   privateGameTemplateTag: string
 ): NewProjectSource => {
-  sendNewGameCreated({
+  const newProjectSource = getNewProjectSourceFromUrl(privateGameTemplateUrl, {
     exampleUrl: privateGameTemplateUrl,
     exampleSlug: privateGameTemplateTag,
     creationSource: 'default',
     exampleCompositeSlug: getCompositeSlug('default', privateGameTemplateTag),
   });
-  const newProjectSource = getNewProjectSourceFromUrl(privateGameTemplateUrl);
   newProjectSource.templateSlug = privateGameTemplateTag;
   return newProjectSource;
 };
@@ -157,16 +167,18 @@ export const createNewProjectFromExampleShortHeader = async ({
     );
     const creationSource = newProjectSetup.creationSource;
 
-    sendNewGameCreated({
-      exampleUrl: example.projectFileUrl,
-      exampleSlug: exampleShortHeader.slug,
-      exampleCompositeSlug: getCompositeSlug(
+    const newProjectSource = getNewProjectSourceFromUrl(
+      example.projectFileUrl,
+      {
+        exampleUrl: example.projectFileUrl,
+        exampleSlug: exampleShortHeader.slug,
+        exampleCompositeSlug: getCompositeSlug(
+          creationSource,
+          exampleShortHeader.slug
+        ),
         creationSource,
-        exampleShortHeader.slug
-      ),
-      creationSource,
-    });
-    const newProjectSource = getNewProjectSourceFromUrl(example.projectFileUrl);
+      }
+    );
     newProjectSource.templateSlug = exampleShortHeader.slug;
     return newProjectSource;
   } catch (error) {

--- a/newIDE/app/src/Utils/Analytics/EventSender.js
+++ b/newIDE/app/src/Utils/Analytics/EventSender.js
@@ -321,11 +321,13 @@ export const sendNewGameCreated = ({
   exampleSlug,
   exampleCompositeSlug,
   creationSource,
+  projectUuid,
 }: {|
   exampleUrl: string,
   exampleSlug: string,
   exampleCompositeSlug: string,
   creationSource: NewProjectCreationSource,
+  projectUuid: string,
 |}) => {
   recordEvent('new_game_creation', {
     platform: 'GDevelop JS Platform', // Hardcoded here for now
@@ -333,7 +335,19 @@ export const sendNewGameCreated = ({
     exampleSlug,
     exampleCompositeSlug,
     creationSource,
+    projectUuid,
   });
+};
+
+export const sendProjectOpened = (metadata: {|
+  projectUuid: string,
+  storageProviderName: string,
+  // Milliseconds since the project file was last modified, if known. Lets analytics
+  // distinguish "came back after a long time" from "reopened right away". Null when
+  // the storage provider does not expose a last-modified date.
+  timeSinceLastModified: number | null,
+|}) => {
+  recordEvent('project-opened', metadata);
 };
 
 export const sendTutorialOpened = (tutorialName: string) => {
@@ -681,6 +695,7 @@ const canSendPreviewStartedForQuickCustomization = makeCanSendEvent({
 });
 
 export const sendPreviewStarted = (metadata: {|
+  projectUuid: string,
   quickCustomizationGameId: string | null,
   networkPreview: boolean,
   numberOfWindows: number,

--- a/newIDE/app/src/Utils/UseCreateProject.js
+++ b/newIDE/app/src/Utils/UseCreateProject.js
@@ -13,6 +13,8 @@ import {
   type NewProjectSetup,
   type ExampleProjectSetup,
 } from '../ProjectCreation/NewProjectSetupDialog';
+import { sendNewGameCreated } from './Analytics/EventSender';
+import { type MessageDescriptor } from './i18n/MessageDescriptor.flow';
 import { type State } from '../MainFrame/MainFrameState';
 import {
   type StorageProvider,
@@ -65,7 +67,14 @@ type Props = {|
     project: gdProject,
     fileMetadata: ?FileMetadata
   ) => Promise<State>,
-  openFromFileMetadata: (fileMetadata: FileMetadata) => Promise<?State>,
+  openFromFileMetadata: (
+    fileMetadata: FileMetadata,
+    options?: {|
+      openingMessage?: ?MessageDescriptor,
+      ignoreAutoSave?: boolean,
+      doNotTrackAsProjectOpened?: boolean,
+    |}
+  ) => Promise<?State>,
   onProjectSaved: (fileMetadata: ?FileMetadata) => void,
   ensureResourcesAreMoved: (
     options: MoveAllProjectResourcesOptionsWithoutProgress
@@ -169,7 +178,12 @@ const useCreateProject = ({
         if (newProjectSource.project) {
           state = await loadFromProject(newProjectSource.project, null);
         } else if (newProjectSource.fileMetadata && sourceStorageProvider) {
-          state = await openFromFileMetadata(newProjectSource.fileMetadata);
+          state = await openFromFileMetadata(newProjectSource.fileMetadata, {
+            // This "open" is only loading the template/example that this new
+            // project is based on - it must not be reported as the user
+            // re-opening an existing project.
+            doNotTrackAsProjectOpened: true,
+          });
         }
 
         if (!state) {
@@ -185,6 +199,15 @@ const useCreateProject = ({
 
         const oldProjectId = currentProject.getProjectUuid();
         initialiseProjectProperties(currentProject, newProjectSetup);
+
+        // Now that the project has its final UUID (assigned by
+        // initialiseProjectProperties), report its creation along with that UUID,
+        // so the new game can be tied to its later "project-opened" events.
+        sendNewGameCreated({
+          ...newProjectSource.analyticsMetadata,
+          projectUuid: currentProject.getProjectUuid(),
+        });
+
         if (newProjectSource.templateSlug) {
           currentProject.setTemplateSlug(newProjectSource.templateSlug);
         }


### PR DESCRIPTION
Changes to understand progress signs in an existent project (commitment/progress) to answer "can we tell if a user returns to the same project?"

- A new project-opened event holding projectUuid, storageProviderName, and timeSinceLastModified (so we can distinguish "came back after a long time" vs. "reopened immediately"). -> Also the idea is that  "create-a-project-from-template" doesn't count as reopen...
- Attaching projectUuid to existing events (preview-started and new_game_creation) so we can see this activity by project.
- new_game_creation would signal "project inception"
- project-opened would track project return