### PR TITLE
Gameplay tests: fix the camera-measured yaw, expose the aim tolerance

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -1699,11 +1699,15 @@ namespace gdjs {
 
         const distance = Math.hypot(relativeX, relativeY, relativeZ || 0);
 
+        // The world direction a 3D camera looks at is its angle minus 90
+        // (with the ZYX rotation order, at the horizon the view direction
+        // is the former screen-up - games set the camera angle to
+        // "facing + 90", e.g. LookFromObjectEyes).
         const currentYaw =
           options && options.heading !== undefined
             ? options.heading
             : camera !== null
-              ? camera.angle
+              ? camera.angle - 90
               : reference.getAngle();
         const desiredAngle = gdjs.toDegrees(Math.atan2(relativeY, relativeX));
         const yawDiff = normalizeAngleDifference(desiredAngle - currentYaw);
@@ -1940,10 +1944,17 @@ namespace gdjs {
         target:
           | { name: string; id?: integer }
           | { x: float; y: float; z?: float },
-        options?: { yawOnly?: boolean; fromCamera?: string }
+        options?: {
+          yawOnly?: boolean;
+          fromCamera?: string;
+          /** Consider the aim done when both angles are within this
+           * tolerance (default 3 degrees - lower it to hit a small or far
+           * target). */
+          toleranceDegrees?: float;
+        }
       ): Promise<GameplayTestAimResult | null> {
         const maxAimFrames = 180;
-        const toleranceDegrees = 3;
+        const toleranceDegrees = (options && options.toleranceDegrees) || 3;
         const responseThresholdDegrees = 0.1;
         const maxPixelsPerDegree = 64;
         // Frames tolerated with a demand on an axis, a maxed-out gain and


### PR DESCRIPTION
Both issues reported from the starter tests were valid:

- **Camera yaw was 90° out.** The world direction a 3D camera looks at is its `angle - 90`: with the ZYX rotation order, a camera pitched to the horizon faces the former "screen-up" direction, which is why games (e.g. `LookFromObjectEyes`) set the camera angle to `facing + 90`. `getRelativePosition`'s `fromCamera` yaw now subtracts that offset — the reported `yawDiff: -90.04` while demonstrably facing the target becomes ~0, and `lookTowardWithMouseDelta`'s camera mode inherits the fix. (The pitch from the same call was already exact.)
- **`toleranceDegrees` exposed on `lookTowardWithMouseDelta`** (default 3): a shooting test needs "aimed well enough to hit", which can be under a degree on a small or far target — at 1.3° off the helper reported `aimed: true` and a second call stepped zero frames.

Validated: GDJS type-check and build clean, harness karma suite 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b)_