### PR TITLE
Save scroll position of object group and layer properties panels

### DIFF
--- a/newIDE/app/src/LayersList/CompactLayerPropertiesEditor/index.js
+++ b/newIDE/app/src/LayersList/CompactLayerPropertiesEditor/index.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { type UnsavedChanges } from '../../MainFrame/UnsavedChangesContext';
 import { type ProjectScopedContainersAccessor } from '../../InstructionOrExpression/EventsScope';
 import ErrorBoundary from '../../UI/ErrorBoundary';
-import ScrollView from '../../UI/ScrollView';
+import ScrollView, { type ScrollViewInterface } from '../../UI/ScrollView';
 import { Column, marginsSize } from '../../UI/Grid';
 import CompactPropertiesEditor from '../../CompactPropertiesEditor';
 import Text from '../../UI/Text';
@@ -22,6 +22,7 @@ import { makeSchema } from './CompactLayerPropertiesSchema';
 import { type Schema } from '../../PropertiesEditor/PropertiesEditorSchema';
 import { CompactEffectsListEditor } from './CompactEffectsListEditor';
 import { useForceRecompute } from '../../Utils/UseForceUpdate';
+import { usePersistedScrollPosition } from '../../Utils/UsePersistedScrollPosition';
 import { TopLevelCollapsibleSection } from '../../ObjectEditor/CompactObjectPropertiesEditor';
 
 export const styles = {
@@ -89,6 +90,21 @@ export const CompactLayerPropertiesEditor = ({
 
   const [schemaRecomputeTrigger, forceRecomputeSchema] = useForceRecompute();
 
+  const scrollViewRef = React.useRef<?ScrollViewInterface>(null);
+  const scrollKey = 'layer-' + layer.ptr;
+
+  // Layers have no persistent UUID, so the name is used (like for scenes).
+  // The base layer has an empty name, so a placeholder is used instead.
+  const persistedScrollId = layer.getName() || 'base-layer';
+
+  const onScroll = usePersistedScrollPosition({
+    project,
+    scrollViewRef,
+    scrollKey,
+    persistedScrollId,
+    persistedScrollType: 'layer',
+  });
+
   const layerPropertiesSchema = React.useMemo<Schema>(
     () => {
       if (schemaRecomputeTrigger) {
@@ -114,7 +130,13 @@ export const CompactLayerPropertiesEditor = ({
       componentTitle={<Trans>Layer properties</Trans>}
       scope="scene-editor-layer-properties"
     >
-      <ScrollView autoHideScrollbar style={styles.scrollView} key={layer.ptr}>
+      <ScrollView
+        ref={scrollViewRef}
+        autoHideScrollbar
+        style={styles.scrollView}
+        key={scrollKey}
+        onScroll={onScroll}
+      >
         <Column expand noMargin id="layer-properties-editor" noOverflowParent>
           <ColumnStackLayout expand noOverflowParent>
             <LineStackLayout

--- a/newIDE/app/src/ObjectGroupEditor/CompactObjectGroupPropertiesEditor.js
+++ b/newIDE/app/src/ObjectGroupEditor/CompactObjectGroupPropertiesEditor.js
@@ -144,11 +144,16 @@ export const CompactObjectGroupPropertiesEditor = ({
 
   const scrollViewRef = React.useRef<?ScrollViewInterface>(null);
   const scrollKey = '' + objectGroup.ptr;
+
+  // Object groups have no persistent UUID, so the name is used
+  // (like for scenes).
+  const persistedScrollId = objectGroup.getName();
+
   const onScroll = usePersistedScrollPosition({
     project,
     scrollViewRef,
     scrollKey,
-    persistedScrollId: null,
+    persistedScrollId,
     persistedScrollType: 'objectGroup',
   });
 

--- a/newIDE/app/src/Utils/UsePersistedScrollPosition.js
+++ b/newIDE/app/src/Utils/UsePersistedScrollPosition.js
@@ -11,7 +11,8 @@ type Props = {|
     | 'instances-of-object'
     | 'object'
     | 'scene'
-    | 'objectGroup',
+    | 'objectGroup'
+    | 'layer',
   persistedScrollId: string | null,
   saveDebounceTimeInMs?: number,
 |};


### PR DESCRIPTION
The properties panel already persisted its scroll position for instances, objects and scene properties. The object group panel had the hook wired but with a null id (making it a no-op), and the layer panel did not use it at all. Use the group/layer name as the persisted id, like it's done for scenes, with a placeholder for the base layer whose name is empty.