### PR TITLE
Fix inputs right click on Windows (Comments, Groups, JS Blocks...)

### DIFF
--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -210,9 +210,14 @@ const EventContainer = (props: EventsContainerProps) => {
       // native text editing context menu (cut/copy/paste) be shown instead of
       // the event context menu. Otherwise both would open at the same time,
       // which makes the menu flicker and disappear on Windows.
-      const { target } = domEvent;
+      // `closest` is duck-typed rather than gated on `instanceof Element`: when
+      // the events sheet is rendered in a popped-out window, the target comes
+      // from that window's realm and would fail an `instanceof` check against
+      // the main window's `Element`.
+      const target: any = domEvent.target;
       if (
-        target instanceof Element &&
+        target &&
+        typeof target.closest === 'function' &&
         target.closest('textarea, input, [contenteditable="true"]')
       ) {
         return;

--- a/newIDE/app/src/EventsSheet/EventsTree/index.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/index.js
@@ -205,6 +205,18 @@ const EventContainer = (props: EventsContainerProps) => {
 
   const _onEventContextMenu = React.useCallback(
     (domEvent: MouseEvent) => {
+      // When right-clicking inside an editable text field (for example when
+      // editing a Comment, a Group name or some JavaScript code), let the
+      // native text editing context menu (cut/copy/paste) be shown instead of
+      // the event context menu. Otherwise both would open at the same time,
+      // which makes the menu flicker and disappear on Windows.
+      const { target } = domEvent;
+      if (
+        target instanceof Element &&
+        target.closest('textarea, input, [contenteditable="true"]')
+      ) {
+        return;
+      }
       domEvent.preventDefault();
       onEventContextMenu(domEvent.clientX, domEvent.clientY);
     },


### PR DESCRIPTION
See https://forum.gdevelop.io/t/right-click-menu-not-working-for-comments-and-group-names/77337