### PR TITLE
feat: Support binary Spine (.skel) skeleton imports alongside JSON

### DIFF
--- a/Extensions/Spine/SpineObjectConfiguration.cpp
+++ b/Extensions/Spine/SpineObjectConfiguration.cpp
@@ -54,7 +54,7 @@ SpineObjectConfiguration::GetProperties() const {
       .SetValue(spineResourceName)
       .SetType("resource")
       .AddExtraInfo("spine")
-      .SetLabel(_("Spine json"));
+      .SetLabel(_("Spine skeleton"));
 
   objectProperties["skinName"]
       .SetValue(skinName)

--- a/newIDE/app/src/EventsSheet/ParameterFields/SpineResourceField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/SpineResourceField.js
@@ -39,7 +39,7 @@ export default (React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
         fullWidth
         initialResourceName={props.value}
         onChange={props.onChange}
-        floatingLabelText={<Trans>Choose the spine json file to use</Trans>}
+        floatingLabelText={<Trans>Choose the spine skeleton file to use</Trans>}
         onRequestClose={props.onRequestClose}
         onApply={props.onApply}
         ref={field}

--- a/newIDE/app/src/EventsSheet/ParameterRenderingService.js
+++ b/newIDE/app/src/EventsSheet/ParameterRenderingService.js
@@ -204,7 +204,7 @@ const userFriendlyTypeName: { [string]: MessageDescriptor } = {
   jsonResource: t`JSON resource`,
   tilemapResource: t`Tile map resource`,
   atlasResource: t`Atlas resource`,
-  spineResource: t`Spine json resource`,
+  spineResource: t`Spine skeleton resource`,
   color: t`Color`,
   forceMultiplier: t`Instant or permanent force`,
   sceneName: t`Scene name`,

--- a/newIDE/app/src/ResourcesList/FileToCloudProjectResourceUploader.js
+++ b/newIDE/app/src/ResourcesList/FileToCloudProjectResourceUploader.js
@@ -56,7 +56,11 @@ const resourceKindToInputAcceptedMimes = {
     // Same as above: .atlas files have no recognized mime type on iOS Safari, so the
     // 'file' pseudo-mime is used and validation happens post-picking.
   ],
-  spine: ['application/json'],
+  spine: [
+    'file',
+    // .skel has no recognized mime type; .json would be filtered out on iOS if mixed
+    // with application/json. Validation happens post-picking (json and skel).
+  ],
   javascript: ['text/javascript'],
 };
 

--- a/newIDE/app/src/ResourcesList/FileToCloudProjectResourceUploader.spec.js
+++ b/newIDE/app/src/ResourcesList/FileToCloudProjectResourceUploader.spec.js
@@ -35,7 +35,7 @@ describe('FileToCloudProjectResourceUploader', () => {
       `"file"`
     );
     expect(getInputAcceptedMimesAndExtensions('spine')).toMatchInlineSnapshot(
-      `"application/json,.json"`
+      `"file"`
     );
   });
 });

--- a/newIDE/app/src/ResourcesList/LocalEmbeddedResourceSources.js
+++ b/newIDE/app/src/ResourcesList/LocalEmbeddedResourceSources.js
@@ -234,7 +234,7 @@ export async function listSpineEmbeddedResources(
 ): Promise<?EmbeddedResources> {
   if (!fs || !path) return null;
 
-  const atlasPath = filePath.replace('.json', '.atlas');
+  const atlasPath = filePath.replace(/\.(json|skel)$/i, '.atlas');
   const hasAtlasWithSameBasename = await new Promise<boolean>(resolve => {
     fs.promises
       .access(atlasPath, fs.constants.F_OK)
@@ -243,7 +243,7 @@ export async function listSpineEmbeddedResources(
   });
 
   // Spine resources usually have the same base names:
-  // e.g. skeleton.json, skeleton.atlas and skeleton.png.
+  // e.g. skeleton.json or skeleton.skel, skeleton.atlas and skeleton.png.
   if (!hasAtlasWithSameBasename) {
     console.error(`Could not find an atlas file for Spine file ${filePath}.`);
     return null;

--- a/newIDE/app/src/ResourcesList/ResourceSource.js
+++ b/newIDE/app/src/ResourcesList/ResourceSource.js
@@ -101,8 +101,8 @@ export const allResourceKindsAndMetadata = [
   },
   {
     kind: 'spine',
-    displayName: (t`Spine Json`: any),
-    fileExtensions: ['json'],
+    displayName: (t`Spine skeleton`: any),
+    fileExtensions: ['json', 'skel'],
     createNewResource: (): gdSpineResource => {
       return new gd.SpineResource();
     },


### PR DESCRIPTION
## Summary

Extend Spine resource support in the IDE so binary `.skel` skeletons can be imported and selected alongside JSON. The runtime already loads both formats; this PR updates file pickers, cloud import validation, and embedded atlas discovery.

## Changes

- Add `skel` to accepted extensions for `spine` resources (Electron dialog + post-picking validation on Cloud).
- Resolve companion `.atlas` files for both `.json` and `.skel` imports (same basename).
- Rename user-facing labels from “Spine json” to “Spine skeleton”.