### PR TITLE
Gameplay tests: fix the inverted camera-measured pitch

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -1508,7 +1508,7 @@ namespace gdjs {
        * convention as object angles). `rotationX`/`rotationY` are the 3D
        * camera rotations: `rotationX` is 0 looking straight down (the 2D
        * default) and 90 at the horizon, so the pitch of a first-person
-       * view is `90 - rotationX`.
+       * view is `rotationX - 90` (positive = looking up).
        */
       getCameraState(layerName: string = ''): {
         x: float;
@@ -1741,11 +1741,11 @@ namespace gdjs {
           relativeZ === undefined
             ? 0
             : gdjs.toDegrees(Math.atan2(relativeZ, horizontalDistance));
-        // The pitch of a camera view: 90 - rotationX (rotationX is 0
-        // looking straight down, 90 at the horizon).
+        // The pitch of a camera view: rotationX - 90 (rotationX is 0
+        // looking straight down - a pitch of -90 - and 90 at the horizon).
         const currentPitch =
           camera !== null
-            ? 90 - camera.rotationX
+            ? camera.rotationX - 90
             : typeof anyReference.getRotationX === 'function'
               ? anyReference.getRotationX()
               : 0;


### PR DESCRIPTION
The pitch of a camera view is `rotationX - 90`, not `90 - rotationX`: `rotationX` is 0 looking straight down (a pitch of -90) and 90 at the horizon, so beyond 90 the view tilts **up**. The previous formula had the right magnitude and the wrong sign, so `lookTowardWithMouseDelta` converged to the mirrored vertical aim — measured in two different games (FPS: ended at `rotationX 93.16`, tilted up by exactly the 3.16° it should have tilted down; farming: sweeping down moved `pitchDiff` further from zero). `getCameraState`'s documentation is updated to state the convention (`rotationX - 90`, positive = looking up).

Validated: GDJS type-check and build clean, harness karma suite 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b)_