### PR TITLE
Improve AI tool error messages and input validation

### DIFF
--- a/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/BaseObjectExtension.cpp
@@ -1498,7 +1498,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddExpression("Distance",
                     _("Distance between two objects"),
-                    _("Distance between two objects"),
+                    _("Distance between two objects, on the X/Y plane only (Z "
+                      "is ignored)"),
                     _("Position"),
                     "res/conditions/distance.png")
       .AddParameter("object", _("Object"))
@@ -1506,7 +1507,8 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
 
   obj.AddExpression("SqDistance",
                     _("Square distance between two objects"),
-                    _("Square distance between two objects"),
+                    _("Square distance between two objects, on the X/Y plane "
+                      "only (Z is ignored)"),
                     _("Position"),
                     "res/conditions/distance.png")
       .AddParameter("object", _("Object"))
@@ -1851,6 +1853,10 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsBaseObjectExtension(
       .AddParameter("objectList", _("Object 2"))
       .AddParameter("expression", _("Distance"))
       .AddCodeOnlyParameter("conditionInverted", "")
+      .SetHint(
+          "The distance is measured on the X/Y plane only: Z is ignored. For "
+          "3D games, also compare the Z difference between the objects, or "
+          "compute the full 3D distance in an expression.")
       .MarkAsSimple();
 
   extension

--- a/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/CameraExtension.cpp
@@ -429,6 +429,11 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsCameraExtension(
       .SetDefaultValue("\"\"")
       .AddParameter("expression", _("Camera number (default : 0)"), "", true)
       .SetDefaultValue("0")
+      .SetHint(
+          "This only centers the 2D camera on the X/Y axes: it does not set "
+          "the camera Z position nor a 3D viewing angle. For 3D games, use "
+          "the 3D camera actions or a camera behavior (third person camera, "
+          "first person camera...).")
       .MarkAsSimple();
 
   // Compatibility with GD <= 5.6.251

--- a/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
+++ b/Core/GDCore/Extensions/Builtin/SpriteExtension/SpriteExtension.cpp
@@ -485,7 +485,13 @@ void GD_CORE_API BuiltinExtensionsImplementer::ImplementsSpriteExtension(
                 "res/actions/color.png")
 
       .AddParameter("object", _("Object"), "Sprite")
-      .AddParameter("color", _("Tint"));
+      .AddParameter("color", _("Tint"))
+      .SetHint(
+          "The tint is multiplicative on the image pixels (white restores the "
+          "original colors): it can only darken or shift existing colors, and "
+          "cannot turn a non-white sprite into an arbitrary solid color. For a "
+          "solid color, use a white image, another animation/image or an "
+          "effect.");
 
   obj.AddAction("ChangeBlendMode",
                 _("Blend mode"),

--- a/newIDE/app/src/EditorFunctions/EditorFunctions.spec.js
+++ b/newIDE/app/src/EditorFunctions/EditorFunctions.spec.js
@@ -982,6 +982,28 @@ describe('editorFunctions', () => {
       expect(properties.get('shadowAngle').getValue()).toBe('20');
     });
 
+    it('lists the available properties only once when several properties are not found', async () => {
+      const result: EditorFunctionGenericOutput = await editorFunctions.change_object_property.launchFunction(
+        {
+          ...makeFakeLaunchFunctionOptionsWithProject(project),
+          args: {
+            scene_name: 'TestScene',
+            object_name: 'MyTextObject',
+            changed_properties: [
+              { property_name: 'fontSize', new_value: '56' },
+              { property_name: 'scaleX', new_value: '2' },
+              { property_name: 'wrongProperty', new_value: '3' },
+            ],
+          },
+        }
+      );
+
+      expect(result.success).toBe(false);
+      expect(
+        (result.message || '').split('Available properties:').length - 1
+      ).toBe(1);
+    });
+
     it('reports the FINAL renamed name when a collision forces a suffix', async () => {
       // The scene already has another object named "Foo": renaming
       // MyTextObject -> Foo must collide and end up as "Foo2".
@@ -2986,9 +3008,6 @@ describe('editorFunctions', () => {
       });
     });
 
-    // The 3D line brush used to silently skip positioning when
-    // brush_end_position was missing, leaving every instance at (0,0,0)
-    // (the 2D variant already had this guard).
     it('fails without creating instances when the line brush lacks brush_end_position', async () => {
       const result = await editorFunctions.put_3d_instances.launchFunction({
         ...makeFakeLaunchFunctionOptionsWithProject(project),

--- a/newIDE/app/src/EditorFunctions/EditorFunctions.spec.js
+++ b/newIDE/app/src/EditorFunctions/EditorFunctions.spec.js
@@ -966,7 +966,7 @@ describe('editorFunctions', () => {
         Set \\"shadowBlurRadius\\" on \\"MyTextObject\\" = \\"20.41\\".
         Warnings:
         Could not set \\"textAlignment\\" on \\"MyTextObject\\": invalid value or type.
-        Property \\"nonExistingProperty\\" not found on object \\"MyTextObject\\".
+        Property \\"nonExistingProperty\\" not found on object \\"MyTextObject\\". Available properties: bold, characterSize, color, font, isOutlineEnabled, isShadowEnabled, italic, lineHeight, outlineColor, outlineThickness, shadowAngle, shadowBlurRadius, shadowColor, shadowDistance, shadowOpacity, text, textAlignment, verticalTextAlignment.
         \\"shadowAngle\\" on \\"MyTextObject\\" = \\"20\\", but requested \\"20,40 , 50\\" looks multi-dimensional; only a single number is allowed.
         \\"shadowDistance\\" on \\"MyTextObject\\" = \\"0\\", but requested \\"20X   40 X 50\\" looks multi-dimensional; only a single number is allowed.
         \\"shadowBlurRadius\\" on \\"MyTextObject\\" = \\"20.41\\", but requested \\"20.41 × 50\\" looks multi-dimensional; only a single number is allowed."
@@ -1443,7 +1443,7 @@ describe('editorFunctions', () => {
         Set \\"IgnoreDefaultControls\\" on behavior \\"PlatformerObject\\" = \\"false\\".
         Warnings:
         \\"MaxSpeed\\" on behavior \\"PlatformerObject\\" = \\"300\\", but requested \\"300 x 20\\" looks multi-dimensional; only a single number is allowed.
-        Property \\"nonExistingProperty\\" not on behavior \\"PlatformerObject\\" of \\"MySprite\\"."
+        Property \\"nonExistingProperty\\" not on behavior \\"PlatformerObject\\" of \\"MySprite\\". Available properties: Acceleration, CanGoDownFromJumpthru, CanGrabPlatforms, CanGrabWithoutMoving, Deceleration, Gravity, IgnoreDefaultControls, JumpSpeed, JumpSustainTime, LadderClimbingSpeed, MaxFallingSpeed, MaxSpeed, SlopeMaxAngle, XGrabTolerance, YGrabOffset."
       `);
 
       // Verify the behavior properties were actually changed
@@ -2252,7 +2252,7 @@ describe('editorFunctions', () => {
       expect(result.success).toBe(true);
       expect(result.message).toEqual(
         expect.stringContaining(
-          'Created 1 new instance of object "Player" using point brush at 100, 200 on layer "base".'
+          'Created 1 new instance of object "Player" using point brush at 100, 200 on the base layer ("").'
         )
       );
     });
@@ -2277,7 +2277,7 @@ describe('editorFunctions', () => {
       expect(result.success).toBe(true);
       expect(result.message).toEqual(
         expect.stringContaining(
-          'Created 2 new instances of object "Player" using point brush at 50, 60 on layer "base" (size 64x64, rotation 45°, opacity 128/255, z-order 5, origin at this position, each occupies X 50 to 114, Y 60 to 124).'
+          'Created 2 new instances of object "Player" using point brush at 50, 60 on the base layer ("") (size 64x64, rotation 45°, opacity 128/255, z-order 5, origin at this position, each occupies X 50 to 114, Y 60 to 124).'
         )
       );
     });
@@ -2452,18 +2452,65 @@ describe('editorFunctions', () => {
       expect(uniqueKeys.size).toBe(positions.length);
     });
 
-    it('falls back to the scene center when no brush_position is given', async () => {
-      await putInstances({
-        brush_kind: 'point',
-        new_instances_count: 1,
+    // Creating instances without an explicit brush_position used to silently
+    // fall back to the scene center — a major source of instances duplicated
+    // or dropped at a meaningless position by the AI. It must fail instead.
+    it('fails when creating instances without a brush_position', async () => {
+      const result = await editorFunctions.put_2d_instances.launchFunction({
+        ...makeFakeLaunchFunctionOptionsWithProject(project),
+        args: {
+          scene_name: 'TestScene',
+          object_name: 'Player',
+          layer_name: '',
+          brush_kind: 'point',
+          new_instances_count: 1,
+        },
       });
 
-      expect(getInstancePositions(testScene)).toEqual([
-        {
-          x: project.getGameResolutionWidth() / 2,
-          y: project.getGameResolutionHeight() / 2,
+      expect(result.success).toBe(false);
+      expect(result.message).toEqual(
+        expect.stringContaining('`brush_position` is required')
+      );
+      expect(getInstancePositions(testScene)).toEqual([]);
+    });
+
+    // The most frequent malformed call seen in production: a "modification"
+    // call that forgot `existing_instance_ids` (and gave no position). It used
+    // to create a duplicate instance at the scene center; it must fail.
+    it('fails instead of creating a default instance when neither existing_instance_ids nor brush_position are given', async () => {
+      const result = await editorFunctions.put_2d_instances.launchFunction({
+        ...makeFakeLaunchFunctionOptionsWithProject(project),
+        args: {
+          scene_name: 'TestScene',
+          object_name: 'Player',
+          layer_name: '',
+          brush_kind: 'none',
+          instances_opacity: 0,
         },
-      ]);
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toEqual(
+        expect.stringContaining('existing_instance_ids')
+      );
+      expect(getInstancePositions(testScene)).toEqual([]);
+    });
+
+    // The base layer's real name is "": accept the frequent "base" mistake
+    // (when no layer literally named "base" exists) instead of failing.
+    it('accepts "base" as the base layer name when no such layer exists', async () => {
+      const result = await putInstances({
+        brush_kind: 'point',
+        brush_position: '100,200',
+        new_instances_count: 1,
+        layer_name: 'base',
+      });
+
+      const [created] = getInstances(testScene);
+      expect(created.layer).toBe('');
+      expect(result.message).toEqual(
+        expect.stringContaining('the base layer ("")')
+      );
     });
 
     it('scatters instances within the radius for the random_in_circle brush', async () => {
@@ -2668,6 +2715,35 @@ describe('editorFunctions', () => {
       expect(getInstancePositions(testScene)).toEqual([]);
     });
 
+    // An erase that removed nothing used to report "Erased 0 instances." as a
+    // success, which the AI took as a confirmation the instances were gone.
+    it('fails when the erase brush matches nothing', async () => {
+      await putInstances({
+        brush_kind: 'point',
+        brush_position: '100,200',
+        new_instances_count: 1,
+      });
+
+      const result = await editorFunctions.put_2d_instances.launchFunction({
+        ...makeFakeLaunchFunctionOptionsWithProject(project),
+        args: {
+          scene_name: 'TestScene',
+          object_name: 'Player',
+          layer_name: '',
+          brush_kind: 'erase',
+          brush_position: '900,900',
+          brush_size: 10,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toEqual(
+        expect.stringContaining('No instance was erased.')
+      );
+      // The existing instance is untouched.
+      expect(getInstancePositions(testScene)).toEqual([{ x: 100, y: 200 }]);
+    });
+
     it('fails when erasing an unknown instance id (none found, nothing changed)', async () => {
       // Bypass the `putInstances` helper, which asserts success — here we
       // expect a failure so the agent gets a real error signal instead of a
@@ -2772,7 +2848,7 @@ describe('editorFunctions', () => {
       expect(result.success).toBe(true);
       expect(result.message).toEqual(
         expect.stringContaining(
-          'Created 1 new instance of object "Player" using point brush at 10, 20, 30 on layer "base" (size 8x16x24, rotation (15°, 30°, 45°), origin at this position, each occupies X 10 to 18, Y 20 to 36, Z 30 to 54).'
+          'Created 1 new instance of object "Player" using point brush at 10, 20, 30 on the base layer ("") (size 8x16x24, rotation (15°, 30°, 45°), origin at this position, each occupies X 10 to 18, Y 20 to 36, Z 30 to 54).'
         )
       );
     });
@@ -2908,6 +2984,50 @@ describe('editorFunctions', () => {
       positions.forEach(({ x, y, z }) => {
         expect(Math.sqrt(x * x + y * y + z * z)).toBeLessThanOrEqual(radius);
       });
+    });
+
+    // The 3D line brush used to silently skip positioning when
+    // brush_end_position was missing, leaving every instance at (0,0,0)
+    // (the 2D variant already had this guard).
+    it('fails without creating instances when the line brush lacks brush_end_position', async () => {
+      const result = await editorFunctions.put_3d_instances.launchFunction({
+        ...makeFakeLaunchFunctionOptionsWithProject(project),
+        args: {
+          scene_name: 'TestScene',
+          object_name: 'Player',
+          layer_name: '',
+          brush_kind: 'line',
+          brush_position: '10,20,30',
+          new_instances_count: 3,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toEqual(
+        expect.stringContaining('requires brush_end_position')
+      );
+      expect(getInstancePositions(testScene)).toEqual([]);
+    });
+
+    // Creating instances without an explicit brush_position used to silently
+    // fall back to the scene center: it must fail instead.
+    it('fails when creating instances without a brush_position', async () => {
+      const result = await editorFunctions.put_3d_instances.launchFunction({
+        ...makeFakeLaunchFunctionOptionsWithProject(project),
+        args: {
+          scene_name: 'TestScene',
+          object_name: 'Player',
+          layer_name: '',
+          brush_kind: 'point',
+          new_instances_count: 1,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toEqual(
+        expect.stringContaining('`brush_position` is required')
+      );
+      expect(getInstancePositions(testScene)).toEqual([]);
     });
 
     it('fails when no requested instance id is found and nothing is created', async () => {

--- a/newIDE/app/src/EditorFunctions/index.js
+++ b/newIDE/app/src/EditorFunctions/index.js
@@ -509,9 +509,16 @@ const serializeNamedProperty = (
 
 // List the (visible) property names so a "property not found" warning lets
 // the caller immediately pick the right name instead of guessing again.
+// Emitted at most once per call: if a previous warning already lists the
+// properties (e.g. several unknown properties in the same call), returns "".
 const getAvailablePropertyNamesText = (
-  properties: gdMapStringPropertyDescriptor | null
+  properties: gdMapStringPropertyDescriptor | null,
+  existingWarnings: Array<string>
 ): string => {
+  if (
+    existingWarnings.some(warning => warning.includes('Available properties:'))
+  )
+    return '';
   if (!properties) return '';
   const names = properties
     .keys()
@@ -1584,7 +1591,8 @@ const applyObjectPropertyChange = ({
     }
     warnings.push(
       `Property "${propertyName}" not found on object "${object_name}".${getAvailablePropertyNamesText(
-        objectProperties
+        objectProperties,
+        warnings
       )}`
     );
     return;
@@ -2898,7 +2906,8 @@ const changeBehaviorProperty: EditorFunction = {
       } else {
         warnings.push(
           `Property "${propertyName}" not on behavior "${behavior_name}" of "${object_name}".${getAvailablePropertyNamesText(
-            behaviorProperties
+            behaviorProperties,
+            warnings
           )}`
         );
       }

--- a/newIDE/app/src/EditorFunctions/index.js
+++ b/newIDE/app/src/EditorFunctions/index.js
@@ -445,6 +445,11 @@ const makeGenericSuccess = (message: string): EditorFunctionGenericOutput => ({
   message,
 });
 
+// The base layer's real name is the empty string: never display it as "base"
+// in tool results, as this teaches the AI a layer name that does not exist.
+const getLayerNameForMessage = (layerName: string): string =>
+  layerName === '' ? 'the base layer ("")' : `layer "${layerName}"`;
+
 const makeMultipleChangesOutput = (
   changes: Array<string>,
   warnings: Array<string>
@@ -500,6 +505,23 @@ const serializeNamedProperty = (
     quickCustomizationVisibility: undefined,
     advanced: undefined,
   };
+};
+
+// List the (visible) property names so a "property not found" warning lets
+// the caller immediately pick the right name instead of guessing again.
+const getAvailablePropertyNamesText = (
+  properties: gdMapStringPropertyDescriptor | null
+): string => {
+  if (!properties) return '';
+  const names = properties
+    .keys()
+    .toJSArray()
+    .filter(name => !shouldHideProperty(properties.get(name)));
+  if (names.length === 0) return '';
+  const maxCount = 25;
+  return ` Available properties: ${names.slice(0, maxCount).join(', ')}${
+    names.length > maxCount ? `, … (${names.length - maxCount} more)` : ''
+  }.`;
 };
 
 const findPropertyByName = ({
@@ -1561,19 +1583,53 @@ const applyObjectPropertyChange = ({
       return;
     }
     warnings.push(
-      `Property "${propertyName}" not found on object "${object_name}".`
+      `Property "${propertyName}" not found on object "${object_name}".${getAvailablePropertyNamesText(
+        objectProperties
+      )}`
     );
     return;
   }
 
-  const sanitizedNewValue = sanitizePropertyNewValue(foundProperty, newValue);
+  let sanitizedNewValue = sanitizePropertyNewValue(foundProperty, newValue);
 
   if (foundProperty.getType() === 'resource') {
     if (!project.getResourcesManager().hasResource(sanitizedNewValue)) {
-      warnings.push(
-        `"${foundPropertyName}" on "${object_name}" -> "${newValue}": resource "${sanitizedNewValue}" does not exist. New resources cannot be added just by name; use \`create_or_replace_object\` to import assets from the asset store (preserving properties/behaviors/events).`
+      // Resource names can contain backslashes (e.g. "assets\\Player.glb"):
+      // tolerate a name given with the wrong slashes or casing, and suggest
+      // close candidates otherwise.
+      const normalizeResourceName = (resourceName: string) =>
+        resourceName.replace(/\\/g, '/').toLowerCase();
+      const allResourceNames = project
+        .getResourcesManager()
+        .getAllResourceNames()
+        .toJSArray();
+      const normalizedNewValue = normalizeResourceName(sanitizedNewValue);
+      const matchingResourceNames = allResourceNames.filter(
+        resourceName =>
+          normalizeResourceName(resourceName) === normalizedNewValue
       );
-      return;
+      if (matchingResourceNames.length === 1) {
+        sanitizedNewValue = matchingResourceNames[0];
+      } else {
+        const requestedBaseName = normalizedNewValue.split('/').pop() || '';
+        const closeResourceNames = requestedBaseName
+          ? allResourceNames
+              .filter(resourceName =>
+                normalizeResourceName(resourceName).endsWith(requestedBaseName)
+              )
+              .slice(0, 5)
+          : [];
+        warnings.push(
+          `"${foundPropertyName}" on "${object_name}" -> "${newValue}": resource "${sanitizedNewValue}" does not exist.${
+            closeResourceNames.length > 0
+              ? ` Did you mean: ${closeResourceNames
+                  .map(resourceName => `"${resourceName}"`)
+                  .join(', ')}?`
+              : ''
+          } New resources cannot be added just by name; use \`create_or_replace_object\` to import assets from the asset store (preserving properties/behaviors/events).`
+        );
+        return;
+      }
     }
     const resource = project
       .getResourcesManager()
@@ -1610,6 +1666,21 @@ const applyObjectPropertyChange = ({
   });
   warnings.push(...propertyWarnings);
   changes.push(...propertyChanges);
+
+  // Resizing an object that keeps its aspect ratio can visually do nothing
+  // (the rendered size is clamped to the model aspect ratio) even though the
+  // stored property changed — so `verifyPropertyChange` cannot catch it.
+  if (['width', 'height', 'depth'].includes(foundPropertyName.toLowerCase())) {
+    const keepAspectRatioValue = getPropertyValue({
+      properties: objectConfiguration.getProperties(),
+      propertyName: 'keepAspectRatio',
+    });
+    if (keepAspectRatioValue === 'true') {
+      warnings.push(
+        `"${object_name}" has "keepAspectRatio" enabled: the rendered size keeps the model's aspect ratio, so this change may have no visible effect. Set "keepAspectRatio" to false first to control each dimension exactly.`
+      );
+    }
+  }
 };
 
 /**
@@ -2826,7 +2897,9 @@ const changeBehaviorProperty: EditorFunction = {
         changes.push(...propertyChanges);
       } else {
         warnings.push(
-          `Property "${propertyName}" not on behavior "${behavior_name}" of "${object_name}".`
+          `Property "${propertyName}" not on behavior "${behavior_name}" of "${object_name}".${getAvailablePropertyNamesText(
+            behaviorProperties
+          )}`
         );
       }
     });
@@ -3148,10 +3221,19 @@ const put2dInstances: EditorFunction = {
       ? getObjectSizeInfo(namedObject, project, PixiResourcesLoader)
       : null;
 
+    // Accept the frequent mistake of calling the base layer "base" (its real
+    // name is the empty string) when no layer with that literal name exists.
+    const layerName =
+      layer_name !== '' &&
+      layer_name.trim().toLowerCase() === 'base' &&
+      !layout.hasLayerNamed(layer_name)
+        ? ''
+        : layer_name;
+
     // Check if layer exists (empty string is allowed for base layer)
-    if (layer_name !== '' && !layout.hasLayerNamed(layer_name)) {
+    if (layerName !== '' && !layout.hasLayerNamed(layerName)) {
       return makeGenericFailure(
-        `Layer not found: ${layer_name} in scene "${scene_name}".`
+        `Layer not found: ${layerName} in scene "${scene_name}".`
       );
     }
 
@@ -3184,7 +3266,7 @@ const put2dInstances: EditorFunction = {
         if (instance.getObjectName() !== object_name) return;
 
         if (!brushPosition) return;
-        if (instance.getLayer() !== layer_name) return; // Layer must be the same as specified when deleting instances with a brush.
+        if (instance.getLayer() !== layerName) return; // Layer must be the same as specified when deleting instances with a brush.
 
         if (brushSize === 0) {
           if (
@@ -3206,20 +3288,21 @@ const put2dInstances: EditorFunction = {
         }
       });
 
-      // If specific instance ids were requested but none matched (and the brush
-      // did not select anything either), the call erased nothing. Return a
-      // failure so the agent gets a real error signal instead of a misleading
-      // success that could make it retry the same call in a loop.
-      if (
-        instancesToDelete.size === 0 &&
-        notFoundExistingInstanceIds.size > 0
-      ) {
+      // An erase call that removed nothing is a failure: return a real error
+      // signal instead of a misleading "Erased 0 instances." success that
+      // could make the agent retry the same call in a loop, or believe the
+      // instances are gone.
+      if (instancesToDelete.size === 0) {
         return makeGenericFailure(
-          `None of the specified instance ids were found: ${Array.from(
-            notFoundExistingInstanceIds
-          ).join(
-            ', '
-          )}. Nothing was changed. Call \`describe_instances\` to get valid ids (the \`id\` field of each instance), and check the scene and layer names.`
+          [
+            'No instance was erased.',
+            notFoundExistingInstanceIds.size > 0
+              ? `None of the specified instance ids were found: ${Array.from(
+                  notFoundExistingInstanceIds
+                ).join(', ')}.`
+              : 'No instance matched the brush (check `object_name`, the layer and the brush position/size).',
+            'Call `describe_instances` to get valid ids (the `id` field of each instance), and check the scene and layer names.',
+          ].join(' ')
         );
       }
 
@@ -3252,11 +3335,9 @@ const put2dInstances: EditorFunction = {
         injectObjectSizeInfo(eraseResult, { [object_name]: objectSizeInfo });
       return eraseResult;
     } else {
-      const brushPosition: [number, number] = (brush_position &&
-        SafeExtractor.parseCommaSeparatedTwoFiniteNumbers(brush_position)) || [
-        project.getGameResolutionWidth() / 2,
-        project.getGameResolutionHeight() / 2,
-      ];
+      const parsedBrushPosition = brush_position
+        ? SafeExtractor.parseCommaSeparatedTwoFiniteNumbers(brush_position)
+        : null;
       const brushSize = brush_size || 0;
       const brushEndPosition = SafeExtractor.parseCommaSeparatedTwoFiniteNumbers(
         brush_end_position
@@ -3287,6 +3368,26 @@ const put2dInstances: EditorFunction = {
         newInstancesCount =
           rowCount && columnCount ? rowCount * columnCount : 1;
       }
+
+      // As stated in the tool description, `brush_position` can only be
+      // omitted when modifying existing instances with the "none" brush. Fail
+      // instead of silently using a default position (like the scene center):
+      // a call without a position is usually a modification that forgot
+      // `existing_instance_ids`, or would drop every new instance at a
+      // meaningless position.
+      if (
+        !parsedBrushPosition &&
+        !(brush_kind === 'none' && newInstancesCount === 0)
+      ) {
+        return makeGenericFailure(
+          newInstancesCount > 0
+            ? `A valid \`brush_position\` is required to create ${newInstancesCount} new instance(s) (or pass \`existing_instance_ids\` from \`describe_instances\` if you meant to modify existing instances).`
+            : `A valid \`brush_position\` is required for the "${brush_kind}" brush (or use the "none" brush to modify existing instances without moving them).`
+        );
+      }
+      // After the guard, a missing position can only happen when nothing is
+      // created nor moved ("none" brush only): the fallback is never used.
+      const brushPosition: [number, number] = parsedBrushPosition || [0, 0];
 
       // Track changes for detailed success message
       const changes = [];
@@ -3340,8 +3441,8 @@ const put2dInstances: EditorFunction = {
 
           modifiedAndCreatedInstances.push(instance);
           // Take the opportunity to move to a new layer if specified.
-          if (instance.getLayer() !== layer_name) {
-            instance.setLayer(layer_name);
+          if (instance.getLayer() !== layerName) {
+            instance.setLayer(layerName);
           }
         }
       });
@@ -3349,7 +3450,7 @@ const put2dInstances: EditorFunction = {
       for (let i = 0; i < newInstancesCount; i++) {
         const instance = initialInstances.insertNewInitialInstance();
         instance.setObjectName(object_name || '');
-        instance.setLayer(layer_name);
+        instance.setLayer(layerName);
         modifiedAndCreatedInstances.push(instance);
       }
 
@@ -3522,7 +3623,7 @@ const put2dInstances: EditorFunction = {
           } of object "${object_name ||
             ''}" using ${brush_kind} brush at ${brushPosition.join(
             ', '
-          )} on layer "${layer_name || 'base'}"${
+          )} on ${getLayerNameForMessage(layerName)}${
             attrs.length > 0 ? ` (${attrs.join(', ')})` : ''
           }.`
         );
@@ -3577,7 +3678,7 @@ const put2dInstances: EditorFunction = {
         changes.push(
           `Moved ${movedToLayerCount} instance${
             movedToLayerCount > 1 ? 's' : ''
-          } to layer "${layer_name || 'base'}".`
+          } to ${getLayerNameForMessage(layerName)}.`
         );
       }
 
@@ -3851,10 +3952,19 @@ const put3dInstances: EditorFunction = {
       ? getObjectSizeInfo(namedObject, project, PixiResourcesLoader)
       : null;
 
+    // Accept the frequent mistake of calling the base layer "base" (its real
+    // name is the empty string) when no layer with that literal name exists.
+    const layerName =
+      layer_name !== '' &&
+      layer_name.trim().toLowerCase() === 'base' &&
+      !layout.hasLayerNamed(layer_name)
+        ? ''
+        : layer_name;
+
     // Check if layer exists (empty string is allowed for base layer)
-    if (layer_name !== '' && !layout.hasLayerNamed(layer_name)) {
+    if (layerName !== '' && !layout.hasLayerNamed(layerName)) {
       return makeGenericFailure(
-        `Layer not found: ${layer_name} in scene "${scene_name}".`
+        `Layer not found: ${layerName} in scene "${scene_name}".`
       );
     }
 
@@ -3887,7 +3997,7 @@ const put3dInstances: EditorFunction = {
         if (instance.getObjectName() !== object_name) return;
 
         if (!brushPosition) return;
-        if (instance.getLayer() !== layer_name) return; // Layer must be the same as specified when deleting instances with a brush.
+        if (instance.getLayer() !== layerName) return; // Layer must be the same as specified when deleting instances with a brush.
 
         if (brushSize <= 0) {
           if (
@@ -3911,20 +4021,21 @@ const put3dInstances: EditorFunction = {
         }
       });
 
-      // If specific instance ids were requested but none matched (and the brush
-      // did not select anything either), the call erased nothing. Return a
-      // failure so the agent gets a real error signal instead of a misleading
-      // success that could make it retry the same call in a loop.
-      if (
-        instancesToDelete.size === 0 &&
-        notFoundExistingInstanceIds.size > 0
-      ) {
+      // An erase call that removed nothing is a failure: return a real error
+      // signal instead of a misleading "Erased 0 instances." success that
+      // could make the agent retry the same call in a loop, or believe the
+      // instances are gone.
+      if (instancesToDelete.size === 0) {
         return makeGenericFailure(
-          `None of the specified instance ids were found: ${Array.from(
-            notFoundExistingInstanceIds
-          ).join(
-            ', '
-          )}. Nothing was changed. Call \`describe_instances\` to get valid ids (the \`id\` field of each instance), and check the scene and layer names.`
+          [
+            'No instance was erased.',
+            notFoundExistingInstanceIds.size > 0
+              ? `None of the specified instance ids were found: ${Array.from(
+                  notFoundExistingInstanceIds
+                ).join(', ')}.`
+              : 'No instance matched the brush (check `object_name`, the layer and the brush position/size).',
+            'Call `describe_instances` to get valid ids (the `id` field of each instance), and check the scene and layer names.',
+          ].join(' ')
         );
       }
 
@@ -3957,24 +4068,52 @@ const put3dInstances: EditorFunction = {
         injectObjectSizeInfo(eraseResult, { [object_name]: objectSizeInfo });
       return eraseResult;
     } else {
-      const brushPosition: [number, number, number] = (brush_position &&
-        SafeExtractor.parseCommaSeparatedThreeFiniteNumbers(
-          brush_position
-        )) || [
-        project.getGameResolutionWidth() / 2,
-        project.getGameResolutionHeight() / 2,
-        0,
-      ];
+      const parsedBrushPosition = brush_position
+        ? SafeExtractor.parseCommaSeparatedThreeFiniteNumbers(brush_position)
+        : null;
       const brushSize = brush_size || 0;
       const brushEndPosition = SafeExtractor.parseCommaSeparatedThreeFiniteNumbers(
         brush_end_position
       );
+
+      // The `line` brush needs an end position to spread instances. Fail early
+      // (before creating any instance) so the caller retries with a valid
+      // request, instead of silently leaving every instance at the origin.
+      if (brush_kind === 'line' && !brushEndPosition) {
+        return makeGenericFailure(
+          `The "line" brush requires brush_end_position (the end of the line). Provide it, or use the "point" brush to place instances at a single position.`
+        );
+      }
 
       let newInstancesCount =
         new_instances_count !== null ? new_instances_count : 0;
       if (newInstancesCount === 0 && existingInstanceIds.length === 0) {
         newInstancesCount = 1;
       }
+
+      // As stated in the tool description, `brush_position` can only be
+      // omitted when modifying existing instances with the "none" brush. Fail
+      // instead of silently using a default position (like the scene center):
+      // a call without a position is usually a modification that forgot
+      // `existing_instance_ids`, or would drop every new instance at a
+      // meaningless position.
+      if (
+        !parsedBrushPosition &&
+        !(brush_kind === 'none' && newInstancesCount === 0)
+      ) {
+        return makeGenericFailure(
+          newInstancesCount > 0
+            ? `A valid \`brush_position\` is required to create ${newInstancesCount} new instance(s) (or pass \`existing_instance_ids\` from \`describe_instances\` if you meant to modify existing instances).`
+            : `A valid \`brush_position\` is required for the "${brush_kind}" brush (or use the "none" brush to modify existing instances without moving them).`
+        );
+      }
+      // After the guard, a missing position can only happen when nothing is
+      // created nor moved ("none" brush only): the fallback is never used.
+      const brushPosition: [number, number, number] = parsedBrushPosition || [
+        0,
+        0,
+        0,
+      ];
 
       // Track changes for detailed success message
       const changes = [];
@@ -4031,8 +4170,8 @@ const put3dInstances: EditorFunction = {
 
           modifiedAndCreatedInstances.push(instance);
           // Take the opportunity to move to a new layer if specified.
-          if (instance.getLayer() !== layer_name) {
-            instance.setLayer(layer_name);
+          if (instance.getLayer() !== layerName) {
+            instance.setLayer(layerName);
           }
         }
       });
@@ -4040,7 +4179,7 @@ const put3dInstances: EditorFunction = {
       for (let i = 0; i < newInstancesCount; i++) {
         const instance = initialInstances.insertNewInitialInstance();
         instance.setObjectName(object_name || '');
-        instance.setLayer(layer_name);
+        instance.setLayer(layerName);
         modifiedAndCreatedInstances.push(instance);
       }
 
@@ -4176,7 +4315,7 @@ const put3dInstances: EditorFunction = {
           } of object "${object_name ||
             ''}" using ${brush_kind} brush at ${brushPosition.join(
             ', '
-          )} on layer "${layer_name || 'base'}"${
+          )} on ${getLayerNameForMessage(layerName)}${
             attrs.length > 0 ? ` (${attrs.join(', ')})` : ''
           }.`
         );
@@ -4222,7 +4361,7 @@ const put3dInstances: EditorFunction = {
         changes.push(
           `Moved ${movedToLayerCount} instance${
             movedToLayerCount > 1 ? 's' : ''
-          } to layer "${layer_name || 'base'}".`
+          } to ${getLayerNameForMessage(layerName)}.`
         );
       }
 
@@ -5689,17 +5828,25 @@ const changeScenePropertiesLayersEffectsGroups: EditorFunction = {
             scene,
           });
         } else {
+          const createdLayerName = new_layer_name || layerName;
+          // Never create a layer literally named "base": this is always a
+          // confusion with the default base layer, whose real name is "".
+          if (createdLayerName.trim().toLowerCase() === 'base') {
+            warnings.push(
+              `Layer "${createdLayerName}" was not created: the default base layer already exists and its real name is the empty string. Use "" to target it.`
+            );
+            return;
+          }
           scene
             .getLayers()
             .insertNewLayer(
-              new_layer_name || layerName,
+              createdLayerName,
               new_layer_position === null
                 ? scene.getLayersCount()
                 : new_layer_position
             );
           changes.push(
-            `Created new layer "${new_layer_name ||
-              layerName}" for scene "${scene.getName()}" at position ${new_layer_position ||
+            `Created new layer "${createdLayerName}" for scene "${scene.getName()}" at position ${new_layer_position ||
               0}.`
           );
         }


### PR DESCRIPTION
## Summary
This PR enhances error messages and input validation in editor functions to provide clearer feedback to AI agents and prevent silent failures that could lead to incorrect behavior.

## Key Changes

### Error Message Improvements
- **Property not found warnings**: Now list available properties when a property is not found on an object or behavior, helping users quickly identify the correct property name. The list is shown at most once per call to avoid redundancy.
- **Layer name display**: Introduced `getLayerNameForMessage()` helper to properly display the base layer as `the base layer ("")` instead of `"base"`, teaching the AI the correct layer name.
- **Resource name suggestions**: When a resource is not found, the tool now suggests close matches based on the requested base name, and tolerates mismatched slashes or casing in resource paths.
- **Aspect ratio warnings**: Added warning when resizing objects with `keepAspectRatio` enabled, since the visual size may not change even though the property was modified.

### Input Validation & Error Handling
- **Brush position validation**: `put_2d_instances` and `put_3d_instances` now fail with clear error messages when `brush_position` is missing in cases where it's required (creating new instances or using non-"none" brushes). Previously, these calls would silently fall back to the scene center, causing instances to be dropped at meaningless positions.
- **Base layer name handling**: Both 2D and 3D instance functions now accept "base" as a layer name when no layer literally named "base" exists, automatically converting it to the empty string (the actual base layer name).
- **Line brush validation**: `put_3d_instances` now validates that `brush_end_position` is provided when using the "line" brush, failing early before creating instances.
- **Erase operation failures**: Erase operations that match no instances now return a failure instead of a misleading "Erased 0 instances" success. The error message distinguishes between cases where specific instance IDs weren't found vs. the brush matched nothing.
- **Layer creation validation**: Prevents creating a layer literally named "base" (which would be confused with the default base layer).

### Documentation Improvements
- Updated descriptions for `Distance` and `SqDistance` expressions to clarify they operate on the X/Y plane only (Z is ignored).
- Added hints to sprite tint action explaining its multiplicative nature and limitations.
- Added hint to camera center action clarifying it only affects 2D camera positioning.

## Implementation Details
- New helper function `getAvailablePropertyNamesText()` generates property lists with a maximum of 25 items shown, with a count of remaining items if there are more.
- Resource name matching uses normalized paths (forward slashes, lowercase) to handle common mistakes while preserving the actual resource name.
- Layer name normalization logic is applied consistently in both 2D and 3D instance functions.
- Error messages are more structured and actionable, guiding users toward correct usage patterns.

https://claude.ai/code/session_01GEBw19Jbybtx1tJ1C6m2G3