### PR TITLE
Gameplay tests: measure FPS aiming on the layer camera, fix mouse position on 3D layers

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -262,6 +262,9 @@ namespace gdjs {
       pitchDiff: float;
       sawYawResponse: boolean;
       sawPitchResponse: boolean;
+      /** What the aim was measured on: the camera of the object's layer
+       * (first-person views) or the object's own rotations. */
+      measuredFrom: 'camera' | 'object';
     };
 
     export type GameplayTestProgressStatus = {
@@ -955,10 +958,52 @@ namespace gdjs {
           throw new Error(`The layer "${layerName}" does not exist.`);
         }
         const layer = currentScene.getLayer(layerName);
-        const screenPosition = layer.convertInverseCoords(x, y, 0, [0, 0]);
+        const screenPosition = this._convertSceneToScreenPosition(layer, x, y);
         this._runtimeGame
           .getInputManager()
           .onMouseMove(screenPosition[0], screenPosition[1]);
+      }
+
+      /**
+       * Convert a position in scene coordinates of a layer to screen
+       * coordinates - through the actual 3D camera when the layer has a
+       * 3D-rotated one: the engine's 2D conversion
+       * (`convertInverseCoords`) does not handle 3D rotations, while games
+       * read the cursor back through the 3D-aware `convertCoords`, so the
+       * 2D conversion would place the cursor somewhere else than asked.
+       * TODO: this inversion belongs in GDJS itself
+       * (`RuntimeLayer.convertInverseCoords`), so that every consumer gets
+       * the right conversion - do it there and remove this.
+       */
+      private _convertSceneToScreenPosition(
+        layer: gdjs.RuntimeLayer,
+        x: float,
+        y: float
+      ): FloatPoint {
+        if (
+          Math.abs(layer.getCameraRotationX()) > 0.001 ||
+          Math.abs(layer.getCameraRotationY()) > 0.001
+        ) {
+          const renderer = layer.getRenderer() as any;
+          const threeCamera =
+            renderer && typeof renderer.getThreeCamera === 'function'
+              ? renderer.getThreeCamera()
+              : null;
+          if (threeCamera && typeof THREE !== 'undefined') {
+            threeCamera.updateMatrixWorld();
+            // The three.js world Y axis is the opposite of the scene one
+            // (see `transformTo3DWorld`, the inverse of this projection).
+            const vector = new THREE.Vector3(x, -y, 0);
+            vector.project(threeCamera);
+            if (Number.isFinite(vector.x) && Number.isFinite(vector.y)) {
+              return [
+                ((vector.x + 1) / 2) * layer.getWidth(),
+                ((1 - vector.y) / 2) * layer.getHeight(),
+              ];
+            }
+          }
+        }
+        return layer.convertInverseCoords(x, y, 0, [0, 0]);
       }
 
       /**
@@ -1032,7 +1077,7 @@ namespace gdjs {
         layerName: string = ''
       ): void {
         const layer = this._getCurrentScene().getLayer(layerName);
-        const screenPosition = layer.convertInverseCoords(x, y, 0, [0, 0]);
+        const screenPosition = this._convertSceneToScreenPosition(layer, x, y);
         this._runtimeGame
           .getInputManager()
           .onTouchStart(identifier, screenPosition[0], screenPosition[1]);
@@ -1049,7 +1094,7 @@ namespace gdjs {
         layerName: string = ''
       ): void {
         const layer = this._getCurrentScene().getLayer(layerName);
-        const screenPosition = layer.convertInverseCoords(x, y, 0, [0, 0]);
+        const screenPosition = this._convertSceneToScreenPosition(layer, x, y);
         this._runtimeGame
           .getInputManager()
           .onTouchMove(identifier, screenPosition[0], screenPosition[1]);
@@ -1337,6 +1382,37 @@ namespace gdjs {
       }
 
       /**
+       * The camera of a layer (JSON-safe), or null if the layer does not
+       * exist. `angle` is the 2D rotation (the yaw of the view, same
+       * convention as object angles). `rotationX`/`rotationY` are the 3D
+       * camera rotations: `rotationX` is 0 looking straight down (the 2D
+       * default) and 90 at the horizon, so the pitch of a first-person
+       * view is `90 - rotationX`.
+       */
+      getCameraState(layerName: string = ''): {
+        x: float;
+        y: float;
+        z: float;
+        rotationX: float;
+        rotationY: float;
+        angle: float;
+        zoom: float;
+      } | null {
+        const currentScene = this._getCurrentScene();
+        if (!currentScene.hasLayer(layerName)) return null;
+        const layer = currentScene.getLayer(layerName);
+        return {
+          x: layer.getCameraX(),
+          y: layer.getCameraY(),
+          z: layer.getCameraZ(null),
+          rotationX: layer.getCameraRotationX(),
+          rotationY: layer.getCameraRotationY(),
+          angle: layer.getCameraRotation(),
+          zoom: layer.getCameraZoom(),
+        };
+      }
+
+      /**
        * The raw `gdjs.RuntimeObject` of an instance, or null if not found.
        * Behaviors can be reached with `getBehavior(behaviorName)` (also null
        * if not found). Prefer the harness APIs (snapshots, inputs...) -
@@ -1429,7 +1505,20 @@ namespace gdjs {
         target:
           | { name: string; id?: integer }
           | { x: float; y: float; z?: float },
-        options?: { reachRadius?: float }
+        options?: {
+          reachRadius?: float;
+          /** Measure from the camera of this layer (position, yaw and
+           * pitch) instead of the object: what a first-person view aims
+           * with. */
+          fromCamera?: string;
+          /** Measure from this Z instead of the object's center Z (an eye
+           * or muzzle height). */
+          fromZ?: float;
+          /** Compute `yawDiff` against this heading (in degrees) instead of
+           * the object's angle - for turrets and weapons with their own
+           * rotation. */
+          heading?: float;
+        }
       ): GameplayTestRelativePosition | null {
         const referenceInstances = this._getInstances(referenceObjectName);
         if (referenceInstances.length === 0) return null;
@@ -1440,13 +1529,23 @@ namespace gdjs {
 
         const reachRadius =
           (options && options.reachRadius) || DEFAULT_REACH_RADIUS;
+        const camera =
+          options && options.fromCamera !== undefined
+            ? this.getCameraState(options.fromCamera)
+            : null;
 
-        const referenceX = reference.getCenterXInScene();
-        const referenceY = reference.getCenterYInScene();
+        const referenceX =
+          camera !== null ? camera.x : reference.getCenterXInScene();
+        const referenceY =
+          camera !== null ? camera.y : reference.getCenterYInScene();
         const referenceZ =
-          typeof anyReference.getCenterZInScene === 'function'
-            ? anyReference.getCenterZInScene()
-            : undefined;
+          options && options.fromZ !== undefined
+            ? options.fromZ
+            : camera !== null
+              ? camera.z
+              : typeof anyReference.getCenterZInScene === 'function'
+                ? anyReference.getCenterZInScene()
+                : undefined;
 
         const relativeX = resolvedTarget.x - referenceX;
         const relativeY = resolvedTarget.y - referenceY;
@@ -1457,19 +1556,27 @@ namespace gdjs {
 
         const distance = Math.hypot(relativeX, relativeY, relativeZ || 0);
 
+        const currentYaw =
+          options && options.heading !== undefined
+            ? options.heading
+            : camera !== null
+              ? camera.angle
+              : reference.getAngle();
         const desiredAngle = gdjs.toDegrees(Math.atan2(relativeY, relativeX));
-        const yawDiff = normalizeAngleDifference(
-          desiredAngle - reference.getAngle()
-        );
+        const yawDiff = normalizeAngleDifference(desiredAngle - currentYaw);
         const horizontalDistance = Math.hypot(relativeX, relativeY);
         const desiredPitch =
           relativeZ === undefined
             ? 0
             : gdjs.toDegrees(Math.atan2(relativeZ, horizontalDistance));
+        // The pitch of a camera view: 90 - rotationX (rotationX is 0
+        // looking straight down, 90 at the horizon).
         const currentPitch =
-          typeof anyReference.getRotationX === 'function'
-            ? anyReference.getRotationX()
-            : 0;
+          camera !== null
+            ? 90 - camera.rotationX
+            : typeof anyReference.getRotationX === 'function'
+              ? anyReference.getRotationX()
+              : 0;
         const pitchDiff =
           relativeZ === undefined
             ? 0
@@ -1674,36 +1781,63 @@ namespace gdjs {
       /**
        * Turn the first instance of `referenceObjectName` toward the target,
        * by applying mouse movement deltas (FPS/pointer-lock style, yaw and
-       * pitch in 3D) until it is aiming at it. The mouse sensitivity of the
-       * game is measured and adapted to live, per axis. When the vertical
-       * aim shows no measurable response (some games map the pitch to
-       * another axis), the vertical input is undone and the aim falls back
-       * to yaw-only, reported as `sawPitchResponse: false`. Returns null if
-       * the object or the target is missing.
+       * pitch in 3D) until it is aiming at it. The aim is measured on the
+       * camera of the object's layer when it is a 3D one (the ground truth
+       * of a first-person view: right eye height, right rotations whatever
+       * the game drives to move it - see `measuredFrom` in the result),
+       * with a fallback to the object's own rotations. The mouse
+       * sensitivity and direction of the game are measured and adapted to
+       * live, per axis. When the vertical aim shows no measurable response,
+       * the vertical input is undone and the aim falls back to yaw-only,
+       * reported as `sawPitchResponse: false`. Returns null if the object
+       * or the target is missing.
        */
       async lookTowardWithMouseDelta(
         referenceObjectName: string,
         target:
           | { name: string; id?: integer }
           | { x: float; y: float; z?: float },
-        options?: { yawOnly?: boolean }
+        options?: { yawOnly?: boolean; fromCamera?: string }
       ): Promise<GameplayTestAimResult | null> {
         const maxAimFrames = 180;
         const toleranceDegrees = 3;
         const responseThresholdDegrees = 0.1;
         const maxPixelsPerDegree = 64;
-        // Frames tolerated with a pitch demand, a maxed-out gain and no
-        // measured response before giving up on the vertical aim.
-        const maxUnresponsivePitchFrames = 10;
+        // Frames tolerated with a demand on an axis, a maxed-out gain and
+        // no measured response, before reacting (giving up the vertical
+        // aim, or falling back from the camera to the object).
+        const maxUnresponsiveFrames = 10;
         // Pixels of mouse movement per degree of desired rotation: adapted
         // live (per axis) by measuring the actual rotation achieved.
         let yawPixelsPerDegree = 2;
         let pitchPixelsPerDegree = 2;
+        // Mouse direction giving a positive rotation on each axis: flipped
+        // when a measured response moves the aim away from the target.
+        let yawDirection = 1;
+        let pitchDirection = 1;
+
+        // Measure the aim on the camera of the object's layer (the ground
+        // truth of a first-person view: right eye height, right rotations
+        // whatever the game drives to move it) when it is a 3D camera, on
+        // the object's own rotations otherwise - falling back to the
+        // object if the camera turns out not to respond to the mouse.
+        const firstInstance = this._getInstances(referenceObjectName)[0];
+        if (!firstInstance) return null;
+        const objectLayerName =
+          options && options.fromCamera !== undefined
+            ? options.fromCamera
+            : firstInstance.getLayer();
+        const layerCamera = this.getCameraState(objectLayerName);
+        let aimOptions: { fromCamera?: string } =
+          layerCamera && Math.abs(layerCamera.rotationX) > 0.5
+            ? { fromCamera: objectLayerName }
+            : {};
 
         let sawYawResponse = false;
         let sawPitchResponse = false;
         let pitchGivenUp = false;
         let unresponsivePitchFrames = 0;
+        let unresponsiveYawFrames = 0;
         let appliedPitchPixels = 0;
 
         const clamp = (value: float, maximum: float) =>
@@ -1717,6 +1851,8 @@ namespace gdjs {
           pitchDiff: relativePosition.pitchDiff,
           sawYawResponse,
           sawPitchResponse,
+          measuredFrom:
+            aimOptions.fromCamera !== undefined ? 'camera' : 'object',
         });
 
         // Undo the vertical input applied so far: when the measured pitch
@@ -1735,7 +1871,8 @@ namespace gdjs {
         for (let i = 0; i < maxAimFrames; i++) {
           const relativePosition = this.getRelativePosition(
             referenceObjectName,
-            target
+            target,
+            aimOptions
           );
           if (!relativePosition) return null;
           lastRelativePosition = relativePosition;
@@ -1749,9 +1886,10 @@ namespace gdjs {
             return makeResult(true, relativePosition);
           }
 
-          const pitchDeltaPixels = clamp(pitchDiff * pitchPixelsPerDegree, 100);
+          const pitchDeltaPixels =
+            clamp(pitchDiff * pitchPixelsPerDegree, 100) * pitchDirection;
           this.setMouseDelta(
-            clamp(yawDiff * yawPixelsPerDegree, 100),
+            clamp(yawDiff * yawPixelsPerDegree, 100) * yawDirection,
             pitchDeltaPixels
           );
           appliedPitchPixels += pitchDeltaPixels;
@@ -1759,7 +1897,8 @@ namespace gdjs {
 
           const newRelativePosition = this.getRelativePosition(
             referenceObjectName,
-            target
+            target,
+            aimOptions
           );
           if (newRelativePosition) {
             const achievedYawRotation = Math.abs(
@@ -1767,15 +1906,44 @@ namespace gdjs {
             );
             if (achievedYawRotation >= responseThresholdDegrees) {
               sawYawResponse = true;
+              unresponsiveYawFrames = 0;
+              // The mouse turned the view AWAY from the target: the game
+              // maps this axis in the other direction.
+              if (
+                Math.abs(newRelativePosition.yawDiff) >
+                Math.abs(yawDiff) + responseThresholdDegrees
+              ) {
+                yawDirection = -yawDirection;
+              }
             }
             if (Math.abs(yawDiff) > toleranceDegrees) {
               if (achievedYawRotation < responseThresholdDegrees) {
                 // No response to the mouse: increase the gain (the game may
                 // have a low mouse sensitivity).
-                yawPixelsPerDegree = Math.min(
-                  yawPixelsPerDegree * 2,
-                  maxPixelsPerDegree
-                );
+                if (yawPixelsPerDegree < maxPixelsPerDegree) {
+                  yawPixelsPerDegree = Math.min(
+                    yawPixelsPerDegree * 2,
+                    maxPixelsPerDegree
+                  );
+                } else {
+                  unresponsiveYawFrames++;
+                  if (
+                    unresponsiveYawFrames >= maxUnresponsiveFrames &&
+                    aimOptions.fromCamera !== undefined
+                  ) {
+                    // The camera never responds to the mouse (it may not be
+                    // driven by this object): fall back to measuring on the
+                    // object's own rotations and start over.
+                    aimOptions = {};
+                    yawPixelsPerDegree = 2;
+                    pitchPixelsPerDegree = 2;
+                    sawYawResponse = false;
+                    sawPitchResponse = false;
+                    unresponsiveYawFrames = 0;
+                    unresponsivePitchFrames = 0;
+                    await unwindAppliedPitch();
+                  }
+                }
               } else {
                 const ratio = Math.abs(yawDiff) / achievedYawRotation;
                 yawPixelsPerDegree = Math.max(
@@ -1795,6 +1963,12 @@ namespace gdjs {
               if (achievedPitchRotation >= responseThresholdDegrees) {
                 sawPitchResponse = true;
                 unresponsivePitchFrames = 0;
+                if (
+                  Math.abs(newRelativePosition.pitchDiff) >
+                  Math.abs(pitchDiff) + responseThresholdDegrees
+                ) {
+                  pitchDirection = -pitchDirection;
+                }
                 const ratio = Math.abs(pitchDiff) / achievedPitchRotation;
                 pitchPixelsPerDegree = Math.max(
                   0.25,
@@ -1810,7 +1984,7 @@ namespace gdjs {
                 );
               } else {
                 unresponsivePitchFrames++;
-                if (unresponsivePitchFrames >= maxUnresponsivePitchFrames) {
+                if (unresponsivePitchFrames >= maxUnresponsiveFrames) {
                   // The measured pitch never responds (the game may map the
                   // vertical aim to another axis): stop driving it - and
                   // undo what was applied, in case the actual view WAS

--- a/GDJS/tests/tests/gameplaytestharness.js
+++ b/GDJS/tests/tests/gameplaytestharness.js
@@ -440,6 +440,41 @@ describe('gdjs.gameplayTests', () => {
     expect(result.errors[0]).to.contain('did not finish starting');
   }).timeout(10000);
 
+  it('gives the camera state and camera/heading-relative positions', async () => {
+    const runtimeGame = makeRuntimeGame();
+    const result = await runTestScript(
+      runtimeGame,
+      `
+      await harness.goToScene('Scene 1');
+      const camera = harness.getCameraState('');
+      harness.assert(!!camera, 'The base layer camera exists');
+      harness.assert(
+        typeof camera.x === 'number' && camera.zoom === 1 &&
+          camera.rotationX === 0 && camera.angle === 0,
+        'The camera state is JSON-safe with the expected defaults'
+      );
+      harness.assert(harness.getCameraState('Nope') === null, 'Unknown layer gives null');
+
+      const spawned = harness.spawn('MyObject', 100, 100);
+      // Target straight to the right: yawDiff 0 against the object's
+      // angle (0), -90 against a heading of 90.
+      const straight = harness.getRelativePosition('MyObject', { x: 300, y: 100 });
+      harness.assert(Math.abs(straight.yawDiff) < 0.001, 'yawDiff is 0 toward the right');
+      const withHeading = harness.getRelativePosition('MyObject', { x: 300, y: 100 }, { heading: 90 });
+      harness.assert(Math.abs(withHeading.yawDiff + 90) < 0.001, 'heading is used for yawDiff');
+
+      // fromZ gives an eye height even for a 2D object: a target at the
+      // same height as the eye needs no pitch, one below needs to look down.
+      const level = harness.getRelativePosition('MyObject', { x: 300, y: 100, z: 50 }, { fromZ: 50 });
+      harness.assert(Math.abs(level.pitchDiff) < 0.001, 'No pitch toward a target at eye height');
+      const below = harness.getRelativePosition('MyObject', { x: 300, y: 100, z: 0 }, { fromZ: 50 });
+      harness.assert(below.pitchDiff < -10, 'Negative pitch toward a target below the eye');
+      `
+    );
+
+    expect(result.status).to.be('passed');
+  }).timeout(10000);
+
   it('stops with a timeout when the maximum frames count is reached', async () => {
     const runtimeGame = makeRuntimeGame();
     const result = await runTestScript(


### PR DESCRIPTION
Fixes the two silent aiming failures found while writing gameplay tests for the 3D starters (stacked on #8932):

- **`getCameraState(layerName)`**: JSON-safe `{x, y, z, rotationX, rotationY, angle, zoom}` — the camera was previously only reachable through raw GDJS.
- **`lookTowardWithMouseDelta` measures on the layer camera** when it is a 3D one: the camera is the ground truth of a first-person view (right eye height, right rotations — whatever rotation the game's mapper drives, including `FirstPersonPointerMapper` storing the pitch in `rotationY`). Falls back to the object's own rotations when the camera does not respond, detects and corrects the mouse direction of each axis live, and reports `measuredFrom` in the result. Previously it computed the pitch from the object's center and `rotationX`, reporting `aimed: true` in the FPS starter while firing 3.3° above every target.
- **`getRelativePosition`** gains `fromCamera` (measure from a layer's camera), `fromZ` (eye/muzzle height) and `heading` (turrets: `tank.angle + state.TopRotation`).
- **`setMousePosition`/`touchStart`/`touchMove` on a 3D-rotated layer** now project the scene point through the actual three.js camera: the 2D `convertInverseCoords` disagrees with the 3D-aware `convertCoords` games read the cursor back through (up to 30° of aim error measured in the 3D twin-stick starter). A TODO marks that this inversion belongs in GDJS's `convertInverseCoords` itself eventually.

Validated: GDJS type-check and build clean, harness karma suite 31/31 (new test covering `getCameraState` and the `heading`/`fromZ` math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b)_