### PR TITLE
Match objects with unicode names in EventScript source view filters

### DIFF
--- a/Core/GDCore/Events/Parsers/GrammarTerminals.h
+++ b/Core/GDCore/Events/Parsers/GrammarTerminals.h
@@ -5,6 +5,13 @@ namespace gd {
 
 /**
  * Contains functions to handle the grammar of the expressions accepted by GDevelop.
+ *
+ * \warning This file is ported to JavaScript (notably `IsAllowedInIdentifier`
+ * and the character sets it relies on). Any change here must be mirrored in:
+ * - `newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.js`
+ *   (this repository),
+ * - `generation-api/src/lib/gdevelop-identifiers.js`
+ *   (GDevelop-services repository).
  */
 namespace GrammarTerminals {
 

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.js
@@ -1,0 +1,95 @@
+// @flow
+// A port of GDevelop `Core/GDCore/Events/Parsers/GrammarTerminals.h`
+// (`IsAllowedInIdentifier`), also ported backend-side in
+// `lib/gdevelop-identifiers.js` (GDevelop-services repository): identifiers
+// (object, variable, behavior names...) can contain any unicode character
+// except the ones reserved by the expressions grammar.
+
+const RESERVED_CHARACTERS = new Set([
+  // Whitespaces:
+  ' ',
+  '\n',
+  '\r',
+  // Parameter separator:
+  ',',
+  // Dot:
+  '.',
+  // Quote:
+  '"',
+  // Brackets:
+  '(',
+  ')',
+  '[',
+  ']',
+  '{',
+  '}',
+  // Expression operators:
+  '+',
+  '-',
+  '<',
+  '>',
+  '?',
+  '^',
+  '=',
+  '\\',
+  ':',
+  '!',
+  // Term operators:
+  '/',
+  '*',
+  // Additional reserved characters:
+  '~',
+  "'",
+  '%',
+  '#',
+  '@',
+  '|',
+  '&',
+  '`',
+  '$',
+  ';',
+]);
+
+export const isAllowedInIdentifier = (character: string): boolean => {
+  const code = character.charCodeAt(0);
+
+  // Quick check to allow basic ASCII letters and digits.
+  if (
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) // a-z
+  ) {
+    return true;
+  }
+
+  return !RESERVED_CHARACTERS.has(character);
+};
+
+/**
+ * Check if the text contains the name used as a whole identifier: an
+ * occurrence with no identifier character just before or after (the
+ * unicode-aware equivalent of a `\b` word boundary, which only understands
+ * ASCII word characters).
+ */
+export const containsNameUsedAsIdentifier = (
+  text: string,
+  name: string
+): boolean => {
+  if (!name) return false;
+  let searchStartIndex = 0;
+  for (;;) {
+    const index = text.indexOf(name, searchStartIndex);
+    if (index === -1) return false;
+    const characterBefore = text[index - 1] || '';
+    const characterAfter = text[index + name.length] || '';
+    if (
+      (!characterBefore || !isAllowedInIdentifier(characterBefore)) &&
+      (!characterAfter || !isAllowedInIdentifier(characterAfter))
+    ) {
+      return true;
+    }
+    searchStartIndex = index + 1;
+  }
+  // eslint-disable-next-line no-unreachable
+  return false;
+};

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.js
@@ -76,6 +76,30 @@ export const isAllowedInIdentifier = (character: string): boolean => {
 };
 
 /**
+ * Check if the name is safe to use as an identifier (object name, behavior
+ * name...) - the port of `gd::Project::IsNameSafe`. The editor can also
+ * call the real C++ implementation through `gd.Project.isNameSafe`: this
+ * port exists because the source view needs character-level checks (see
+ * `containsNameUsedAsIdentifier`, which the C++ does not expose), and it is
+ * verified against the C++ one by the conformance test of this module.
+ */
+export const isNameSafe = (name: string): boolean => {
+  if (!name) return false;
+  const firstLetter = name[0];
+  if (!firstLetter) return false;
+
+  if (!Number.isNaN(parseInt(firstLetter, 10))) return false;
+
+  for (const character of Array.from(name)) {
+    if (!isAllowedInIdentifier(character)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
  * Check if the text contains the name used as a whole identifier: an
  * occurrence with no identifier character just before or after (the
  * unicode-aware equivalent of a `\b` word boundary, which only understands

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.js
@@ -1,9 +1,19 @@
 // @flow
 // A port of GDevelop `Core/GDCore/Events/Parsers/GrammarTerminals.h`
-// (`IsAllowedInIdentifier`), also ported backend-side in
-// `lib/gdevelop-identifiers.js` (GDevelop-services repository): identifiers
+// (`IsAllowedInIdentifier` and the character sets it relies on): identifiers
 // (object, variable, behavior names...) can contain any unicode character
 // except the ones reserved by the expressions grammar.
+//
+// KEEP IN SYNC - this definition exists in three places, which must all
+// change together:
+// - `Core/GDCore/Events/Parsers/GrammarTerminals.h` (the C++ source of
+//   truth, used by the expressions parser and `gd::Project::IsNameSafe`),
+// - this file (used by the EventScript source view),
+// - `generation-api/src/lib/gdevelop-identifiers.js` in the
+//   GDevelop-services repository (used by the EventScript parser and the
+//   events validation).
+// A character added or removed in one and not the others means the editor,
+// the backend and the engine would disagree on what a valid name is.
 
 const RESERVED_CHARACTERS = new Set([
   // Whitespaces:

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.spec.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.spec.js
@@ -1,0 +1,69 @@
+// @flow
+import {
+  isAllowedInIdentifier,
+  containsNameUsedAsIdentifier,
+} from './EventScriptIdentifiers';
+
+describe('isAllowedInIdentifier', () => {
+  it('allows any unicode character except the grammar separators', () => {
+    for (const character of ['a', 'Z', '0', '_', 'é', 'Œ', '名', '🙂']) {
+      expect(isAllowedInIdentifier(character)).toBe(true);
+    }
+    // The characters reserved by the expressions grammar
+    // (see `GrammarTerminals.h`):
+    for (const character of [
+      ' ',
+      '\n',
+      '\r',
+      ',',
+      '.',
+      '"',
+      '(',
+      ')',
+      '[',
+      ']',
+      '{',
+      '}',
+      '+',
+      '-',
+      '<',
+      '>',
+      '?',
+      '^',
+      '=',
+      '\\',
+      ':',
+      '!',
+      '/',
+      '*',
+      '~',
+      "'",
+      '%',
+      '#',
+      '@',
+      '|',
+      '&',
+      '`',
+      '$',
+      ';',
+    ]) {
+      expect(isAllowedInIdentifier(character)).toBe(false);
+    }
+  });
+});
+
+describe('containsNameUsedAsIdentifier', () => {
+  it('matches whole identifiers only, with unicode-aware boundaries', () => {
+    expect(containsNameUsedAsIdentifier('Delete(Héros)', 'Héros')).toBe(true);
+    expect(containsNameUsedAsIdentifier('Héros.X() + 1', 'Héros')).toBe(true);
+    // Not a whole identifier: an ASCII `\b`-style boundary would wrongly
+    // match these (the characters around are identifier characters too).
+    expect(containsNameUsedAsIdentifier('SuperHéros.X()', 'Héros')).toBe(false);
+    expect(containsNameUsedAsIdentifier('Delete(Héros2)', 'Héros')).toBe(false);
+    // A later occurrence still matches after a partial one.
+    expect(
+      containsNameUsedAsIdentifier('SuperHéros.X() + Héros.X()', 'Héros')
+    ).toBe(true);
+    expect(containsNameUsedAsIdentifier('anything', '')).toBe(false);
+  });
+});

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.spec.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptIdentifiers.spec.js
@@ -1,8 +1,95 @@
 // @flow
 import {
   isAllowedInIdentifier,
+  isNameSafe,
   containsNameUsedAsIdentifier,
 } from './EventScriptIdentifiers';
+
+const gd: libGDevelop = global.gd;
+
+// A corpus of tricky names checked against the REAL C++ implementation
+// (`gd.Project.isNameSafe`, compiled to wasm): a change to
+// `GrammarTerminals.h` not mirrored in the JavaScript ports makes this test
+// fail. Keep it in sync with the same corpus in
+// `generation-api/src/lib/__tests__/gdevelop-identifiers.spec.js`
+// (GDevelop-services repository, which cannot call the wasm and pins the
+// same expectations explicitly).
+const trickyNames = [
+  // Safe names:
+  'A',
+  'a',
+  '_',
+  'MyObject',
+  'abc5',
+  'My_Object_2',
+  'Héros',
+  'SuperHéros',
+  'Pièce_dorée',
+  'Œuf',
+  '名前',
+  'valid_名称',
+  '🙂',
+  'emoji🙂name',
+  // The first character must not be an (ASCII) digit:
+  '5',
+  '5abc',
+  '9lives',
+  // Unicode digits are NOT considered digits (neither by the C++ `isdigit`
+  // nor by the JavaScript `parseInt`):
+  '٥name',
+  '５fullwidth',
+  // A tab is NOT part of the grammar whitespaces (space, \n, \r): a name
+  // containing one is allowed.
+  'a\tb',
+  // Empty:
+  '',
+  // Grammar whitespaces:
+  'My Object',
+  'a\nb',
+  'a\rb',
+  // Every reserved character of the grammar:
+  'a,b',
+  'a.b',
+  'a"b',
+  'a(b',
+  'a)b',
+  'a[b',
+  'a]b',
+  'a{b',
+  'a}b',
+  'a+b',
+  'a-b',
+  'a<b',
+  'a>b',
+  'a?b',
+  'a^b',
+  'a=b',
+  'a\\b',
+  'a:b',
+  'a!b',
+  'a/b',
+  'a*b',
+  'a~b',
+  "a'b",
+  'a%b',
+  'a#b',
+  'a@b',
+  'a|b',
+  'a&b',
+  'a`b',
+  'a$b',
+  'a;b',
+];
+
+describe('conformance with the C++ GrammarTerminals (via libGD.js)', () => {
+  it('isNameSafe agrees with gd.Project.isNameSafe on every tricky name', () => {
+    for (const name of trickyNames) {
+      expect(`${JSON.stringify(name)} -> ${String(isNameSafe(name))}`).toBe(
+        `${JSON.stringify(name)} -> ${String(gd.Project.isNameSafe(name))}`
+      );
+    }
+  });
+});
 
 describe('isAllowedInIdentifier', () => {
   it('allows any unicode character except the grammar separators', () => {

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptRenderer.fixtures.json
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptRenderer.fixtures.json
@@ -243,6 +243,45 @@
       "expectedEventScript": ["group \"Empty group\":", "  pass"]
     },
     {
+      "name": "unicode identifiers (objects, variables, iterators) are preserved",
+      "parsesBack": true,
+      "serializedEvents": [
+        {
+          "type": "BuiltinCommonInstructions::ForEach",
+          "object": "Héros",
+          "conditions": [],
+          "actions": [
+            { "type": { "value": "Delete" }, "parameters": ["Héros", ""] }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "variables": [
+            { "name": "Vitesse_éclair", "type": "number", "value": "3" }
+          ],
+          "conditions": [],
+          "actions": [{ "type": { "value": "Wait" }, "parameters": ["1"] }]
+        },
+        {
+          "type": "BuiltinCommonInstructions::ForEachChildVariable",
+          "iterableVariableName": "Inventaire",
+          "valueIteratorVariableName": "Objet",
+          "keyIteratorVariableName": "",
+          "conditions": [],
+          "actions": []
+        }
+      ],
+      "expectedEventScript": [
+        "for each Héros:",
+        "  Delete(Héros)",
+        "always:",
+        "  local number Vitesse_éclair = 3",
+        "  Wait(1)",
+        "for each child in Inventaire value Objet:",
+        "  pass"
+      ]
+    },
+    {
       "name": "unknown instruction and non-representable event",
       "parsesBack": true,
       "serializedEvents": [

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptSourceView.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptSourceView.js
@@ -5,6 +5,7 @@ import {
   renderEventScriptHeaderLine,
   type EventScriptRenderingError,
 } from './EventScriptRenderer';
+import { containsNameUsedAsIdentifier } from './EventScriptIdentifiers';
 
 const gd: libGDevelop = global.gd;
 
@@ -124,11 +125,6 @@ export const renderEventSourceById = ({
     subEventsDepth: Number.MAX_SAFE_INTEGER,
     renderingErrors,
   }).join('\n');
-};
-
-const makeWordBoundaryRegex = (name: string): RegExp => {
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`(^|[^A-Za-z0-9_])${escaped}($|[^A-Za-z0-9_])`);
 };
 
 /**
@@ -326,7 +322,7 @@ export const buildEventScriptSourceView = ({
   let selectedPaths: Array<string> = [];
   if (hasSearch) {
     const lowerCaseSearchText = searchText ? searchText.toLowerCase() : null;
-    const objectNameRegexes = (objectNames || []).map(makeWordBoundaryRegex);
+    const filterObjectNames = objectNames || [];
     const isInScope = (path: string) =>
       !hasEventIds ||
       scopeRootPaths.some(
@@ -343,8 +339,13 @@ export const buildEventScriptSourceView = ({
         continue;
       }
       if (
-        objectNameRegexes.length > 0 &&
-        !objectNameRegexes.some(regex => regex.test(ownText))
+        filterObjectNames.length > 0 &&
+        !filterObjectNames.some(objectName =>
+          // Object names can contain any unicode character allowed by
+          // GDevelop identifiers: a plain `\b`-style regex boundary would
+          // not work, use the identifier-aware matching.
+          containsNameUsedAsIdentifier(ownText, objectName)
+        )
       ) {
         continue;
       }

--- a/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptSourceView.spec.js
+++ b/newIDE/app/src/EventsSheet/EventsTree/TextRenderer/EventScriptSourceView.spec.js
@@ -130,6 +130,39 @@ describe('EventScriptSourceView', () => {
     }
   });
 
+  it('filters by object names with unicode identifiers (whole-name matches only)', () => {
+    const { project } = makeTestProject(gd);
+    try {
+      const eventsList = makeEventsList(project, [
+        {
+          type: 'BuiltinCommonInstructions::Standard',
+          conditions: [],
+          actions: [{ type: { value: 'Delete' }, parameters: ['Héros', ''] }],
+        },
+        {
+          type: 'BuiltinCommonInstructions::Standard',
+          conditions: [],
+          actions: [
+            { type: { value: 'Delete' }, parameters: ['SuperHéros', ''] },
+          ],
+        },
+      ]);
+
+      const view = buildEventScriptSourceView({
+        eventsList,
+        objectNames: ['Héros'],
+        maxChars: 10000,
+      });
+
+      // "SuperHéros" must NOT match the object name "Héros": identifier
+      // boundaries are unicode-aware, not ASCII `\b` ones.
+      expect(view.selectedEventIds).toEqual(['event-0']);
+      expect(view.text).toContain('Delete(Héros)');
+    } finally {
+      project.delete();
+    }
+  });
+
   it('renders the source of one event by id (own lines, or the full subtree)', () => {
     const { project } = makeTestProject(gd);
     try {


### PR DESCRIPTION
GDevelop identifiers can contain any unicode character except the ones reserved by the expressions grammar (GrammarTerminals.h), but the read_events_source object-name filter used an ASCII [A-Za-z0-9_] word boundary: objects named like "Héros" could match or miss incorrectly.
