### PR TITLE
Report the behavior name add_behavior assigned

### DIFF
--- a/newIDE/app/src/EditorFunctions/ScriptExecution/TypedOutputsConformance.spec.js
+++ b/newIDE/app/src/EditorFunctions/ScriptExecution/TypedOutputsConformance.spec.js
@@ -24,6 +24,7 @@ const TESTED_TYPED_FUNCTION_NAMES = [
   'inspect_scene_properties_layers_effects',
   'inspect_project_properties_resources',
   'read_events_source',
+  'add_behavior',
 ];
 
 const sharedTypes = schemasFixture.sharedOutputTypes;
@@ -187,6 +188,53 @@ describe('typed outputs conformance (script API declared reads)', () => {
     );
     expect(result.success).toBe(true);
     validateResultAgainstSchema(result, 'inspect_project_properties_resources');
+  });
+
+  // The only declared WRITE: `add_behavior` picks the behavior name, so a script
+  // can only chain on it if the call reports it.
+  it('add_behavior output conforms and reports the name it assigned', async () => {
+    const result: EditorFunctionGenericOutput = await editorFunctions.add_behavior.launchFunction(
+      {
+        ...makeFakeLaunchFunctionOptionsWithProject(project),
+        args: {
+          scene_name: 'TestScene',
+          object_name: 'Player',
+          behavior_type: 'DestroyOutsideBehavior::DestroyOutside',
+        },
+      }
+    );
+    expect(result.success).toBe(true);
+    validateResultAgainstSchema(result, 'add_behavior');
+    // The reported name is the one the behavior really got on the object, so it
+    // can be passed straight to `change_behavior_property`.
+    const [added] = result.addedBehaviors || [];
+    expect(added.objectName).toBe('Player');
+    expect(added.behaviorType).toBe('DestroyOutsideBehavior::DestroyOutside');
+    expect(
+      testScene
+        .getObjects()
+        .getObject('Player')
+        .hasBehaviorNamed(added.behaviorName)
+    ).toBe(true);
+  });
+
+  it('add_behavior reports the name of a behavior that was already there', async () => {
+    const args = {
+      scene_name: 'TestScene',
+      object_name: 'Player',
+      behavior_type: 'DestroyOutsideBehavior::DestroyOutside',
+    };
+    const first: EditorFunctionGenericOutput = await editorFunctions.add_behavior.launchFunction(
+      { ...makeFakeLaunchFunctionOptionsWithProject(project), args }
+    );
+    const second: EditorFunctionGenericOutput = await editorFunctions.add_behavior.launchFunction(
+      { ...makeFakeLaunchFunctionOptionsWithProject(project), args }
+    );
+
+    expect(second.success).toBe(true);
+    validateResultAgainstSchema(second, 'add_behavior');
+    // Re-running a script must give the same usable name, not an empty list.
+    expect(second.addedBehaviors).toEqual(first.addedBehaviors);
   });
 
   it('read_events_source output conforms', async () => {

--- a/newIDE/app/src/EditorFunctions/ScriptExecution/TypedOutputsSchemas.fixture.json
+++ b/newIDE/app/src/EditorFunctions/ScriptExecution/TypedOutputsSchemas.fixture.json
@@ -352,6 +352,38 @@
       "required": [
         "eventScript"
       ]
+    },
+    "add_behavior": {
+      "type": "object",
+      "openEnded": true,
+      "properties": {
+        "addedBehaviors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "openEnded": true,
+            "properties": {
+              "objectName": {
+                "type": "string"
+              },
+              "behaviorName": {
+                "type": "string"
+              },
+              "behaviorType": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "objectName",
+              "behaviorName",
+              "behaviorType"
+            ]
+          }
+        }
+      },
+      "required": [
+        "addedBehaviors"
+      ]
     }
   }
 }

--- a/newIDE/app/src/EditorFunctions/index.js
+++ b/newIDE/app/src/EditorFunctions/index.js
@@ -175,6 +175,13 @@ export type EditorFunctionGenericOutput = {|
   resources?: any,
   resourcesSummary?: any,
   behaviors?: Array<SimplifiedBehavior>,
+  // `add_behavior`: the behavior name the editor assigned, per object — a
+  // declared output type, because nothing else lets a script know it.
+  addedBehaviors?: Array<{|
+    objectName: string,
+    behaviorName: string,
+    behaviorType: string,
+  |}>,
   variables?: Array<SimplifiedVariable>,
   reminder?: string,
   animationNames?: string,
@@ -2612,6 +2619,22 @@ const addBehavior: EditorFunction = {
 
     const changes = [];
     const warnings = [];
+    // The behavior NAME the editor assigned, per object: a script cannot guess
+    // it (there is no argument to impose one) and needs it to call the behavior
+    // functions afterwards. Reported as a declared output type, so a script does
+    // not have to read it back with `inspect_object_properties_effects`.
+    const addedBehaviors: Array<{|
+      objectName: string,
+      behaviorName: string,
+      behaviorType: string,
+    |}> = [];
+    const reportBehaviorOnObject = (objectName: string) => {
+      addedBehaviors.push({
+        objectName,
+        behaviorName,
+        behaviorType: behavior_type,
+      });
+    };
     for (const object of concerned.objects) {
       const objectName = object.getName();
 
@@ -2626,6 +2649,8 @@ const addBehavior: EditorFunction = {
           changes.push(
             `Behavior "${behaviorName}" already on "${objectName}".`
           );
+          // Already there: a script chaining on the name must still get it.
+          reportBehaviorOnObject(objectName);
         }
         continue;
       }
@@ -2641,6 +2666,7 @@ const addBehavior: EditorFunction = {
           changes.push(
             `Behavior "${behaviorName}" (type "${behavior_type}") is a default capability already on "${objectName}".`
           );
+          reportBehaviorOnObject(objectName);
         } else {
           warnings.push(
             `Behavior "${behaviorName}" (type "${behavior_type}") is a default capability; cannot be added to "${objectName}".`
@@ -2679,10 +2705,14 @@ const addBehavior: EditorFunction = {
           behavior.getProperties()
         )}.`
       );
+      reportBehaviorOnObject(objectName);
     }
     layout.updateBehaviorsSharedData(project);
 
-    return makeMultipleChangesOutput(changes, warnings, toolsVersion);
+    return {
+      ...makeMultipleChangesOutput(changes, warnings, toolsVersion),
+      addedBehaviors,
+    };
   },
   modifiesProject: true,
 };


### PR DESCRIPTION
So a script can chain on the assigned name instead of reading it back with an `inspect_*` call or guessing it.