### PR TITLE
Mention the Android file formats AAB & APK in the export dialog.

### DIFF
--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineCordovaExport.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineCordovaExport.js
@@ -57,7 +57,8 @@ export const SetupExportHeader = ({
             control={<Radio color="secondary" disabled={isExporting} />}
             label={
               <Trans>
-                APK (for testing on device or sharing outside Google Play)
+                .apk - Android Package Kit (for testing on device or sharing
+                outside Google Play)
               </Trans>
             }
           />
@@ -65,7 +66,9 @@ export const SetupExportHeader = ({
             value={'androidAppBundle'}
             control={<Radio color="secondary" disabled={isExporting} />}
             label={
-              <Trans>Android App Bundle (for publishing on Google Play)</Trans>
+              <Trans>
+                .aab - Android App Bundle (for publishing on Google Play)
+              </Trans>
             }
           />
         </RadioGroup>

--- a/newIDE/app/src/ExportAndShare/GenericExporters/OnlineCordovaExport.js
+++ b/newIDE/app/src/ExportAndShare/GenericExporters/OnlineCordovaExport.js
@@ -57,8 +57,7 @@ export const SetupExportHeader = ({
             control={<Radio color="secondary" disabled={isExporting} />}
             label={
               <Trans>
-                .apk - Android Package Kit (for testing on device or sharing
-                outside Google Play)
+                APK (for testing on device or sharing outside Google Play)
               </Trans>
             }
           />
@@ -67,7 +66,7 @@ export const SetupExportHeader = ({
             control={<Radio color="secondary" disabled={isExporting} />}
             label={
               <Trans>
-                .aab - Android App Bundle (for publishing on Google Play)
+                Android App Bundle (.AAB file, for publishing on Google Play)
               </Trans>
             }
           />


### PR DESCRIPTION
Add more details about Android file formats; I saw a user who couldn't find the .aab file even though it already exists.

Before:
<img width="945" height="783" alt="image" src="https://github.com/user-attachments/assets/e6aa073e-c618-43dc-80d7-f97345a8f57a" />


This PR:
<img width="947" height="790" alt="image" src="https://github.com/user-attachments/assets/833a2abd-0085-42d0-8ff0-df21af67f9f5" />
