### PR TITLE
Allow using the scene editor shortcuts without clicking on the canvas first

### DIFF
--- a/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
+++ b/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
@@ -240,6 +240,37 @@ export const EmbeddedGameFrame = ({
       shortcutCallbacks: {},
     })
   );
+  const hasSomeDialogOpen = React.useRef<boolean>(false);
+
+  // The game is displayed in an iframe, which is a separate document: it only receives
+  // the keyboard events if it has the focus. Give it the focus as soon as it is hovered,
+  // so that the in-game editor shortcuts (notably space to move the view) can be used
+  // without having to click on the game first.
+  const focusGameFrameOnHover = React.useCallback(
+    () => {
+      const iframe = iframeRef.current;
+      if (!iframe || !iframe.contentWindow) return;
+
+      // Don't take the focus away from a dialog: it would either break its keyboard
+      // navigation or fight with its focus trap.
+      if (hasSomeDialogOpen.current || isPointerEventsPrevented) return;
+
+      const { activeElement } = document;
+      // Don't interrupt the user while a text is being edited (renaming an object,
+      // editing a property...).
+      const isEditingText =
+        activeElement &&
+        // $FlowFixMe[prop-missing] - `closest` is available on the focused element.
+        activeElement.closest('textarea, input, [contenteditable="true"]');
+      if (isEditingText) return;
+
+      // Already focused: nothing to do (also avoids focusing again at every event).
+      if (activeElement === iframe) return;
+
+      iframe.contentWindow.focus();
+    },
+    [isPointerEventsPrevented]
+  );
 
   const inGameEditorSettings = useInGameEditorSettings();
   React.useEffect(
@@ -568,7 +599,6 @@ export const EmbeddedGameFrame = ({
 
   React.useEffect(
     () => {
-      let hasSomeDialogOpen = false;
       let hasSomeEmbeddedGameFrameHoleActive = false;
 
       const sendInGameEditorVisibleStatus = () => {
@@ -579,7 +609,8 @@ export const EmbeddedGameFrame = ({
               previewDebuggerServer.sendMessage(debuggerId, {
                 command: 'setVisibleStatus',
                 visible:
-                  !hasSomeDialogOpen && hasSomeEmbeddedGameFrameHoleActive,
+                  !hasSomeDialogOpen.current &&
+                  hasSomeEmbeddedGameFrameHoleActive,
               });
             });
         }
@@ -587,7 +618,7 @@ export const EmbeddedGameFrame = ({
 
       const unregisterDialogOpenCallback = registerOpenedDialogsCountCallback(
         ({ openedDialogsCount }) => {
-          hasSomeDialogOpen = openedDialogsCount > 0;
+          hasSomeDialogOpen.current = openedDialogsCount > 0;
           sendInGameEditorVisibleStatus();
         }
       );
@@ -620,7 +651,11 @@ export const EmbeddedGameFrame = ({
       onKeyDown={keyboardShortcuts.current.onKeyDown}
       onKeyUp={keyboardShortcuts.current.onKeyUp}
     >
-      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <div
+        style={{ position: 'relative', width: '100%', height: '100%' }}
+        onMouseOver={focusGameFrameOnHover}
+        onMouseMove={focusGameFrameOnHover}
+      >
         <iframe
           ref={iframeRef}
           title="Game Preview"

--- a/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
+++ b/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js
@@ -246,31 +246,27 @@ export const EmbeddedGameFrame = ({
   // the keyboard events if it has the focus. Give it the focus as soon as it is hovered,
   // so that the in-game editor shortcuts (notably space to move the view) can be used
   // without having to click on the game first.
-  const focusGameFrameOnHover = React.useCallback(
-    () => {
-      const iframe = iframeRef.current;
-      if (!iframe || !iframe.contentWindow) return;
+  const focusGameFrameOnHover = React.useCallback(() => {
+    const iframe = iframeRef.current;
+    if (!iframe || !iframe.contentWindow) return;
 
-      // Don't take the focus away from a dialog: it would either break its keyboard
-      // navigation or fight with its focus trap.
-      if (hasSomeDialogOpen.current || isPointerEventsPrevented) return;
+    // A dialog can be opened on top of the game, or show it through a "hole": don't
+    // fight with its focus trap.
+    if (hasSomeDialogOpen.current) return;
 
-      const { activeElement } = document;
-      // Don't interrupt the user while a text is being edited (renaming an object,
-      // editing a property...).
-      const isEditingText =
-        activeElement &&
-        // $FlowFixMe[prop-missing] - `closest` is available on the focused element.
-        activeElement.closest('textarea, input, [contenteditable="true"]');
-      if (isEditingText) return;
+    const { activeElement } = document;
+    // Nothing to do if the game is already focused, and don't interrupt the user while
+    // a text is being edited (renaming an object, editing a property...).
+    if (
+      activeElement === iframe ||
+      // $FlowFixMe[prop-missing] - `closest` is available on the focused element.
+      (activeElement &&
+        activeElement.closest('textarea, input, [contenteditable="true"]'))
+    )
+      return;
 
-      // Already focused: nothing to do (also avoids focusing again at every event).
-      if (activeElement === iframe) return;
-
-      iframe.contentWindow.focus();
-    },
-    [isPointerEventsPrevented]
-  );
+    iframe.contentWindow.focus();
+  }, []);
 
   const inGameEditorSettings = useInGameEditorSettings();
   React.useEffect(
@@ -651,16 +647,15 @@ export const EmbeddedGameFrame = ({
       onKeyDown={keyboardShortcuts.current.onKeyDown}
       onKeyUp={keyboardShortcuts.current.onKeyUp}
     >
-      <div
-        style={{ position: 'relative', width: '100%', height: '100%' }}
-        onMouseOver={focusGameFrameOnHover}
-        onMouseMove={focusGameFrameOnHover}
-      >
+      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
         <iframe
           ref={iframeRef}
           title="Game Preview"
           src={previewIndexHtmlLocation}
           tabIndex={0}
+          // Listened on the iframe itself and not on its container, so that the overlay
+          // covering it (drop target, pointer events blocker) doesn't take the focus.
+          onMouseOver={focusGameFrameOnHover}
           style={{
             position: 'absolute',
             top: 0,

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -194,6 +194,7 @@ export default class InstancesEditor extends Component<Props, State> {
   nextFrame: AnimationFrameID;
   contextMenuLongTouchTimeoutID: TimeoutID;
   hasCursorMovedSinceItIsDown = false;
+  _isPointerOverCanvas = false;
   _showObjectInstancesIn3D: boolean = false;
   _previousToolBeforePicker: ?TileMapTileSelection = null;
 
@@ -335,13 +336,14 @@ export default class InstancesEditor extends Component<Props, State> {
       event.preventDefault();
     };
     this.pixiRenderer.view.setAttribute('tabIndex', -1);
+    // Keyboard shortcuts are listened on the window rather than on the canvas, so that
+    // they also work when the canvas is not focused but only hovered (for example when
+    // the focus is still in the objects list). See `_shouldHandleKeyboardShortcuts`.
+    window.addEventListener('keydown', this._onWindowKeyDown);
+    window.addEventListener('keyup', this._onWindowKeyUp);
     this.pixiRenderer.view.addEventListener(
-      'keydown',
-      this.keyboardShortcuts.onKeyDown
-    );
-    this.pixiRenderer.view.addEventListener(
-      'keyup',
-      this.keyboardShortcuts.onKeyUp
+      'mouseover',
+      this._onCanvasPointerEnter
     );
     this.pixiRenderer.view.addEventListener(
       'mousedown',
@@ -355,15 +357,18 @@ export default class InstancesEditor extends Component<Props, State> {
       this.pixiRenderer.view.addEventListener('mousemove', event => {
         onMouseMove(event);
       });
-    if (onMouseLeave)
-      this.pixiRenderer.view.addEventListener('mouseout', event => {
-        onMouseLeave(event);
-      });
+    this.pixiRenderer.view.addEventListener('mouseout', event => {
+      this._onCanvasPointerLeave();
+      if (onMouseLeave) onMouseLeave(event);
+    });
     this.pixiRenderer.view.addEventListener('focusout', event => {
       if (this.keyboardShortcuts) {
         this.keyboardShortcuts.resetModifiers();
       }
     });
+    // The canvas can be removed from the DOM (or the window blurred) while a key is
+    // still held down: in this case no `keyup` would be received, so reset the modifiers.
+    window.addEventListener('blur', this._onWindowBlur);
 
     this.uiPixiContainer = new PIXI.Container();
     this.backgroundPixiContainer = new PIXI.Container();
@@ -660,10 +665,62 @@ export default class InstancesEditor extends Component<Props, State> {
     this.backgroundPixiContainer.addChild(this.background.getPixiObject());
   }
 
+  _onCanvasPointerEnter = () => {
+    this._isPointerOverCanvas = true;
+  };
+
+  _onCanvasPointerLeave = () => {
+    this._isPointerOverCanvas = false;
+    // A key (typically space, used to move the view) could still be held down while
+    // leaving the canvas: as the shortcuts are not handled anymore, its `keyup` would
+    // be ignored and the grabbing tool would stay stuck.
+    if (this.keyboardShortcuts) {
+      this.keyboardShortcuts.resetModifiers();
+    }
+  };
+
+  _onWindowBlur = () => {
+    this._isPointerOverCanvas = false;
+    if (this.keyboardShortcuts) {
+      this.keyboardShortcuts.resetModifiers();
+    }
+  };
+
+  /**
+   * Keyboard shortcuts are handled either when the canvas is focused, or when it is
+   * merely hovered by the cursor. The latter allows to use them (notably space to move
+   * the view) without having to first click on the canvas to focus it, which is
+   * consistent with the mouse wheel zoom that already works when only hovering.
+   */
+  _shouldHandleKeyboardShortcuts = (): boolean => {
+    if (this._unmounted || !this.pixiRenderer) return false;
+
+    return (
+      this._isPointerOverCanvas ||
+      document.activeElement === this.pixiRenderer.view
+    );
+  };
+
+  _onWindowKeyDown = (event: KeyboardEvent) => {
+    if (!this._shouldHandleKeyboardShortcuts()) return;
+
+    this.keyboardShortcuts.onKeyDown(event);
+  };
+
+  _onWindowKeyUp = (event: KeyboardEvent) => {
+    if (!this._shouldHandleKeyboardShortcuts()) return;
+
+    this.keyboardShortcuts.onKeyUp(event);
+  };
+
   componentWillUnmount() {
     // This is an antipattern and is theoretically not needed, but help
     // to protect against renders after the component is unmounted.
     this._unmounted = true;
+
+    window.removeEventListener('keydown', this._onWindowKeyDown);
+    window.removeEventListener('keyup', this._onWindowKeyUp);
+    window.removeEventListener('blur', this._onWindowBlur);
 
     // We've seen all those elements being undefined in some cases, so
     // by security, check that they are defined before deleting them.

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -245,6 +245,7 @@ export default class InstancesEditor extends Component<Props, State> {
     const { onMouseMove, onMouseLeave } = this.props;
 
     this.keyboardShortcuts = new KeyboardShortcuts({
+      isActive: this._shouldHandleKeyboardShortcuts,
       shortcutCallbacks: {
         onMove: this.moveSelection,
         onEscape: this.onPressEscape,
@@ -337,16 +338,21 @@ export default class InstancesEditor extends Component<Props, State> {
     };
     this.pixiRenderer.view.setAttribute('tabIndex', -1);
     // Keyboard shortcuts are listened on the window rather than on the canvas, so that
-    // they also work when the canvas is not focused but only hovered (for example when
-    // the focus is still in the objects list). See `_shouldHandleKeyboardShortcuts`.
-    // The capture phase is used so that a focused component stopping the propagation of
-    // the event (the tree views handle the keyboard) can't prevent the shortcuts from
-    // being handled.
-    window.addEventListener('keydown', this._onWindowKeyDown, true);
-    window.addEventListener('keyup', this._onWindowKeyUp, true);
+    // they also work when the canvas is only hovered and not focused (for example when
+    // the focus is still in the objects list), like the mouse wheel zoom already does.
+    // They are restricted to this editor by `_shouldHandleKeyboardShortcuts`, and the
+    // capture phase is used so that a focused component stopping the event propagation
+    // (the tree views handle the keyboard) can't prevent them from working.
+    window.addEventListener('keydown', this.keyboardShortcuts.onKeyDown, true);
+    // Key releases are always handled, even when the canvas is not hovered anymore, so
+    // that a key released after leaving the canvas (which happens when moving the view
+    // up to its border) is not considered as still pressed. A key can also be released
+    // while the window is blurred (Alt+Tab...), in which case no `keyup` is received.
+    window.addEventListener('keyup', this.keyboardShortcuts.onKeyUp, true);
+    window.addEventListener('blur', this.keyboardShortcuts.resetModifiers);
     this.pixiRenderer.view.addEventListener(
       'mouseover',
-      this._onCanvasPointerEnter
+      this._onPointerOverCanvas
     );
     this.pixiRenderer.view.addEventListener(
       'mousedown',
@@ -357,15 +363,12 @@ export default class InstancesEditor extends Component<Props, State> {
       this.keyboardShortcuts.onMouseUp
     );
     this.pixiRenderer.view.addEventListener('mousemove', event => {
-      // `mouseover` can be missed (for example if the cursor is already over the canvas
-      // when it is created), so also consider the canvas hovered when the mouse moves on it.
-      // Only the hovering is tracked here, not the focus, to avoid fighting with something
-      // else that would take the focus back at every mouse move.
-      this._markPointerOverCanvas();
+      // `mouseover` can be missed, for example if the canvas appears under a still cursor.
+      this._onPointerOverCanvas();
       if (onMouseMove) onMouseMove(event);
     });
     this.pixiRenderer.view.addEventListener('mouseout', event => {
-      this._onCanvasPointerLeave();
+      this._isPointerOverCanvas = false;
       if (onMouseLeave) onMouseLeave(event);
     });
     this.pixiRenderer.view.addEventListener('focusout', event => {
@@ -373,9 +376,6 @@ export default class InstancesEditor extends Component<Props, State> {
         this.keyboardShortcuts.resetModifiers();
       }
     });
-    // The canvas can be removed from the DOM (or the window blurred) while a key is
-    // still held down: in this case no `keyup` would be received, so reset the modifiers.
-    window.addEventListener('blur', this._onWindowBlur);
 
     this.uiPixiContainer = new PIXI.Container();
     this.backgroundPixiContainer = new PIXI.Container();
@@ -672,84 +672,31 @@ export default class InstancesEditor extends Component<Props, State> {
     this.backgroundPixiContainer.addChild(this.background.getPixiObject());
   }
 
-  _markPointerOverCanvas = () => {
+  _onPointerOverCanvas = () => {
     this._isPointerOverCanvas = true;
   };
 
-  _onCanvasPointerEnter = () => {
-    this._markPointerOverCanvas();
-
-    // Give the focus to the canvas as soon as it is hovered, so that the keyboard
-    // shortcuts (notably space to move the view) can be used without having to click on
-    // it first - which is what the mouse wheel zoom already allows.
-    // This is not done if a text is being edited, so that hovering the canvas while
-    // typing (renaming an object, editing a property...) does not interrupt the user.
-    const { activeElement } = document;
-    const isEditingText =
-      activeElement &&
-      // $FlowFixMe[prop-missing] - `closest` is available on the focused element.
-      activeElement.closest('textarea, input, [contenteditable="true"]');
-    if (
-      this.pixiRenderer &&
-      activeElement !== this.pixiRenderer.view &&
-      !isEditingText
-    ) {
-      this.pixiRenderer.view.focus({ preventScroll: true });
-    }
-  };
-
-  _onCanvasPointerLeave = () => {
-    this._isPointerOverCanvas = false;
-    // A key (typically space, used to move the view) could still be held down while
-    // leaving the canvas: as the shortcuts are not handled anymore, its `keyup` would
-    // be ignored and the grabbing tool would stay stuck.
-    if (this.keyboardShortcuts) {
-      this.keyboardShortcuts.resetModifiers();
-    }
-  };
-
-  _onWindowBlur = () => {
-    this._isPointerOverCanvas = false;
-    if (this.keyboardShortcuts) {
-      this.keyboardShortcuts.resetModifiers();
-    }
-  };
-
   /**
-   * Keyboard shortcuts are handled either when the canvas is focused, or when it is
-   * merely hovered by the cursor. The latter allows to use them (notably space to move
-   * the view) without having to first click on the canvas to focus it, which is
-   * consistent with the mouse wheel zoom that already works when only hovering.
+   * Keyboard shortcuts are handled when the canvas is hovered by the cursor, or when it
+   * is focused - so that they can be used without having to click on the canvas first,
+   * consistently with the mouse wheel zoom that already works when only hovering.
    */
-  _shouldHandleKeyboardShortcuts = (): boolean => {
-    if (this._unmounted || !this.pixiRenderer) return false;
-
-    return (
-      this._isPointerOverCanvas ||
-      document.activeElement === this.pixiRenderer.view
-    );
-  };
-
-  _onWindowKeyDown = (event: KeyboardEvent) => {
-    if (!this._shouldHandleKeyboardShortcuts()) return;
-
-    this.keyboardShortcuts.onKeyDown(event);
-  };
-
-  _onWindowKeyUp = (event: KeyboardEvent) => {
-    if (!this._shouldHandleKeyboardShortcuts()) return;
-
-    this.keyboardShortcuts.onKeyUp(event);
-  };
+  _shouldHandleKeyboardShortcuts = (): boolean =>
+    !!this.pixiRenderer &&
+    (this._isPointerOverCanvas ||
+      document.activeElement === this.pixiRenderer.view);
 
   componentWillUnmount() {
     // This is an antipattern and is theoretically not needed, but help
     // to protect against renders after the component is unmounted.
     this._unmounted = true;
 
-    window.removeEventListener('keydown', this._onWindowKeyDown, true);
-    window.removeEventListener('keyup', this._onWindowKeyUp, true);
-    window.removeEventListener('blur', this._onWindowBlur);
+    if (this.keyboardShortcuts) {
+      const { onKeyDown, onKeyUp, resetModifiers } = this.keyboardShortcuts;
+      window.removeEventListener('keydown', onKeyDown, true);
+      window.removeEventListener('keyup', onKeyUp, true);
+      window.removeEventListener('blur', resetModifiers);
+    }
 
     // We've seen all those elements being undefined in some cases, so
     // by security, check that they are defined before deleting them.

--- a/newIDE/app/src/InstancesEditor/index.js
+++ b/newIDE/app/src/InstancesEditor/index.js
@@ -339,8 +339,11 @@ export default class InstancesEditor extends Component<Props, State> {
     // Keyboard shortcuts are listened on the window rather than on the canvas, so that
     // they also work when the canvas is not focused but only hovered (for example when
     // the focus is still in the objects list). See `_shouldHandleKeyboardShortcuts`.
-    window.addEventListener('keydown', this._onWindowKeyDown);
-    window.addEventListener('keyup', this._onWindowKeyUp);
+    // The capture phase is used so that a focused component stopping the propagation of
+    // the event (the tree views handle the keyboard) can't prevent the shortcuts from
+    // being handled.
+    window.addEventListener('keydown', this._onWindowKeyDown, true);
+    window.addEventListener('keyup', this._onWindowKeyUp, true);
     this.pixiRenderer.view.addEventListener(
       'mouseover',
       this._onCanvasPointerEnter
@@ -353,10 +356,14 @@ export default class InstancesEditor extends Component<Props, State> {
       'mouseup',
       this.keyboardShortcuts.onMouseUp
     );
-    if (onMouseMove)
-      this.pixiRenderer.view.addEventListener('mousemove', event => {
-        onMouseMove(event);
-      });
+    this.pixiRenderer.view.addEventListener('mousemove', event => {
+      // `mouseover` can be missed (for example if the cursor is already over the canvas
+      // when it is created), so also consider the canvas hovered when the mouse moves on it.
+      // Only the hovering is tracked here, not the focus, to avoid fighting with something
+      // else that would take the focus back at every mouse move.
+      this._markPointerOverCanvas();
+      if (onMouseMove) onMouseMove(event);
+    });
     this.pixiRenderer.view.addEventListener('mouseout', event => {
       this._onCanvasPointerLeave();
       if (onMouseLeave) onMouseLeave(event);
@@ -665,8 +672,30 @@ export default class InstancesEditor extends Component<Props, State> {
     this.backgroundPixiContainer.addChild(this.background.getPixiObject());
   }
 
-  _onCanvasPointerEnter = () => {
+  _markPointerOverCanvas = () => {
     this._isPointerOverCanvas = true;
+  };
+
+  _onCanvasPointerEnter = () => {
+    this._markPointerOverCanvas();
+
+    // Give the focus to the canvas as soon as it is hovered, so that the keyboard
+    // shortcuts (notably space to move the view) can be used without having to click on
+    // it first - which is what the mouse wheel zoom already allows.
+    // This is not done if a text is being edited, so that hovering the canvas while
+    // typing (renaming an object, editing a property...) does not interrupt the user.
+    const { activeElement } = document;
+    const isEditingText =
+      activeElement &&
+      // $FlowFixMe[prop-missing] - `closest` is available on the focused element.
+      activeElement.closest('textarea, input, [contenteditable="true"]');
+    if (
+      this.pixiRenderer &&
+      activeElement !== this.pixiRenderer.view &&
+      !isEditingText
+    ) {
+      this.pixiRenderer.view.focus({ preventScroll: true });
+    }
   };
 
   _onCanvasPointerLeave = () => {
@@ -718,8 +747,8 @@ export default class InstancesEditor extends Component<Props, State> {
     // to protect against renders after the component is unmounted.
     this._unmounted = true;
 
-    window.removeEventListener('keydown', this._onWindowKeyDown);
-    window.removeEventListener('keyup', this._onWindowKeyUp);
+    window.removeEventListener('keydown', this._onWindowKeyDown, true);
+    window.removeEventListener('keyup', this._onWindowKeyUp, true);
     window.removeEventListener('blur', this._onWindowBlur);
 
     // We've seen all those elements being undefined in some cases, so


### PR DESCRIPTION

This PR allows using space bar panning without having to focus the canvas.
It removes a currently mandatory focus click. This is much more consistent with mouse wheel zoom, which doesn't need focus to work.
Moreover, it makes the workflow smoother and more pleasant.


Tested on web with the 2D and 3D views in editor.





<details>
  <summary>Claude Code said:</summary>

## Problem

In the scene editor, the mouse wheel zoom works as soon as the canvas is hovered, but the keyboard shortcuts (notably space to move the view) require clicking on the canvas first. Clicking in any panel, for example the objects list, is enough to lose them.

Two different causes, one per editor:

- **2D canvas**: `keydown`/`keyup` were listened on the canvas itself, which has `tabIndex = -1`, so the events only arrived when it was focused.
- **In-game editor**: the game runs in an `<iframe>`, a separate document that only receives keyboard events when it has the focus.

## Changes

**Instances editor** ([`InstancesEditor/index.js`](https://github.com/4ian/GDevelop/blob/master/newIDE/app/src/InstancesEditor/index.js)): the shortcuts are listened on the `window` and restricted to this editor by the `isActive` option of `KeyboardShortcuts`, which is true when the canvas is hovered or focused. The capture phase is used so that a focused component stopping the event propagation (the tree views handle the keyboard) can't prevent them from working. Key releases are always handled, so that releasing a key after leaving the canvas (which happens when moving the view up to its border) doesn't leave it considered as pressed, and the modifiers are reset when the window is blurred (Alt+Tab with a key held down).

**In-game editor** ([`EmbeddedGameFrame.js`](https://github.com/4ian/GDevelop/blob/master/newIDE/app/src/EmbeddedGame/EmbeddedGameFrame.js)): the iframe is given the focus as soon as it is hovered, with the same call that is already made when a preview is attached. The listener is on the iframe itself, so the overlay covering it (drop target, pointer events blocker) never triggers it.

The focus is not taken when a text is being edited (renaming an object, editing a property...) nor when a dialog is opened, to avoid interrupting the user or fighting with a focus trap. Nothing changes for touch devices: only `KeyboardEvent`s are involved, the pinch and touch gestures go through their own handlers.

## Testing

- Click in the objects list, hover the 2D canvas, then use space + drag to move the view, and the arrow keys / Delete / Ctrl+C on the selection.
- Same with the in-game editor (2D and 3D).
- Check that renaming an object while the cursor sits over the canvas still types normally, and that a dialog opened over the game keeps its keyboard navigation.
</details>

