### PR TITLE
Fix variable parameter "add or edit" auto-completions

### DIFF
--- a/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
+++ b/newIDE/app/src/EventsFunctionsExtensionEditor/index.js
@@ -1384,6 +1384,20 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
     const selectedEventsBasedEntity =
       selectedEventsBasedBehavior || selectedEventsBasedObject;
 
+    const isLifecycleEventsFunction =
+      !!selectedEventsFunction &&
+      (selectedEventsBasedBehavior
+        ? gd.MetadataDeclarationHelper.isBehaviorLifecycleEventsFunction(
+            selectedEventsFunction.getName()
+          )
+        : selectedEventsBasedObject
+        ? gd.MetadataDeclarationHelper.isObjectLifecycleEventsFunction(
+            selectedEventsFunction.getName()
+          )
+        : gd.MetadataDeclarationHelper.isExtensionLifecycleEventsFunction(
+            selectedEventsFunction.getName()
+          ));
+
     const editors: {
       [string]: Editor,
     } = {
@@ -1578,9 +1592,15 @@ export default class EventsFunctionsExtensionEditor extends React.Component<
                 }
                 onWillInstallExtension={this.props.onWillInstallExtension}
                 onExtensionInstalled={this.props.onExtensionInstalled}
-                editEventsFunctionParameter={this._editEventsFunctionParameter}
+                editEventsFunctionParameter={
+                  isLifecycleEventsFunction
+                    ? null
+                    : this._editEventsFunctionParameter
+                }
                 openEventsBasedEntityPropertyEditorDialog={
-                  this._openEventsBasedEntityPropertyEditorDialog
+                  selectedEventsBasedEntity
+                    ? this._openEventsBasedEntityPropertyEditorDialog
+                    : null
                 }
               />
             </Background>

--- a/newIDE/app/src/EventsSheet/InlineParameterEditor.js
+++ b/newIDE/app/src/EventsSheet/InlineParameterEditor.js
@@ -41,8 +41,10 @@ type Props = {|
   anchorEl: ?any,
 
   resourceManagementProps: ResourceManagementProps,
-  editEventsFunctionParameter: VariableDialogOpeningProps => void,
-  openEventsBasedEntityPropertyEditorDialog: VariableDialogOpeningProps => void,
+  editEventsFunctionParameter: (VariableDialogOpeningProps => void) | null,
+  openEventsBasedEntityPropertyEditorDialog:
+    | (VariableDialogOpeningProps => void)
+    | null,
 |};
 
 const InlineParameterEditor = ({

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorDialog.js
@@ -80,8 +80,10 @@ type Props = {|
   onPasteInstructions: () => void, // Unused
   onWillInstallExtension: (extensionNames: Array<string>) => void,
   onExtensionInstalled: (extensionNames: Array<string>) => void,
-  editEventsFunctionParameter: VariableDialogOpeningProps => void,
-  openEventsBasedEntityPropertyEditorDialog: VariableDialogOpeningProps => void,
+  editEventsFunctionParameter: (VariableDialogOpeningProps => void) | null,
+  openEventsBasedEntityPropertyEditorDialog:
+    | (VariableDialogOpeningProps => void)
+    | null,
 |};
 
 const getInitialStepName = (isNewInstruction: boolean): StepName => {
@@ -293,11 +295,13 @@ const InstructionEditorDialog = ({
                 eventsFunction,
                 behaviorParameter
               );
-              editEventsFunctionParameter({
-                variableName: behaviorParameter.getName(),
-                shouldCreate: false,
-                variableType: null,
-              });
+              if (editEventsFunctionParameter) {
+                editEventsFunctionParameter({
+                  variableName: behaviorParameter.getName(),
+                  shouldCreate: false,
+                  variableType: null,
+                });
+              }
               setNewBehaviorDialogOpen(false);
             }
           }

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorMenu.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionEditorMenu.js
@@ -63,8 +63,10 @@ type Props = {|
   onPasteInstructions: () => void, // Unused
   onWillInstallExtension: (extensionNames: Array<string>) => void,
   onExtensionInstalled: (extensionNames: Array<string>) => void,
-  editEventsFunctionParameter: VariableDialogOpeningProps => void,
-  openEventsBasedEntityPropertyEditorDialog: VariableDialogOpeningProps => void,
+  editEventsFunctionParameter: (VariableDialogOpeningProps => void) | null,
+  openEventsBasedEntityPropertyEditorDialog:
+    | (VariableDialogOpeningProps => void)
+    | null,
 |};
 
 /**

--- a/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
+++ b/newIDE/app/src/EventsSheet/InstructionEditor/InstructionParametersEditor.js
@@ -91,7 +91,9 @@ type Props = {|
   ) => void,
   noHelpButton?: boolean,
   id?: string,
-  openEventsBasedEntityPropertyEditorDialog: VariableDialogOpeningProps => void,
+  openEventsBasedEntityPropertyEditorDialog:
+    | (VariableDialogOpeningProps => void)
+    | null,
 |};
 
 const isParameterVisible = (

--- a/newIDE/app/src/EventsSheet/ParameterFields/ParameterFieldCommons.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ParameterFieldCommons.js
@@ -57,8 +57,10 @@ export type ParameterFieldProps = {|
   // The index of the parameter in the instruction or expression.
   parameterIndex?: number,
   onInstructionTypeChanged?: () => void,
-  editEventsFunctionParameter?: VariableDialogOpeningProps => void,
-  openEventsBasedEntityPropertyEditorDialog?: VariableDialogOpeningProps => void,
+  editEventsFunctionParameter?: (VariableDialogOpeningProps => void) | null,
+  openEventsBasedEntityPropertyEditorDialog?:
+    | (VariableDialogOpeningProps => void)
+    | null,
 |};
 
 export type FieldFocusFunction = (

--- a/newIDE/app/src/EventsSheet/index.js
+++ b/newIDE/app/src/EventsSheet/index.js
@@ -194,8 +194,10 @@ type Props = {|
   hotReloadPreviewButtonProps: HotReloadPreviewButtonProps,
   onWillInstallExtension: (extensionNames: Array<string>) => void,
   onExtensionInstalled: (extensionNames: Array<string>) => void,
-  editEventsFunctionParameter: VariableDialogOpeningProps => void,
-  openEventsBasedEntityPropertyEditorDialog: VariableDialogOpeningProps => void,
+  editEventsFunctionParameter: (VariableDialogOpeningProps => void) | null,
+  openEventsBasedEntityPropertyEditorDialog:
+    | (VariableDialogOpeningProps => void)
+    | null,
 |};
 
 type ComponentProps = {|

--- a/newIDE/app/src/MainFrame/EditorContainers/EventsEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/EventsEditorContainer.js
@@ -223,8 +223,8 @@ export class EventsEditorContainer extends React.Component<RenderEditorContainer
         onWillInstallExtension={this.props.onWillInstallExtension}
         onExtensionInstalled={this.props.onExtensionInstalled}
         // Scene events don't have parameters nor properties
-        editEventsFunctionParameter={() => {}}
-        openEventsBasedEntityPropertyEditorDialog={() => {}}
+        editEventsFunctionParameter={null}
+        openEventsBasedEntityPropertyEditorDialog={null}
       />
     );
   }

--- a/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
+++ b/newIDE/app/src/MainFrame/EditorContainers/ExternalEventsEditorContainer.js
@@ -296,8 +296,8 @@ export class ExternalEventsEditorContainer extends React.Component<
             onWillInstallExtension={this.props.onWillInstallExtension}
             onExtensionInstalled={this.props.onExtensionInstalled}
             // Scene events don't have parameters nor properties
-            editEventsFunctionParameter={() => {}}
-            openEventsBasedEntityPropertyEditorDialog={() => {}}
+            editEventsFunctionParameter={null}
+            openEventsBasedEntityPropertyEditorDialog={null}
           />
         )}
         {!layout && (


### PR DESCRIPTION
All "add or edit" options for variables, properties and parameter were wrongly always displayed.