### PR TITLE
Screen size fit on mobile device

### DIFF
--- a/GDJS/Runtime/Cordova/www/index.html
+++ b/GDJS/Runtime/Cordova/www/index.html
@@ -3,7 +3,7 @@
 <head>
 	<title></title>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=0" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=0, viewport-fit=cover" />
 	<style type="text/css">
 		/* Prevent copy paste for all elements except text fields */
 		*  { -webkit-user-select:none; -webkit-tap-highlight-color:rgba(255, 255, 255, 0); }


### PR DESCRIPTION
cf https://forum.gdevelop.io/t/ios-android-export-issues/77342

Before:

<img width="719" height="412" alt="Capture d’écran 2026-06-26 à 14 50 59" src="https://github.com/user-attachments/assets/32009391-3dd7-4d39-a548-5246a4e0de2c" />


After;

<img width="781" height="455" alt="Capture d’écran 2026-06-26 à 14 49 13" src="https://github.com/user-attachments/assets/11da9a52-9af7-4825-84e5-2463aea5bd79" />
