### PR TITLE
Search assets by their author name in the asset store

### DIFF
--- a/newIDE/app/src/AssetStore/AssetStoreContext.js
+++ b/newIDE/app/src/AssetStore/AssetStoreContext.js
@@ -150,7 +150,11 @@ const getAssetShortHeaderSearchTerms = (assetShortHeader: AssetShortHeader) => {
 };
 
 const getPublicAssetPackSearchTerms = (assetPack: PublicAssetPack) =>
-  assetPack.name + '\n' + assetPack.tag;
+  assetPack.name +
+  '\n' +
+  assetPack.tag +
+  '\n' +
+  assetPack.authors.map(author => author.name).join(', ');
 
 const getPrivateAssetPackListingDataSearchTerms = (
   privateAssetPack: PrivateAssetPackListingData
@@ -471,9 +475,42 @@ export const AssetStoreStateProvider = ({
 
   const currentPage = shopNavigationState.getCurrentPage();
   const { chosenCategory, chosenFilters } = currentPage.filtersState;
+
+  // Map each public asset pack tag to its authors' names. The author is not
+  // stored on the asset short header itself, but assets inherit the authors of
+  // their pack (identified by the asset's first tag), so this lets assets be
+  // searched by their author's name.
+  const authorNamesByAssetPackTag = React.useMemo<{ [string]: string }>(
+    () => {
+      const authorNamesByTag: { [string]: string } = {};
+      if (publicAssetPacks) {
+        publicAssetPacks.starterPacks.forEach(assetPack => {
+          if (assetPack.authors.length > 0) {
+            authorNamesByTag[assetPack.tag] = assetPack.authors
+              .map(author => author.name)
+              .join(', ');
+          }
+        });
+      }
+      return authorNamesByTag;
+    },
+    [publicAssetPacks]
+  );
+  const getAssetShortHeaderSearchTermsWithAuthors = React.useCallback(
+    (assetShortHeader: AssetShortHeader) => {
+      const searchTerms = getAssetShortHeaderSearchTerms(assetShortHeader);
+      const assetPackTag = assetShortHeader.tags[0];
+      const authorNames = assetPackTag
+        ? authorNamesByAssetPackTag[assetPackTag]
+        : null;
+      return authorNames ? searchTerms + '\n' + authorNames : searchTerms;
+    },
+    [authorNamesByAssetPackTag]
+  );
+
   const assetShortHeadersSearchResults: ?Array<AssetShortHeader> = useSearchItem(
     assetShortHeadersById,
-    getAssetShortHeaderSearchTerms,
+    getAssetShortHeaderSearchTermsWithAuthors,
     searchText,
     chosenCategory,
     chosenFilters,
@@ -597,7 +634,7 @@ export const AssetStoreStateProvider = ({
       ) =>
         useSearchItem(
           assetShortHeadersById,
-          getAssetShortHeaderSearchTerms,
+          getAssetShortHeaderSearchTermsWithAuthors,
           searchText,
           chosenCategory,
           chosenFilters,
@@ -625,6 +662,7 @@ export const AssetStoreStateProvider = ({
       clearAllFilters,
       getAssetShortHeaderFromId,
       assetShortHeadersById,
+      getAssetShortHeaderSearchTermsWithAuthors,
     ]
   );
 


### PR DESCRIPTION
Let users find assets by typing an author's name in the asset store search bar.

Before/ This PR
<img width="3840" height="904" alt="image" src="https://github.com/user-attachments/assets/de12b67c-6316-4797-a17a-5a14b7648bb9" />

<img width="3840" height="907" alt="image" src="https://github.com/user-attachments/assets/45354f43-1f67-4422-a958-c63d3298295a" />

