### PR TITLE
Gameplay tests: only render a few times per second in fast runs

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -286,6 +286,9 @@ namespace gdjs {
       status: 'passed' | 'failed' | 'error' | 'stopped' | 'timeout';
       framesExecuted: integer;
       durationMs: number;
+      /** The wall-clock budget the run had (`durationMs` close to it means
+       * the test is at risk of timing out on a slower machine). */
+      timeoutMs: number;
       gameTimeMs: number;
       assertions: Array<GameplayTestAssertion>;
       errors: Array<string>;
@@ -314,6 +317,8 @@ namespace gdjs {
      * the game visibly plays (a rendered frame per refresh), stop/progress
      * messages flow, while keeping near-full stepping throughput. */
     const YIELD_BUDGET_MS = 12;
+    // In fast (unpaced) runs, let the game render at most this often.
+    const FAST_RUN_RENDER_INTERVAL_MS = 250;
     const DEFAULT_MAX_SCREENSHOTS = 5;
     const DEFAULT_PROBE_FRAMES = 30;
     const MAX_PROFILING_SECTIONS = 50;
@@ -502,6 +507,8 @@ namespace gdjs {
       /** Last time the stepping loop yielded to the browser (see
        * `_maybeYield`). */
       _lastYieldTimeMs: number = 0;
+      /** The last time an animation frame was awaited (rendering the game). */
+      _lastRenderTimeMs: number = 0;
       /** Game seconds simulated per real second, or null to run as fast
        * as possible (see `_maybeYield`). */
       _paceSpeedFactor: float | null = null;
@@ -749,7 +756,21 @@ namespace gdjs {
           this._paceReferenceGameTimeMs = this._gameTimeMs;
         }
         if (Date.now() - this._lastYieldTimeMs < YIELD_BUDGET_MS) return;
-        await this._waitForNextAnimationFrame();
+        // Fast (unpaced) run: don't wait for an animation frame at every
+        // yield - with a slow renderer (software WebGL...), rendering would
+        // dominate the wall-clock time of the run. Yield through a timer
+        // (pending events, like a stop request, are still processed) and
+        // only let an animation frame - which renders the game - happen a
+        // few times per second.
+        if (
+          Date.now() - this._lastRenderTimeMs >=
+          FAST_RUN_RENDER_INTERVAL_MS
+        ) {
+          await this._waitForNextAnimationFrame();
+          this._lastRenderTimeMs = Date.now();
+        } else {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        }
         this._lastYieldTimeMs = Date.now();
       }
 
@@ -1977,6 +1998,10 @@ namespace gdjs {
           );
           return;
         }
+        // Let an animation frame happen so the canvas shows the current
+        // state of the game (fast runs only render a few times per second).
+        await this._waitForNextAnimationFrame();
+        this._lastRenderTimeMs = Date.now();
         const canvas = this._runtimeGame.getRenderer().getCanvas();
         if (!canvas) {
           logger.warn('No canvas found: unable to take a screenshot.');
@@ -2272,6 +2297,7 @@ namespace gdjs {
           status,
           framesExecuted: this._framesExecuted,
           durationMs: this._startTimeMs ? Date.now() - this._startTimeMs : 0,
+          timeoutMs: this._timeoutMs,
           gameTimeMs: Math.round(this._gameTimeMs),
           assertions: this._assertions,
           errors: errors.slice(0, MAX_ERRORS),

--- a/GDJS/tests/tests/gameplaytestharness.js
+++ b/GDJS/tests/tests/gameplaytestharness.js
@@ -137,6 +137,7 @@ describe('gdjs.gameplayTests', () => {
     );
 
     expect(result.status).to.be('passed');
+    expect(result.timeoutMs).to.be(5000);
     expect(result.framesExecuted).to.be(6); // 1 (goToScene) + 5.
     expect(result.assertions.length).to.be(1);
     expect(result.assertions[0].passed).to.be(true);

--- a/newIDE/app/src/GameplayTests/GameplayTestRunner.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestRunner.js
@@ -40,6 +40,9 @@ export type GameplayTestResult = {
   status: 'passed' | 'failed' | 'error' | 'stopped' | 'timeout',
   framesExecuted: number,
   durationMs: number,
+  // The wall-clock budget the run had (a duration close to it means the
+  // test is at risk of timing out on a slower machine).
+  timeoutMs: number,
   gameTimeMs: number,
   assertions: Array<GameplayTestAssertion>,
   errors: Array<string>,
@@ -151,6 +154,7 @@ const makeResultWithoutRun = (
   status,
   framesExecuted: 0,
   durationMs: 0,
+  timeoutMs: 0,
   gameTimeMs: 0,
   assertions: [],
   errors: [errorMessage],
@@ -178,6 +182,7 @@ export const makeGameplayTestResultReadableOutput = (
   testName: result.testName,
   framesExecuted: result.framesExecuted,
   durationMs: result.durationMs,
+  timeoutMs: result.timeoutMs,
   gameTimeMs: result.gameTimeMs,
   assertions: result.assertions,
   errors: result.errors,

--- a/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
+++ b/newIDE/app/src/MainFrame/LocalCliCommandRunner.js
@@ -239,13 +239,28 @@ const runners: { [commandName: string]: CliCommandRunner } = {
     for (const result of results) {
       const passed = result.status === 'passed';
       if (!passed) failedCount++;
+      const budgetText = result.timeoutMs
+        ? `, ${(result.durationMs / 1000).toFixed(1)}s / ${result.timeoutMs /
+            1000}s budget`
+        : '';
       console.info(
         `[CLI] ${passed ? 'PASSED' : 'FAILED'} (${result.status}): ${
           result.testName
-        } (${result.framesExecuted} frames, ${Math.round(
-          result.durationMs
-        )}ms)${result.errors.length ? ' - ' + result.errors.join(' | ') : ''}`
+        } (${result.framesExecuted} frames${budgetText})${
+          result.errors.length ? ' - ' + result.errors.join(' | ') : ''
+        }`
       );
+      if (
+        passed &&
+        result.timeoutMs &&
+        result.durationMs >= 0.8 * result.timeoutMs
+      ) {
+        console.warn(
+          `[CLI] WARNING: "${result.testName}" used ${Math.round(
+            (100 * result.durationMs) / result.timeoutMs
+          )}% of its wall-clock budget - it is at risk of timing out on a slower machine. Shorten it or raise its timeout.`
+        );
+      }
     }
     try {
       const resultsPath = writeCliGameplayTestResults(project, results);

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestProperties.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestProperties.stories.js
@@ -73,6 +73,7 @@ const makeResult = (
   status: 'passed',
   framesExecuted: 0,
   durationMs: 0,
+  timeoutMs: 0,
   gameTimeMs: 0,
   assertions: [],
   errors: [],


### PR DESCRIPTION
Fast (unpaced) runs no longer wait for an animation frame at every yield: profiling on headless CI showed stepping was 1-2% of the wall clock, the rest being renders performed while waiting on `requestAnimationFrame` with software WebGL (85-300ms per stepped frame). Fast runs now yield through a timer (stop requests and pending events are still processed) and only let an animation frame - which renders the game - happen every 250ms, plus a forced render before every screenshot. Paced runs (1x/4x, watched by a human) are untouched.

Also:
- The result now carries `timeoutMs` (the wall-clock budget the run had), including in the output read by the AI.
- The CLI prints the budget use per test (`4.8s / 30s budget`) and warns when a passing test used 80%+ of its ceiling - such a test is one slow machine away from a flaky timeout (this happened on CI: passed locally at 27.6s, timed out at 30.1s on CI).

Validated: GDJS type-check and build clean, gameplay harness karma suite 30/30 (stepping is deterministic, so existing tests are unaffected - just faster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b)_