### PR TITLE
Fix zsh dquote> hang when launching terminal scripts on macOS

### DIFF
--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -829,7 +829,7 @@ app.on('ready', function() {
           const escapedPath = projectPath.replace(/'/g, "'\\''");
           const shellCommand = keepOpen
             ? `cd '${escapedPath}' && ${npmCommand}`
-            : `cd '${escapedPath}' && ${npmCommand} && exit || echo "${NPM_SCRIPT_COMMAND_FAILED_MESSAGE}"`;
+            : `cd '${escapedPath}' && ${npmCommand} && exit || echo '${NPM_SCRIPT_COMMAND_FAILED_MESSAGE}'`;
           const script = `tell application "Terminal" to do script "${shellCommand.replace(
             /"/g,
             '\\"'


### PR DESCRIPTION
## Summary

When GDevelop launches an npm script in Terminal.app on macOS, the shell command
includes `echo "Command failed!"`. In zsh (the default macOS shell), the `!"`
sequence triggers bang history expansion, which consumes the closing double quote
and leaves the shell stuck at a `dquote>` prompt — hanging the terminal.

This fix switches the echo argument from double quotes to single quotes, which
suppresses all shell expansions including history expansion.

## Changes

- `newIDE/electron-app/app/main.js`: Changed `echo "..."` to `echo '...'` in the
  macOS `run-npm-script` handler to avoid zsh history expansion on `!`.