### PR TITLE
Gameplay tests: object variables, played sounds, event log, stability helper, snapshot fixes

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -516,7 +516,8 @@ namespace gdjs {
       /** The last time an animation frame was awaited (rendering the game). */
       _lastRenderTimeMs: number = 0;
       _playedSounds: Array<{ sound: string; frame: integer }> = [];
-      _soundLogRestorers: Array<() => void> = [];
+      /** Entries of the sound manager log already copied to `_playedSounds`. */
+      _playedSoundsReadCount: integer = 0;
       /** Game seconds simulated per real second, or null to run as fast
        * as possible (see `_maybeYield`). */
       _paceSpeedFactor: float | null = null;
@@ -716,6 +717,7 @@ namespace gdjs {
           this._worstStepTimeMs = stepTimeMs;
         }
         this._trackChangesAfterStep();
+        this._drainPlayedSounds();
         if (this._onProgress && Date.now() - this._lastProgressTimeMs > 500) {
           this._lastProgressTimeMs = Date.now();
           this._onProgress(this._framesExecuted);
@@ -1532,21 +1534,25 @@ namespace gdjs {
       /**
        * Get a scene variable, or undefined if it does not exist.
        */
-      getSceneVariable(variableName: string): Object | undefined {
+      getSceneVariable(
+        variableName: string
+      ): VariableNetworkSyncData | undefined {
         return this._getCurrentScene()
           .getVariables()
           .getNetworkSyncData({})
-          .find((variable) => (variable as any).name === variableName);
+          .find((variable) => variable.name === variableName);
       }
 
       /**
        * Get a global variable, or undefined if it does not exist.
        */
-      getGlobalVariable(variableName: string): Object | undefined {
+      getGlobalVariable(
+        variableName: string
+      ): VariableNetworkSyncData | undefined {
         return this._runtimeGame
           .getVariables()
           .getNetworkSyncData({})
-          .find((variable) => (variable as any).name === variableName);
+          .find((variable) => variable.name === variableName);
       }
 
       /**
@@ -1564,45 +1570,32 @@ namespace gdjs {
        * (a pickup, a shot, an explosion...).
        */
       getPlayedSounds(): Array<{ sound: string; frame: integer }> {
+        this._drainPlayedSounds();
         return this._playedSounds.slice();
       }
 
       _installSoundLog(): void {
-        const soundManager = this._runtimeGame.getSoundManager() as any;
-        // Wrap the public play methods of the sound manager for the
-        // duration of the test.
-        for (const methodName of [
-          'playSound',
-          'playSoundOnChannel',
-          'playMusic',
-          'playMusicOnChannel',
-        ]) {
-          const original = soundManager[methodName];
-          if (typeof original !== 'function') continue;
-          soundManager[methodName] = (soundName: unknown, ...args: any[]) => {
-            if (this._playedSounds.length < MAX_PLAYED_SOUNDS) {
-              this._playedSounds.push({
-                sound: String(soundName),
-                frame: this._framesExecuted,
-              });
-            }
-            return original.call(soundManager, soundName, ...args);
-          };
-          this._soundLogRestorers.push(() => {
-            soundManager[methodName] = original;
-          });
-        }
+        this._runtimeGame.getSoundManager().setPlayedSoundsLogEnabled(true);
       }
 
       _uninstallSoundLog(): void {
-        for (const restore of this._soundLogRestorers) {
-          try {
-            restore();
-          } catch (error) {
-            logger.warn('Error while restoring the sound manager: ' + error);
-          }
+        this._runtimeGame.getSoundManager().setPlayedSoundsLogEnabled(false);
+      }
+
+      /** Copy the new entries of the sound manager log, stamped with the
+       * current frame. */
+      private _drainPlayedSounds(): void {
+        const log = this._runtimeGame.getSoundManager().getPlayedSoundsLog();
+        while (
+          this._playedSoundsReadCount < log.length &&
+          this._playedSounds.length < MAX_PLAYED_SOUNDS
+        ) {
+          this._playedSounds.push({
+            sound: log[this._playedSoundsReadCount].soundName,
+            frame: this._framesExecuted,
+          });
+          this._playedSoundsReadCount++;
         }
-        this._soundLogRestorers = [];
       }
 
       /**
@@ -2253,13 +2246,13 @@ namespace gdjs {
       getObjectVariable(
         objectIdOrName: integer | string,
         variableName: string
-      ): Object | undefined {
+      ): VariableNetworkSyncData | undefined {
         const object = this.getRuntimeObject(objectIdOrName);
         if (!object) return undefined;
         return object
           .getVariables()
           .getNetworkSyncData({})
-          .find((variable) => (variable as any).name === variableName);
+          .find((variable) => variable.name === variableName);
       }
 
       /**

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -149,6 +149,8 @@ namespace gdjs {
           state: GameplayTestEvaluatedState;
         };
       };
+      flippedX?: boolean;
+      flippedY?: boolean;
       children?: { [objectName: string]: Array<GameplayTestObjectSnapshot> };
     };
 
@@ -322,6 +324,7 @@ namespace gdjs {
     const YIELD_BUDGET_MS = 12;
     // In fast (unpaced) runs, let the game render at most this often.
     const FAST_RUN_RENDER_INTERVAL_MS = 250;
+    const MAX_PLAYED_SOUNDS = 500;
     const DEFAULT_MAX_SCREENSHOTS = 5;
     const DEFAULT_PROBE_FRAMES = 30;
     const MAX_PROFILING_SECTIONS = 50;
@@ -512,6 +515,8 @@ namespace gdjs {
       _lastYieldTimeMs: number = 0;
       /** The last time an animation frame was awaited (rendering the game). */
       _lastRenderTimeMs: number = 0;
+      _playedSounds: Array<{ sound: string; frame: integer }> = [];
+      _soundLogRestorers: Array<() => void> = [];
       /** Game seconds simulated per real second, or null to run as fast
        * as possible (see `_maybeYield`). */
       _paceSpeedFactor: float | null = null;
@@ -910,6 +915,57 @@ namespace gdjs {
       }
 
       /**
+       * Step until the first instance of the object stops moving: its
+       * position changed less than `tolerance` (default 0.5) per frame for
+       * `stableFrames` (default 20) consecutive frames. Returns whether it
+       * settled within `maxFrames` (default 300). Use this for physics
+       * objects instead of a hand-written "read, compare, update"
+       * condition in `stepUntil` (which can silently pass without
+       * stepping a frame).
+       */
+      async stepUntilObjectIsStable(
+        objectName: string,
+        options?: {
+          tolerance?: float;
+          stableFrames?: integer;
+          maxFrames?: integer;
+        }
+      ): Promise<boolean> {
+        const tolerance = (options && options.tolerance) || 0.5;
+        const stableFrames = (options && options.stableFrames) || 20;
+        const maxFrames = (options && options.maxFrames) || 300;
+        let previous: [float, float, float] | null = null;
+        let stillFrames = 0;
+        return await this.stepUntil(() => stillFrames >= stableFrames, {
+          maxFrames,
+          onFrame: () => {
+            const instance = this._getInstances(objectName)[0];
+            if (!instance) {
+              previous = null;
+              stillFrames = 0;
+              return;
+            }
+            const anyInstance = instance as any;
+            const x = instance.getX();
+            const y = instance.getY();
+            const z =
+              typeof anyInstance.getZ === 'function' ? anyInstance.getZ() : 0;
+            if (
+              previous &&
+              Math.abs(x - previous[0]) < tolerance &&
+              Math.abs(y - previous[1]) < tolerance &&
+              Math.abs(z - previous[2]) < tolerance
+            ) {
+              stillFrames++;
+            } else {
+              stillFrames = 0;
+            }
+            previous = [x, y, z];
+          },
+        });
+      }
+
+      /**
        * Get the name of the scene being run.
        */
       getSceneName(): string {
@@ -1217,6 +1273,12 @@ namespace gdjs {
         if (typeof anyObject.getOpacity === 'function') {
           snapshot.opacity = anyObject.getOpacity();
         }
+        if (typeof anyObject.isFlippedX === 'function') {
+          snapshot.flippedX = anyObject.isFlippedX();
+        }
+        if (typeof anyObject.isFlippedY === 'function') {
+          snapshot.flippedY = anyObject.isFlippedY();
+        }
         if (
           includeChildren &&
           typeof anyObject.getChildrenContainer === 'function'
@@ -1226,10 +1288,42 @@ namespace gdjs {
           const children: {
             [objectName: string]: Array<GameplayTestObjectSnapshot>;
           } = {};
+          const canTransformToScene =
+            typeof anyObject.applyObjectTransformation === 'function';
           for (const child of childrenContainer.getAdhocListOfAllInstances()) {
             const childName = child.getName();
             if (!children[childName]) children[childName] = [];
-            children[childName].push(this._makeObjectSnapshot(child, false));
+            const childSnapshot = this._makeObjectSnapshot(child, false);
+            // The children live in the coordinates space of the custom
+            // object: convert to scene coordinates, like every other
+            // snapshot (so clicking a child at its centerX/centerY works).
+            if (canTransformToScene) {
+              const point: FloatPoint = [0, 0];
+              anyObject.applyObjectTransformation(
+                childSnapshot.x,
+                childSnapshot.y,
+                point
+              );
+              childSnapshot.x = point[0];
+              childSnapshot.y = point[1];
+              anyObject.applyObjectTransformation(
+                childSnapshot.centerX,
+                childSnapshot.centerY,
+                point
+              );
+              childSnapshot.centerX = point[0];
+              childSnapshot.centerY = point[1];
+              if (typeof anyObject.getZ === 'function') {
+                if (childSnapshot.z !== undefined)
+                  childSnapshot.z += anyObject.getZ();
+                if (childSnapshot.centerZ !== undefined)
+                  childSnapshot.centerZ += anyObject.getZ();
+              }
+            }
+            // The internal layer name of the parent means nothing outside
+            // of it: report the layer of the custom object itself.
+            childSnapshot.layer = object.getLayer();
+            children[childName].push(childSnapshot);
           }
           snapshot.children = children;
         }
@@ -1453,6 +1547,62 @@ namespace gdjs {
           .getVariables()
           .getNetworkSyncData({})
           .find((variable) => (variable as any).name === variableName);
+      }
+
+      /**
+       * The notable events recorded so far (scene changes and resets with
+       * their cause, stuck detections...), as a JSON-safe copy: lets a
+       * test assert, for example, that the game restarted its scene.
+       */
+      getEventLog(): Array<GameplayTestEvent> {
+        return this._eventLog.map((event) => ({ ...event }));
+      }
+
+      /**
+       * The sounds and musics played during the test so far, with the
+       * frame they were played at - a direct signal that a mechanic fired
+       * (a pickup, a shot, an explosion...).
+       */
+      getPlayedSounds(): Array<{ sound: string; frame: integer }> {
+        return this._playedSounds.slice();
+      }
+
+      _installSoundLog(): void {
+        const soundManager = this._runtimeGame.getSoundManager() as any;
+        // Wrap the public play methods of the sound manager for the
+        // duration of the test.
+        for (const methodName of [
+          'playSound',
+          'playSoundOnChannel',
+          'playMusic',
+          'playMusicOnChannel',
+        ]) {
+          const original = soundManager[methodName];
+          if (typeof original !== 'function') continue;
+          soundManager[methodName] = (soundName: unknown, ...args: any[]) => {
+            if (this._playedSounds.length < MAX_PLAYED_SOUNDS) {
+              this._playedSounds.push({
+                sound: String(soundName),
+                frame: this._framesExecuted,
+              });
+            }
+            return original.call(soundManager, soundName, ...args);
+          };
+          this._soundLogRestorers.push(() => {
+            soundManager[methodName] = original;
+          });
+        }
+      }
+
+      _uninstallSoundLog(): void {
+        for (const restore of this._soundLogRestorers) {
+          try {
+            restore();
+          } catch (error) {
+            logger.warn('Error while restoring the sound manager: ' + error);
+          }
+        }
+        this._soundLogRestorers = [];
       }
 
       /**
@@ -2095,6 +2245,47 @@ namespace gdjs {
       }
 
       /**
+       * Get a variable of an object (same entry shape as `getSceneVariable`),
+       * or undefined if the object or the variable does not exist.
+       * @param objectIdOrName An instance id (from `getObjects`) or an object
+       * name (first instance).
+       */
+      getObjectVariable(
+        objectIdOrName: integer | string,
+        variableName: string
+      ): Object | undefined {
+        const object = this.getRuntimeObject(objectIdOrName);
+        if (!object) return undefined;
+        return object
+          .getVariables()
+          .getNetworkSyncData({})
+          .find((variable) => (variable as any).name === variableName);
+      }
+
+      /**
+       * Set a variable of an object (number, string or boolean).
+       * Use for test setup only. Throws if the object does not exist.
+       * @param objectIdOrName An instance id (from `getObjects`) or an object
+       * name (first instance).
+       */
+      setObjectVariable(
+        objectIdOrName: integer | string,
+        variableName: string,
+        value: string | number | boolean
+      ): void {
+        const object = this.getRuntimeObject(objectIdOrName);
+        if (!object) {
+          throw new Error(
+            `No instance "${objectIdOrName}" found to set the variable "${variableName}".`
+          );
+        }
+        this._setVariableFromValue(
+          object.getVariables().get(variableName),
+          value
+        );
+      }
+
+      /**
        * Set a global variable (number, string or boolean).
        * Use for test setup only.
        */
@@ -2615,6 +2806,7 @@ namespace gdjs {
       harness._callOnFrameEnded = originalOnFrameEnded;
 
       harness._installPointerLockShim();
+      harness._installSoundLog();
 
       // Capture the logs of the game itself (in addition to the `console`
       // passed to the script).
@@ -2746,6 +2938,7 @@ namespace gdjs {
         }
         inputManager.onFrameEnded = originalOnFrameEnded;
         harness._uninstallPointerLockShim();
+        harness._uninstallSoundLog();
         gdjs.Logger.setLoggerOutput(existingLoggerOutput);
         if (payload.freezeWhenFinished) {
           // Keep the game paused (the main loop keeps rendering the last

--- a/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
+++ b/GDJS/Runtime/howler-sound-manager/howler-sound-manager.ts
@@ -696,6 +696,31 @@ namespace gdjs {
       return sound;
     }
 
+    private static playedSoundsLogMaxSize = 500;
+    /** The sounds/musics played while the log is enabled, in play order -
+     * see `setPlayedSoundsLogEnabled`. */
+    private _playedSoundsLog: Array<{
+      soundName: string;
+      isMusic: boolean;
+    }> | null = null;
+
+    /**
+     * Enable (clearing any previous entries) or disable the recording of
+     * the played sounds and musics, read with `getPlayedSoundsLog`.
+     * Used by gameplay tests to check that a sound was played.
+     */
+    setPlayedSoundsLogEnabled(enable: boolean): void {
+      this._playedSoundsLog = enable ? [] : null;
+    }
+
+    /**
+     * The sounds and musics played since the log was enabled (capped),
+     * oldest first. Empty when the log is not enabled.
+     */
+    getPlayedSoundsLog(): Array<{ soundName: string; isMusic: boolean }> {
+      return this._playedSoundsLog || [];
+    }
+
     /**
      * Creates a new gdjs.HowlerSound using preloaded/cached Howl instances.
      * @param soundName The name of the file or resource to play.
@@ -711,6 +736,12 @@ namespace gdjs {
       loop: boolean,
       rate: float
     ): HowlerSound {
+      if (
+        this._playedSoundsLog &&
+        this._playedSoundsLog.length < HowlerSoundManager.playedSoundsLogMaxSize
+      ) {
+        this._playedSoundsLog.push({ soundName, isMusic });
+      }
       const cacheContainer = isMusic ? this._loadedMusics : this._loadedSounds;
       const resource = this._getAudioResource(soundName);
 

--- a/GDJS/tests/tests/gameplaytestharness.js
+++ b/GDJS/tests/tests/gameplaytestharness.js
@@ -475,6 +475,57 @@ describe('gdjs.gameplayTests', () => {
     expect(result.status).to.be('passed');
   }).timeout(10000);
 
+  it('reads and writes object variables, event log, played sounds, stability', async () => {
+    const runtimeGame = makeRuntimeGame();
+    const result = await runTestScript(
+      runtimeGame,
+      `
+      await harness.goToScene('Scene 1');
+      const spawned = harness.spawn('MyObject', 100, 100);
+
+      // Object variables: write then read, by name and by id.
+      harness.assert(
+        harness.getObjectVariable('MyObject', 'Level') === undefined,
+        'Unknown object variable gives undefined'
+      );
+      harness.setObjectVariable(spawned.id, 'Level', 3);
+      harness.assert(
+        harness.getObjectVariable('MyObject', 'Level').value === 3,
+        'The object variable was written and read back'
+      );
+      harness.setObjectVariable('MyObject', 'Locked', true);
+      harness.assert(
+        harness.getObjectVariable(spawned.id, 'Locked').value === true,
+        'Boolean object variables are real booleans'
+      );
+
+      // Event log: readable from the script, with causes.
+      const eventLog = harness.getEventLog();
+      harness.assert(
+        eventLog.some((e) => e.event === 'sceneChanged' && e.cause === 'harness'),
+        'The scene change appears in the readable event log'
+      );
+
+      // Played sounds: the wrapper records the public play methods.
+      harness.getRuntimeGame().getSoundManager().playSound('pickup.aac', false, 100, 1);
+      const playedSounds = harness.getPlayedSounds();
+      harness.assert(
+        playedSounds.length === 1 && playedSounds[0].sound === 'pickup.aac',
+        'The played sound was recorded with its name'
+      );
+
+      // Stability: a still object settles, within the asked frames.
+      const settled = await harness.stepUntilObjectIsStable('MyObject', {
+        stableFrames: 5,
+        maxFrames: 60,
+      });
+      harness.assert(settled === true, 'A still object is reported stable');
+      `
+    );
+
+    expect(result.status).to.be('passed');
+  }).timeout(10000);
+
   it('stops with a timeout when the maximum frames count is reached', async () => {
     const runtimeGame = makeRuntimeGame();
     const result = await runTestScript(


### PR DESCRIPTION
Small additive harness APIs from the starter-tests feedback (stacked on #8933):

- **`getObjectVariable` / `setObjectVariable`**: read object-driven state without `variables.find(...)` boilerplate, and arrange it directly (previously a test had to click a clicker 20 times to afford an upgrade whose price lives in an object variable).
- **`getPlayedSounds()`**: the sounds/musics played during the test with the frame they played at, recorded by wrapping the public play methods of the sound manager for the duration of the run — a cheap, direct "the mechanic fired" signal (pickups, shots, explosions).
- **`getEventLog()`**: the recorded events (scene changes/resets with their cause) readable from the test script — three starters were testing "the run restarted" through "the player is back at its spawn position" for lack of this.
- **`stepUntilObjectIsStable(objectName, {...})`**: settles-detection without the hand-written `stepUntil` condition that silently passes without stepping a frame (a real bug found in a starter test).
- **Snapshots**: `flippedX`/`flippedY` exposed (side-view facing direction); the children of a custom object are now in **scene coordinates** — as the field is documented — instead of the parent's local space, converted through the object's own transformation, and carry the parent's layer instead of the internal `""`.

⚠️ One adaptation needed in existing starter tests: any test that manually converted custom-object children coordinates (`parent.x + child.x + child.width / 2`, e.g. `starting-top-down-rpg`'s dialog test) should now use the child's `centerX`/`centerY` directly.

Validated: GDJS type-check and build clean, harness karma suite 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b)_