### PR TITLE
Run CLI commands in the live editor when the project is already open

### DIFF
--- a/newIDE/README.md
+++ b/newIDE/README.md
@@ -142,6 +142,10 @@ GDevelop.exe --disable-update-check --run-command IMPORT_EXTENSION_AND_SAVE path
 
 Extra flags: `--keep-open` (don't quit after command), `--dev-tools` (open DevTools).
 
+If the same project is already open in a running editor, the command runs in that
+window (fire-and-forget; the CLI exits without waiting or reporting the real result).
+Otherwise the command runs headless with a real exit code (including CI).
+
 ### Making the CLI available on PATH
 
 When GDevelop is installed with the Windows NSIS installer, the install

--- a/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
+++ b/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
@@ -17,6 +17,7 @@ import { type FileMetadata } from '../ProjectsStorage';
 const electron = optionalRequire('electron');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
 const fs = optionalRequire('fs');
+const path = optionalRequire('path');
 
 export type ImportExtension = (options: {|
   i18n: I18nType,
@@ -47,13 +48,16 @@ export type CliCommandRunner = (
   |}
 ) => Promise<void>;
 
-const getCommandArgs = (): Array<string> => {
-  const appArguments = Window.getArguments();
-  const arg = appArguments['cmd-args'];
+const normalizeCommandArgs = (
+  arg: string | Array<string> | void
+): Array<string> => {
   if (!arg) return [];
   const values = Array.isArray(arg) ? arg : [arg];
   return values.map(value => value.trim()).filter(Boolean);
 };
+
+const getCommandArgs = (): Array<string> =>
+  normalizeCommandArgs(Window.getArguments()['cmd-args']);
 
 const runners: { [commandName: string]: CliCommandRunner } = {
   EXPORT_HTML5_EXTERNAL: async (project, i18n, { preferences }) => {
@@ -117,6 +121,13 @@ const exitApp = (exitCode: number) => {
   if (ipcRenderer) ipcRenderer.send('app-exit', exitCode);
 };
 
+// Must match electron-app/app/main.js normalizeProjectPath (IPC routing).
+const normalizeProjectPath = (filePath: ?string): ?string => {
+  if (!filePath || !path) return null;
+  const resolved = path.resolve(filePath);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+};
+
 const ensureProjectExtensionsReadyForCli = async (
   eventsFunctionsExtensionsState: EventsFunctionsExtensionsState
 ): Promise<boolean> => {
@@ -146,9 +157,82 @@ const ensureProjectExtensionsReadyForCli = async (
   return true;
 };
 
+type RunCliCommandOptions = {|
+  project: gdProject,
+  i18n: I18nType,
+  commandName: string,
+  commandArgs: Array<string>,
+  eventsFunctionsExtensionsState: EventsFunctionsExtensionsState,
+  commandPaletteRef: {| current: ?CommandPaletteInterface |},
+  preferences: Preferences,
+  importExtension: ImportExtension,
+  onWillInstallExtension: (extensionNames: Array<string>) => void,
+  onExtensionInstalled: (extensionNames: Array<string>) => void,
+  saveProject: SaveProject,
+  onFinished: (exitCode: number) => void,
+|};
+
+const runCliCommand = async ({
+  project,
+  i18n,
+  commandName,
+  commandArgs,
+  eventsFunctionsExtensionsState,
+  commandPaletteRef,
+  preferences,
+  importExtension,
+  onWillInstallExtension,
+  onExtensionInstalled,
+  saveProject,
+  onFinished,
+}: RunCliCommandOptions): Promise<void> => {
+  try {
+    const extensionsReady = await ensureProjectExtensionsReadyForCli(
+      eventsFunctionsExtensionsState
+    );
+    if (!extensionsReady) {
+      onFinished(1);
+      return;
+    }
+
+    const awaitableRunner = getAwaitableCliRunner(commandName);
+    if (awaitableRunner) {
+      await awaitableRunner(project, i18n, {
+        preferences,
+        commandArgs,
+        importExtension,
+        onWillInstallExtension,
+        onExtensionInstalled,
+        saveProject,
+      });
+      console.info(`[CLI] Command "${commandName}" finished successfully.`);
+      onFinished(0);
+      return;
+    }
+
+    if (commandPaletteRef.current && commandPaletteRef.current.launchCommand) {
+      commandPaletteRef.current.launchCommand((commandName: any));
+      console.info(
+        `[CLI] Command "${commandName}" dispatched (fire-and-forget).`
+      );
+      setTimeout(() => onFinished(0), FIRE_AND_FORGET_GRACE_MS);
+      return;
+    }
+
+    console.error(
+      `[CLI] Command "${commandName}" could not be dispatched: command palette not ready.`
+    );
+    onFinished(1);
+  } catch (error) {
+    console.error(`[CLI] Command "${commandName}" failed:`, error);
+    onFinished(1);
+  }
+};
+
 type Props = {|
   project: ?gdProject,
   i18n: I18nType,
+  fileIdentifier: ?string,
   commandPaletteRef: {| current: ?CommandPaletteInterface |},
   importExtension: ImportExtension,
   onWillInstallExtension: (extensionNames: Array<string>) => void,
@@ -159,6 +243,7 @@ type Props = {|
 export const useCliCommandRunner = ({
   project,
   i18n,
+  fileIdentifier,
   commandPaletteRef,
   importExtension,
   onWillInstallExtension,
@@ -169,6 +254,14 @@ export const useCliCommandRunner = ({
     EventsFunctionsExtensionsContext
   );
   const preferences = React.useContext(PreferencesContext);
+
+  React.useEffect(
+    () => {
+      if (ipcRenderer)
+        ipcRenderer.send('set-window-project-path', fileIdentifier);
+    },
+    [fileIdentifier]
+  );
 
   // Dispatch `--run-command` once the project is loaded. "Awaitable" commands
   // are awaited for a proper exit code; others fall back to fire-and-forget
@@ -186,61 +279,79 @@ export const useCliCommandRunner = ({
       cliCommandRanRef.current = true;
       const keepOpen = !!appArguments['keep-open'];
 
-      const run = async () => {
-        try {
-          const extensionsReady = await ensureProjectExtensionsReadyForCli(
-            eventsFunctionsExtensionsState
-          );
-          if (!extensionsReady) {
-            if (!keepOpen) exitApp(1);
-            return;
-          }
-
-          const awaitableRunner = getAwaitableCliRunner(commandName);
-          if (awaitableRunner) {
-            await awaitableRunner(project, i18n, {
-              preferences,
-              commandArgs: getCommandArgs(),
-              importExtension,
-              onWillInstallExtension,
-              onExtensionInstalled,
-              saveProject,
-            });
-            console.info(
-              `[CLI] Command "${commandName}" finished successfully.`
-            );
-            if (!keepOpen) exitApp(0);
-            return;
-          }
-
-          if (
-            commandPaletteRef.current &&
-            commandPaletteRef.current.launchCommand
-          ) {
-            commandPaletteRef.current.launchCommand((commandName: any));
-            console.info(
-              `[CLI] Command "${commandName}" dispatched (fire-and-forget).`
-            );
-            if (!keepOpen)
-              setTimeout(() => exitApp(0), FIRE_AND_FORGET_GRACE_MS);
-            return;
-          }
-
-          console.error(
-            `[CLI] Command "${commandName}" could not be dispatched: command palette not ready.`
-          );
-          if (!keepOpen) exitApp(1);
-        } catch (error) {
-          console.error(`[CLI] Command "${commandName}" failed:`, error);
-          if (!keepOpen) exitApp(1);
-        }
-      };
-
-      run();
+      runCliCommand({
+        project,
+        i18n,
+        commandName,
+        commandArgs: getCommandArgs(),
+        eventsFunctionsExtensionsState,
+        commandPaletteRef,
+        preferences,
+        importExtension,
+        onWillInstallExtension,
+        onExtensionInstalled,
+        saveProject,
+        onFinished: exitCode => {
+          if (!keepOpen) exitApp(exitCode);
+        },
+      });
     },
     [
       project,
       i18n,
+      commandPaletteRef,
+      eventsFunctionsExtensionsState,
+      preferences,
+      importExtension,
+      onWillInstallExtension,
+      onExtensionInstalled,
+      saveProject,
+    ]
+  );
+
+  React.useEffect(
+    () => {
+      if (!ipcRenderer || !project) return;
+
+      const onRunCliCommand = (
+        event,
+        { commandName, commandArgs, projectPath }
+      ) => {
+        if (
+          normalizeProjectPath(projectPath) !==
+          normalizeProjectPath(fileIdentifier)
+        ) {
+          console.error(
+            `[CLI] Command "${commandName}" was routed to this window for "${projectPath ||
+              ''}", but it now has "${fileIdentifier || ''}" open. Ignoring.`
+          );
+          return;
+        }
+
+        runCliCommand({
+          project,
+          i18n,
+          commandName,
+          commandArgs: normalizeCommandArgs(commandArgs),
+          eventsFunctionsExtensionsState,
+          commandPaletteRef,
+          preferences,
+          importExtension,
+          onWillInstallExtension,
+          onExtensionInstalled,
+          saveProject,
+          onFinished: () => {},
+        });
+      };
+
+      ipcRenderer.on('run-cli-command', onRunCliCommand);
+      return () =>
+        ipcRenderer.removeListener('run-cli-command', onRunCliCommand);
+    },
+    [
+      project,
+      i18n,
+      fileIdentifier,
       commandPaletteRef,
       eventsFunctionsExtensionsState,
       preferences,

--- a/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
+++ b/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
@@ -122,10 +122,10 @@ const exitApp = (exitCode: number) => {
   if (ipcRenderer) ipcRenderer.send('app-exit', exitCode);
 };
 
-// Must match electron-app/app/main.js normalizeProjectPath (IPC routing).
-const normalizeProjectPath = (filePath: ?string): ?string => {
-  if (!filePath || !path) return null;
-  const resolved = path.resolve(filePath);
+// Must match electron-app/app/OpenProjectsRegistry.js normalizeFileIdentifier (IPC routing).
+const normalizeFileIdentifier = (fileIdentifier: ?string): ?string => {
+  if (!fileIdentifier || !path) return null;
+  const resolved = path.resolve(fileIdentifier);
   return process && process.platform === 'win32'
     ? resolved.toLowerCase()
     : resolved;
@@ -134,7 +134,7 @@ const normalizeProjectPath = (filePath: ?string): ?string => {
 type RunCliCommandIpcPayload = {|
   commandName: string,
   commandArgs: string | Array<string> | void,
-  projectPath: ?string,
+  fileIdentifier: ?string,
 |};
 
 const ensureProjectExtensionsReadyForCli = async (
@@ -324,14 +324,18 @@ export const useCliCommandRunner = ({
 
       const onRunCliCommand = (
         event: any,
-        { commandName, commandArgs, projectPath }: RunCliCommandIpcPayload
+        {
+          commandName,
+          commandArgs,
+          fileIdentifier: routedFileIdentifier,
+        }: RunCliCommandIpcPayload
       ) => {
         if (
-          normalizeProjectPath(projectPath) !==
-          normalizeProjectPath(fileIdentifier)
+          normalizeFileIdentifier(routedFileIdentifier) !==
+          normalizeFileIdentifier(fileIdentifier)
         ) {
           console.error(
-            `[CLI] Command "${commandName}" was routed to this window for "${projectPath ||
+            `[CLI] Command "${commandName}" was routed to this window for "${routedFileIdentifier ||
               ''}", but it now has "${fileIdentifier || ''}" open. Ignoring.`
           );
           return;

--- a/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
+++ b/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
@@ -18,6 +18,7 @@ const electron = optionalRequire('electron');
 const ipcRenderer = electron ? electron.ipcRenderer : null;
 const fs = optionalRequire('fs');
 const path = optionalRequire('path');
+const process = optionalRequire('process');
 
 export type ImportExtension = (options: {|
   i18n: I18nType,
@@ -125,8 +126,16 @@ const exitApp = (exitCode: number) => {
 const normalizeProjectPath = (filePath: ?string): ?string => {
   if (!filePath || !path) return null;
   const resolved = path.resolve(filePath);
-  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  return process && process.platform === 'win32'
+    ? resolved.toLowerCase()
+    : resolved;
 };
+
+type RunCliCommandIpcPayload = {|
+  commandName: string,
+  commandArgs: string | Array<string> | void,
+  projectPath: ?string,
+|};
 
 const ensureProjectExtensionsReadyForCli = async (
   eventsFunctionsExtensionsState: EventsFunctionsExtensionsState
@@ -314,8 +323,8 @@ export const useCliCommandRunner = ({
       if (!ipcRenderer || !project) return;
 
       const onRunCliCommand = (
-        event,
-        { commandName, commandArgs, projectPath }
+        event: any,
+        { commandName, commandArgs, projectPath }: RunCliCommandIpcPayload
       ) => {
         if (
           normalizeProjectPath(projectPath) !==

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -413,6 +413,7 @@ export type Props = {|
   useCliCommandRunner: ({|
     project: ?gdProject,
     i18n: I18n,
+    fileIdentifier: ?string,
     commandPaletteRef: {| current: ?CommandPaletteInterface |},
     importExtension: ImportExtension,
     onWillInstallExtension: (extensionNames: Array<string>) => void,
@@ -5278,6 +5279,7 @@ const MainFrame = (props: Props): React.MixedElement => {
   useCliCommandRunner({
     project: state.currentProject,
     i18n,
+    fileIdentifier,
     commandPaletteRef,
     importExtension,
     onWillInstallExtension,

--- a/newIDE/electron-app/app/CliCommandHandoff.js
+++ b/newIDE/electron-app/app/CliCommandHandoff.js
@@ -1,0 +1,73 @@
+const parseArgs = require('minimist');
+const {
+  normalizeFileIdentifier,
+  readOpenProjectFileIdentifiers,
+  getWindowFileIdentifier,
+} = require('./OpenProjectsRegistry');
+
+// In dev, electron is launched with an extra argument, so skip one more.
+const argsParserOptions = {
+  boolean: ['dev-tools', 'disable-update-check', 'keep-open'],
+  string: ['_', 'run-command', 'cmd-args'],
+};
+
+// Drop switches Chromium may inject into argv (e.g. --allow-file-access-from-files)
+// so they can't steal the value of our own -- flags during parsing.
+const knownCliFlagNames = new Set(
+  [...argsParserOptions.boolean, ...argsParserOptions.string].filter(
+    name => name !== '_'
+  )
+);
+const parseGDevelopArgs = argv =>
+  parseArgs(
+    argv.filter(
+      arg =>
+        !arg.startsWith('--') ||
+        knownCliFlagNames.has(arg.slice(2).split('=')[0])
+    ),
+    argsParserOptions
+  );
+
+// Electron reorders commandLine (switches first, values last) before forwarding
+// to 'second-instance', breaking flag-to-value pairing on reparse. Prefer
+// additionalData.args (parsed by the second instance itself) instead.
+const parseSecondInstanceArgs = ({ commandLine, additionalData, isDev }) =>
+  additionalData && additionalData.args
+    ? additionalData.args
+    : parseGDevelopArgs(commandLine.slice(isDev ? 2 : 1));
+
+const isCliProjectAlreadyOpenElsewhere = parsedArgs => {
+  const fileIdentifier = normalizeFileIdentifier(parsedArgs._[0]);
+  return (
+    !!fileIdentifier &&
+    readOpenProjectFileIdentifiers().includes(fileIdentifier)
+  );
+};
+
+// Redirects the command to an already open editor instead of spawning a new window.
+const routeCliCommandToLiveEditor = ({ parsedArgs, mainWindows }) => {
+  const commandName = parsedArgs['run-command'];
+  if (!commandName) return false;
+
+  const fileIdentifier = normalizeFileIdentifier(parsedArgs._[0]);
+  const targetWindow = Array.from(mainWindows).find(
+    window => getWindowFileIdentifier(window.id) === fileIdentifier
+  );
+  if (!targetWindow) return false;
+
+  targetWindow.webContents.send('run-cli-command', {
+    commandName,
+    commandArgs: parsedArgs['cmd-args'],
+    fileIdentifier,
+  });
+  targetWindow.focus();
+  return true;
+};
+
+module.exports = {
+  argsParserOptions,
+  parseGDevelopArgs,
+  parseSecondInstanceArgs,
+  isCliProjectAlreadyOpenElsewhere,
+  routeCliCommandToLiveEditor,
+};

--- a/newIDE/electron-app/app/CliCommandHandoff.js
+++ b/newIDE/electron-app/app/CliCommandHandoff.js
@@ -5,7 +5,6 @@ const {
   getWindowFileIdentifier,
 } = require('./OpenProjectsRegistry');
 
-// In dev, electron is launched with an extra argument, so skip one more.
 const argsParserOptions = {
   boolean: ['dev-tools', 'disable-update-check', 'keep-open'],
   string: ['_', 'run-command', 'cmd-args'],
@@ -34,6 +33,7 @@ const parseGDevelopArgs = argv =>
 const parseSecondInstanceArgs = ({ commandLine, additionalData, isDev }) =>
   additionalData && additionalData.args
     ? additionalData.args
+    // In dev, electron is launched with an extra argument, so skip one more.
     : parseGDevelopArgs(commandLine.slice(isDev ? 2 : 1));
 
 const isCliProjectAlreadyOpenElsewhere = parsedArgs => {

--- a/newIDE/electron-app/app/OpenProjectsRegistry.js
+++ b/newIDE/electron-app/app/OpenProjectsRegistry.js
@@ -1,0 +1,66 @@
+const electron = require('electron');
+const path = require('path');
+const fs = require('fs');
+const app = electron.app;
+
+// Tracks which file identifiers are open in this process's windows, persisted to
+// disk so a separate CLI process can find a live editor to route a command to.
+// File identifier == local file path for now; will cover cloud project UUIDs later.
+const registryFilePath = path.join(
+  app.getPath('userData'),
+  'open-projects.json'
+);
+
+const windowFileIdentifiers = new Map();
+
+const normalizeFileIdentifier = fileIdentifier => {
+  if (!fileIdentifier) return null;
+  try {
+    const resolved = path.resolve(fileIdentifier);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  } catch (e) {
+    return null;
+  }
+};
+
+const writeOpenProjectsRegistry = () => {
+  try {
+    const fileIdentifiers = Array.from(
+      new Set(windowFileIdentifiers.values())
+    );
+    fs.writeFileSync(registryFilePath, JSON.stringify(fileIdentifiers));
+  } catch (e) {}
+};
+
+const readOpenProjectFileIdentifiers = () => {
+  try {
+    const fileIdentifiers = JSON.parse(
+      fs.readFileSync(registryFilePath, 'utf8')
+    );
+    return Array.isArray(fileIdentifiers) ? fileIdentifiers : [];
+  } catch (e) {
+    return [];
+  }
+};
+
+const getWindowFileIdentifier = windowId =>
+  windowFileIdentifiers.get(windowId) || null;
+
+const setWindowFileIdentifier = (windowId, fileIdentifier) => {
+  const normalized = normalizeFileIdentifier(fileIdentifier);
+  if (normalized) windowFileIdentifiers.set(windowId, normalized);
+  else windowFileIdentifiers.delete(windowId);
+  writeOpenProjectsRegistry();
+};
+
+const clearWindowFileIdentifier = windowId => {
+  if (windowFileIdentifiers.delete(windowId)) writeOpenProjectsRegistry();
+};
+
+module.exports = {
+  normalizeFileIdentifier,
+  readOpenProjectFileIdentifiers,
+  getWindowFileIdentifier,
+  setWindowFileIdentifier,
+  clearWindowFileIdentifier,
+};

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -1,5 +1,6 @@
 const electron = require('electron');
 const path = require('path');
+const fs = require('fs');
 const child_process = require('child_process');
 const app = electron.app; // Module to control application life.
 const BrowserWindow = electron.BrowserWindow; // Module to create native browser window.
@@ -66,13 +67,77 @@ let mainWindows = new Set();
 let mainWindow = null; // Primary window reference for backwards compatibility
 let windowCounter = 0; // Counter for creating unique session partitions
 
+// open-projects.json in userData: separate CLI processes read this to find live editors.
+const windowProjectPaths = new Map();
+const openProjectsRegistryPath = path.join(
+  app.getPath('userData'),
+  'open-projects.json'
+);
+
+const normalizeProjectPath = filePath => {
+  if (!filePath) return null;
+  try {
+    const resolved = path.resolve(filePath);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  } catch (e) {
+    return null;
+  }
+};
+
+const writeOpenProjectsRegistry = () => {
+  try {
+    const projectPaths = Array.from(new Set(windowProjectPaths.values()));
+    fs.writeFileSync(openProjectsRegistryPath, JSON.stringify(projectPaths));
+  } catch (e) {}
+};
+
+const readOpenProjectsRegistry = () => {
+  try {
+    const projectPaths = JSON.parse(
+      fs.readFileSync(openProjectsRegistryPath, 'utf8')
+    );
+    return Array.isArray(projectPaths) ? projectPaths : [];
+  } catch (e) {
+    return [];
+  }
+};
+
+const setWindowProjectPath = (windowId, filePath) => {
+  const normalized = normalizeProjectPath(filePath);
+  if (normalized) windowProjectPaths.set(windowId, normalized);
+  else windowProjectPaths.delete(windowId);
+  writeOpenProjectsRegistry();
+};
+
+const clearWindowProjectPath = windowId => {
+  if (windowProjectPaths.delete(windowId)) writeOpenProjectsRegistry();
+};
+
 // Parse arguments (knowing that in dev, we run electron with an argument,
 // so have to ignore one more).
 const argsParserOptions = {
   boolean: ['dev-tools', 'disable-update-check', 'keep-open'],
   string: ['_', 'run-command', 'cmd-args'],
 };
-const args = parseArgs(process.argv.slice(isDev ? 2 : 1), argsParserOptions);
+
+// Chromium may inject its own flags into second-instance argv, landing right
+// between --run-command and its value. Drop unknown -- flags before parsing.
+const knownCliFlagNames = new Set(
+  [...argsParserOptions.boolean, ...argsParserOptions.string].filter(
+    name => name !== '_'
+  )
+);
+const parseGDevelopArgs = argv =>
+  parseArgs(
+    argv.filter(
+      arg =>
+        !arg.startsWith('--') ||
+        knownCliFlagNames.has(arg.slice(2).split('=')[0])
+    ),
+    argsParserOptions
+  );
+
+const args = parseGDevelopArgs(process.argv.slice(isDev ? 2 : 1));
 
 const devTools = !!args['dev-tools'];
 
@@ -87,25 +152,47 @@ if (process.platform === 'win32') {
 
 // Single instance lock - prevents multiple Electron processes
 // This solves Firebase IndexedDB locking issues while still allowing multiple windows.
-//
-// When invoked via `--run-command` (CLI / CI scenarios), we deliberately
-// SKIP the single-instance lock so each CLI invocation runs in its own
-// process. This lets the launching shell wait for completion and observe
-// the exit code, instead of being immediately backgrounded by the existing
-// instance taking over via the second-instance handler.
+// CLI: skip the lock unless the target project is a known open window (registry hit);
+// a stale registry entry falls back to running headless in this process.
 const isCliRunCommand = !!args['run-command'];
-const gotTheLock = isCliRunCommand ? true : app.requestSingleInstanceLock();
+const cliProjectPath = isCliRunCommand
+  ? normalizeProjectPath(args._[0])
+  : null;
+const isCliProjectAlreadyOpenElsewhere =
+  !!cliProjectPath && readOpenProjectsRegistry().includes(cliProjectPath);
+const gotTheLock =
+  isCliRunCommand && !isCliProjectAlreadyOpenElsewhere
+    ? true
+    : app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
   // Second instance attempted - quit immediately
   app.quit();
-} else if (!isCliRunCommand) {
-  // First instance - handle second-instance events by creating new windows
+} else {
   app.on('second-instance', (event, commandLine, workingDirectory) => {
-    const secondInstanceArgs = parseArgs(
-      commandLine.slice(isDev ? 2 : 1),
-      argsParserOptions
+    const secondInstanceArgs = parseGDevelopArgs(
+      commandLine.slice(isDev ? 2 : 1)
     );
+
+    const secondInstanceCommandName = secondInstanceArgs['run-command'];
+    if (secondInstanceCommandName) {
+      const secondInstanceProjectPath = normalizeProjectPath(
+        secondInstanceArgs._[0]
+      );
+      const targetWindow = Array.from(mainWindows).find(
+        window => windowProjectPaths.get(window.id) === secondInstanceProjectPath
+      );
+
+      if (targetWindow) {
+        targetWindow.webContents.send('run-cli-command', {
+          commandName: secondInstanceCommandName,
+          commandArgs: secondInstanceArgs['cmd-args'],
+          projectPath: secondInstanceProjectPath,
+        });
+        targetWindow.focus();
+        return;
+      }
+    }
 
     // Update the global args so the new window's renderer (which reads them
     // via remote.getGlobal('args')) picks up the second-instance CLI flags
@@ -145,6 +232,8 @@ const windowTargetIdToBrowserWindowIds = new Map();
 // Function to create a new GDevelop window
 function createNewWindow(windowArgs = args) {
   const isIntegrated = windowArgs.mode === 'integrated';
+  // windowArgs: a GUI primary process can still open a CLI window (second-instance fallback).
+  const isCliWindow = !!windowArgs['run-command'];
 
   if (isIntegrated && app.dock) {
     app.dock.hide();
@@ -202,13 +291,13 @@ function createNewWindow(windowArgs = args) {
     options.show = false;
   }
 
-  if (isCliRunCommand && !windowArgs['keep-open']) {
+  if (isCliWindow && !windowArgs['keep-open']) {
     options.show = false;
     options.skipTaskbar = true;
   }
 
   const newWindow = new BrowserWindow(options);
-  if (!isIntegrated && !isCliRunCommand) newWindow.maximize();
+  if (!isIntegrated && !isCliWindow) newWindow.maximize();
 
   // Capture window ID and whether this is the primary window before it can be destroyed
   const windowId = newWindow.id;
@@ -230,7 +319,7 @@ function createNewWindow(windowArgs = args) {
 
   // Uses process.stdout/stderr directly (not electron-log) to avoid
   // re-entering the renderer console and causing an infinite loop.
-  if (isCliRunCommand) {
+  if (isCliWindow) {
     newWindow.webContents.on('console-message', (_event, level, message) => {
       if (level < 1) return;
       if (message.startsWith('%c')) return;
@@ -271,6 +360,7 @@ function createNewWindow(windowArgs = args) {
   newWindow.on('closed', function() {
     // Remove from tracked windows
     mainWindows.delete(newWindow);
+    clearWindowProjectPath(windowId);
 
     // If this was the primary window, set a new primary
     if (isPrimaryWindow) {
@@ -381,6 +471,11 @@ function createNewWindow(windowArgs = args) {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.on('ready', function() {
+  // Handoff calls app.quit() but 'ready' still runs; without the lock, do not create a window.
+  if (!gotTheLock) {
+    return;
+  }
+
   registerGdideProtocol({ isDev });
 
   // Create the first window
@@ -420,6 +515,11 @@ app.on('ready', function() {
 
   ipcMain.on('app-exit', (_event, exitCode) => {
     app.exit(typeof exitCode === 'number' ? exitCode : 0);
+  });
+
+  ipcMain.on('set-window-project-path', (event, filePath) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (window) setWindowProjectPath(window.id, filePath);
   });
 
   ipcMain.handle('install-cli-in-path', async () => {

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -120,8 +120,8 @@ const argsParserOptions = {
   string: ['_', 'run-command', 'cmd-args'],
 };
 
-// Chromium may inject its own flags into second-instance argv, landing right
-// between --run-command and its value. Drop unknown -- flags before parsing.
+// Drop switches Chromium may inject into argv (e.g. --allow-file-access-from-files)
+// so they can't steal the value of our own -- flags during parsing.
 const knownCliFlagNames = new Set(
   [...argsParserOptions.boolean, ...argsParserOptions.string].filter(
     name => name !== '_'
@@ -163,16 +163,19 @@ const isCliProjectAlreadyOpenElsewhere =
 const gotTheLock =
   isCliRunCommand && !isCliProjectAlreadyOpenElsewhere
     ? true
-    : app.requestSingleInstanceLock();
+    : app.requestSingleInstanceLock({ args });
 
 if (!gotTheLock) {
   // Second instance attempted - quit immediately
   app.quit();
 } else {
-  app.on('second-instance', (event, commandLine, workingDirectory) => {
-    const secondInstanceArgs = parseGDevelopArgs(
-      commandLine.slice(isDev ? 2 : 1)
-    );
+  app.on('second-instance', (event, commandLine, workingDirectory, additionalData) => {
+    // Prefer the args parsed by the second instance: Chromium reorders commandLine
+    // (switches first, values last), breaking flag-to-value pairing on reparse.
+    const secondInstanceArgs =
+      additionalData && additionalData.args
+        ? additionalData.args
+        : parseGDevelopArgs(commandLine.slice(isDev ? 2 : 1));
 
     const secondInstanceCommandName = secondInstanceArgs['run-command'];
     if (secondInstanceCommandName) {

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -7,7 +7,6 @@ const BrowserWindow = electron.BrowserWindow; // Module to create native browser
 const Menu = electron.Menu;
 const Notification = electron.Notification;
 const protocol = electron.protocol;
-const parseArgs = require('minimist');
 const isDev = require('electron-is-dev');
 const ipcMain = electron.ipcMain;
 const autoUpdater = require('electron-updater').autoUpdater;
@@ -47,6 +46,16 @@ const {
 } = require('./LocalGDJSDevelopmentWatcher');
 const { setupWatcher, disableWatcher } = require('./LocalFilesystemWatcher');
 const { installCliInPath } = require('./InstallCliInPath');
+const {
+  setWindowFileIdentifier,
+  clearWindowFileIdentifier,
+} = require('./OpenProjectsRegistry');
+const {
+  parseGDevelopArgs,
+  parseSecondInstanceArgs,
+  isCliProjectAlreadyOpenElsewhere,
+  routeCliCommandToLiveEditor,
+} = require('./CliCommandHandoff');
 
 // Initialize `@electron/remote` module
 require('@electron/remote/main').initialize();
@@ -67,76 +76,6 @@ let mainWindows = new Set();
 let mainWindow = null; // Primary window reference for backwards compatibility
 let windowCounter = 0; // Counter for creating unique session partitions
 
-// open-projects.json in userData: separate CLI processes read this to find live editors.
-const windowProjectPaths = new Map();
-const openProjectsRegistryPath = path.join(
-  app.getPath('userData'),
-  'open-projects.json'
-);
-
-const normalizeProjectPath = filePath => {
-  if (!filePath) return null;
-  try {
-    const resolved = path.resolve(filePath);
-    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
-  } catch (e) {
-    return null;
-  }
-};
-
-const writeOpenProjectsRegistry = () => {
-  try {
-    const projectPaths = Array.from(new Set(windowProjectPaths.values()));
-    fs.writeFileSync(openProjectsRegistryPath, JSON.stringify(projectPaths));
-  } catch (e) {}
-};
-
-const readOpenProjectsRegistry = () => {
-  try {
-    const projectPaths = JSON.parse(
-      fs.readFileSync(openProjectsRegistryPath, 'utf8')
-    );
-    return Array.isArray(projectPaths) ? projectPaths : [];
-  } catch (e) {
-    return [];
-  }
-};
-
-const setWindowProjectPath = (windowId, filePath) => {
-  const normalized = normalizeProjectPath(filePath);
-  if (normalized) windowProjectPaths.set(windowId, normalized);
-  else windowProjectPaths.delete(windowId);
-  writeOpenProjectsRegistry();
-};
-
-const clearWindowProjectPath = windowId => {
-  if (windowProjectPaths.delete(windowId)) writeOpenProjectsRegistry();
-};
-
-// Parse arguments (knowing that in dev, we run electron with an argument,
-// so have to ignore one more).
-const argsParserOptions = {
-  boolean: ['dev-tools', 'disable-update-check', 'keep-open'],
-  string: ['_', 'run-command', 'cmd-args'],
-};
-
-// Drop switches Chromium may inject into argv (e.g. --allow-file-access-from-files)
-// so they can't steal the value of our own -- flags during parsing.
-const knownCliFlagNames = new Set(
-  [...argsParserOptions.boolean, ...argsParserOptions.string].filter(
-    name => name !== '_'
-  )
-);
-const parseGDevelopArgs = argv =>
-  parseArgs(
-    argv.filter(
-      arg =>
-        !arg.startsWith('--') ||
-        knownCliFlagNames.has(arg.slice(2).split('=')[0])
-    ),
-    argsParserOptions
-  );
-
 const args = parseGDevelopArgs(process.argv.slice(isDev ? 2 : 1));
 
 const devTools = !!args['dev-tools'];
@@ -155,13 +94,8 @@ if (process.platform === 'win32') {
 // CLI: skip the lock unless the target project is a known open window (registry hit);
 // a stale registry entry falls back to running headless in this process.
 const isCliRunCommand = !!args['run-command'];
-const cliProjectPath = isCliRunCommand
-  ? normalizeProjectPath(args._[0])
-  : null;
-const isCliProjectAlreadyOpenElsewhere =
-  !!cliProjectPath && readOpenProjectsRegistry().includes(cliProjectPath);
 const gotTheLock =
-  isCliRunCommand && !isCliProjectAlreadyOpenElsewhere
+  isCliRunCommand && !isCliProjectAlreadyOpenElsewhere(args)
     ? true
     : app.requestSingleInstanceLock({ args });
 
@@ -170,31 +104,14 @@ if (!gotTheLock) {
   app.quit();
 } else {
   app.on('second-instance', (event, commandLine, workingDirectory, additionalData) => {
-    // Prefer the args parsed by the second instance: Chromium reorders commandLine
-    // (switches first, values last), breaking flag-to-value pairing on reparse.
-    const secondInstanceArgs =
-      additionalData && additionalData.args
-        ? additionalData.args
-        : parseGDevelopArgs(commandLine.slice(isDev ? 2 : 1));
+    const secondInstanceArgs = parseSecondInstanceArgs({
+      commandLine,
+      additionalData,
+      isDev,
+    });
 
-    const secondInstanceCommandName = secondInstanceArgs['run-command'];
-    if (secondInstanceCommandName) {
-      const secondInstanceProjectPath = normalizeProjectPath(
-        secondInstanceArgs._[0]
-      );
-      const targetWindow = Array.from(mainWindows).find(
-        window => windowProjectPaths.get(window.id) === secondInstanceProjectPath
-      );
-
-      if (targetWindow) {
-        targetWindow.webContents.send('run-cli-command', {
-          commandName: secondInstanceCommandName,
-          commandArgs: secondInstanceArgs['cmd-args'],
-          projectPath: secondInstanceProjectPath,
-        });
-        targetWindow.focus();
-        return;
-      }
+    if (routeCliCommandToLiveEditor({ parsedArgs: secondInstanceArgs, mainWindows })) {
+      return;
     }
 
     // Update the global args so the new window's renderer (which reads them
@@ -363,7 +280,7 @@ function createNewWindow(windowArgs = args) {
   newWindow.on('closed', function() {
     // Remove from tracked windows
     mainWindows.delete(newWindow);
-    clearWindowProjectPath(windowId);
+    clearWindowFileIdentifier(windowId);
 
     // If this was the primary window, set a new primary
     if (isPrimaryWindow) {
@@ -520,9 +437,9 @@ app.on('ready', function() {
     app.exit(typeof exitCode === 'number' ? exitCode : 0);
   });
 
-  ipcMain.on('set-window-project-path', (event, filePath) => {
+  ipcMain.on('set-window-project-path', (event, fileIdentifier) => {
     const window = BrowserWindow.fromWebContents(event.sender);
-    if (window) setWindowProjectPath(window.id, filePath);
+    if (window) setWindowFileIdentifier(window.id, fileIdentifier);
   });
 
   ipcMain.handle('install-cli-in-path', async () => {


### PR DESCRIPTION
CLI commands with `--run-command` used to always start a separate headless process, even when the target project was already open in the editor. This PR routes those commands into the live window so results (for example imported extensions) appear in memory right away, without reopening the project.

## Behavior

When the target project is open in a running editor, the command runs there (fire-and-forget; the CLI does not reflect the command’s real exit code). If there is no matching open project, behavior is unchanged: headless run with a proper exit code for CI and automation.

## How it works

The main process maintains a small registry of open projects in user data so a CLI process can tell whether a live editor already has the project. On a match, the command is handed off to that window via single-instance instead of spawning another one. Parsed arguments are passed through the single-instance lock’s additional data, because Electron reorders the raw command line and breaks flag-to-value pairing on reparse.