### PR TITLE
Fix cached images not appearing in ImageWithFallback

### DIFF
--- a/newIDE/app/src/UI/CorsAwareImage.js
+++ b/newIDE/app/src/UI/CorsAwareImage.js
@@ -11,6 +11,7 @@ type Props = {|
   onError?: (?Error) => void,
   onLoad?: (e: any) => void,
   loading?: 'lazy',
+  imageRef?: { current: HTMLImageElement | null },
 |};
 
 const addSearchParameterToUrl = (
@@ -38,6 +39,7 @@ const addSearchParameterToUrl = (
  */
 export const CorsAwareImage = ({
   src,
+  imageRef,
   ...props
 }: Props): React.MixedElement => {
   const correctedSrc =
@@ -64,6 +66,7 @@ export const CorsAwareImage = ({
   return (
     <img // eslint-disable-line jsx-a11y/alt-text
       {...props}
+      ref={imageRef}
       src={correctedSrc}
     />
   );

--- a/newIDE/app/src/UI/ImageWithFallback.js
+++ b/newIDE/app/src/UI/ImageWithFallback.js
@@ -46,7 +46,7 @@ export const ImageWithFallback = ({
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const [hasError, setHasError] = React.useState(false);
   const [isLoaded, setIsLoaded] = React.useState(false);
-  const imgRef = React.useRef<?HTMLImageElement>(null);
+  const imageRef = React.useRef<HTMLImageElement | null>(null);
 
   // Reset the loading/error state if the source changes (e.g. when navigating
   // through a carousel, or when a tile is reused in a list).
@@ -62,13 +62,17 @@ export const ImageWithFallback = ({
   // which don't trigger onLoad event in browsers).
   React.useEffect(
     () => {
-      const img = imgRef.current;
-      if (!img) return;
+      const image = imageRef.current;
+      if (!image) return;
 
       // If image is already in browser cache, `complete` will be true and
       // onLoad won't fire, so we need to manually check and update state.
-      if (img.complete && !hasError) {
-        setIsLoaded(true);
+      if (image.complete && !hasError) {
+        if (image.naturalWidth > 0) {
+          setIsLoaded(true);
+        } else {
+          setHasError(true);
+        }
       }
     },
     [src, hasError]
@@ -99,7 +103,7 @@ export const ImageWithFallback = ({
   return (
     <CorsAwareImage
       {...props}
-      ref={imgRef}
+      imageRef={imageRef}
       src={src}
       alt={alt}
       // Keep the image invisible until it has successfully loaded, so the

--- a/newIDE/app/src/UI/ImageWithFallback.js
+++ b/newIDE/app/src/UI/ImageWithFallback.js
@@ -46,6 +46,7 @@ export const ImageWithFallback = ({
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const [hasError, setHasError] = React.useState(false);
   const [isLoaded, setIsLoaded] = React.useState(false);
+  const imgRef = React.useRef<?HTMLImageElement>(null);
 
   // Reset the loading/error state if the source changes (e.g. when navigating
   // through a carousel, or when a tile is reused in a list).
@@ -55,6 +56,22 @@ export const ImageWithFallback = ({
       setIsLoaded(false);
     },
     [src]
+  );
+
+  // Check if the image is already loaded (important for cached images,
+  // which don't trigger onLoad event in browsers).
+  React.useEffect(
+    () => {
+      const img = imgRef.current;
+      if (!img) return;
+
+      // If image is already in browser cache, `complete` will be true and
+      // onLoad won't fire, so we need to manually check and update state.
+      if (img.complete && !hasError) {
+        setIsLoaded(true);
+      }
+    },
+    [src, hasError]
   );
 
   if (hasError || !src) {
@@ -82,6 +99,7 @@ export const ImageWithFallback = ({
   return (
     <CorsAwareImage
       {...props}
+      ref={imgRef}
       src={src}
       alt={alt}
       // Keep the image invisible until it has successfully loaded, so the


### PR DESCRIPTION
Fix a race condition because of the cache.
Images loaded from browser cache don't trigger the onLoad event, causing opacity to remain at 0 and images to be invisible.

https://github.com/4ian/GDevelop/blob/bfb60b4e2a55ac5d22a800b599593e66fda0f72f/newIDE/app/src/UI/ImageWithFallback.js#L83-L98
<img width="1900" height="665" alt="image" src="https://github.com/user-attachments/assets/8abfd350-efa6-41b5-8034-8ba69726dbf4" />

## Solution  
Check the img.complete property to detect cached images and set isLoaded state.
Works for both fresh loads and cached images.


