### PR TITLE
Gameplay tests: wait through game-driven scene changes instead of throwing

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -608,10 +608,26 @@ namespace gdjs {
       }
 
       private _getCurrentScene(): gdjs.RuntimeScene {
-        const currentScene = this._runtimeGame
-          .getSceneStack()
-          .getCurrentScene();
+        const sceneStack = this._runtimeGame.getSceneStack();
+        const currentScene = sceneStack.getCurrentScene();
         if (!currentScene) {
+          if (sceneStack.isNextSceneLoading()) {
+            // Should not happen: every stepped frame waits for a
+            // game-driven scene switch to complete (see
+            // `_waitForGameSceneSwitchIfNeeded`). Kept as a safety net for
+            // a synchronous read racing the switch.
+            throw new Error(
+              'The game is switching scenes and the next scene is still ' +
+                'loading. `await harness.stepFrames(1)` waits for it to be ready.'
+            );
+          }
+          if (sceneStack.wasFirstSceneLoaded()) {
+            throw new Error(
+              'No scene is running anymore: the game removed its last ' +
+                'scene (it likely ended or quit). Use ' +
+                '`await harness.goToScene(sceneName)` to start a scene again.'
+            );
+          }
           throw new Error(
             'No scene is running. Call `await harness.goToScene(sceneName)` first.'
           );
@@ -695,6 +711,38 @@ namespace gdjs {
         }
       }
 
+      /**
+       * When the game's own logic changed scene (a `Scene(...)` action) and
+       * the next scene's assets are not loaded yet, the scene stack is
+       * empty until the load finishes - the game is not over, a scene is on
+       * its way. Wait for it (as loading time, excluded from the timeout
+       * budget) so the test script never observes the gap: without this, a
+       * `getSceneName()` right after the game changed scene throws a
+       * misleading "No scene is running".
+       */
+      async _waitForGameSceneSwitchIfNeeded(): Promise<void> {
+        const sceneStack = this._runtimeGame.getSceneStack();
+        if (sceneStack.getCurrentScene() || !sceneStack.isNextSceneLoading()) {
+          return;
+        }
+        await this._awaitLoading(
+          (async () => {
+            while (
+              !sceneStack.getCurrentScene() &&
+              sceneStack.isNextSceneLoading() &&
+              !this._stopped
+            ) {
+              await new Promise((resolve) => setTimeout(resolve, 20));
+            }
+          })(),
+          'The scene the game is switching to'
+        );
+        // Record the arrival right away (`sceneChanged`/`sceneReset` with
+        // the cause of the game's change request), even if the script never
+        // steps another frame.
+        this._trackChangesAfterStep();
+      }
+
       private _recordEvent(event: GameplayTestEvent): void {
         if (this._eventLog.length >= MAX_EVENT_LOG_ENTRIES) return;
         this._eventLog.push(event);
@@ -725,6 +773,16 @@ namespace gdjs {
         const currentScene = this._runtimeGame
           .getSceneStack()
           .getCurrentScene();
+        if (
+          !currentScene &&
+          this._runtimeGame.getSceneStack().isNextSceneLoading()
+        ) {
+          // The game changed scene and the next one is still loading: the
+          // stack is only transiently empty. Do not record this gap as a
+          // scene change - the arrival is recorded once the new scene
+          // exists (see `_waitForGameSceneSwitchIfNeeded`).
+          return;
+        }
         const sceneName = currentScene ? currentScene.getName() : '';
         if (currentScene !== this._lastTrackedScene) {
           const lastChangeCause = this._runtimeGame
@@ -938,6 +996,7 @@ namespace gdjs {
         const dtMs = (options && options.dtMs) || DEFAULT_FRAME_DT_MS;
         for (let i = 0; i < frameCount; i++) {
           this._stepSingleFrame(dtMs);
+          await this._waitForGameSceneSwitchIfNeeded();
           if (options && options.onFrame) {
             options.onFrame({ frame: this._framesExecuted });
           }
@@ -978,6 +1037,7 @@ namespace gdjs {
         for (let i = 0; i < options.maxFrames; i++) {
           if (condition()) return true;
           this._stepSingleFrame(DEFAULT_FRAME_DT_MS);
+          await this._waitForGameSceneSwitchIfNeeded();
           if (options.onFrame) {
             options.onFrame({ frame: this._framesExecuted });
           }

--- a/GDJS/Runtime/scenestack.ts
+++ b/GDJS/Runtime/scenestack.ts
@@ -353,6 +353,15 @@ namespace gdjs {
     }
 
     /**
+     * Return true while the next scene, requested by a scene change, is
+     * still loading its assets. The stack can be empty during this time
+     * (after a `replace`): the game is not over, a scene is on its way.
+     */
+    isNextSceneLoading(): boolean {
+      return this._isNextLayoutLoading;
+    }
+
+    /**
      * Return the current gdjs.RuntimeScene being played, or null if none is run.
      */
     getCurrentScene(): gdjs.RuntimeScene | null {

--- a/GDJS/tests/tests/gameplaytestharness.js
+++ b/GDJS/tests/tests/gameplaytestharness.js
@@ -474,6 +474,73 @@ describe('gdjs.gameplayTests', () => {
     expect(result.durationMs >= result.loadingMs).to.be(true);
   }).timeout(10000);
 
+  it('waits through a game-driven scene change whose scene is still loading', async () => {
+    const runtimeGame = makeRuntimeGame();
+    // "Scene 2" assets take longer to load than the whole test budget: when
+    // the game changes to it, the scene stack stays empty until the load
+    // finishes (the gap that made real tests throw "No scene is running").
+    const anyRuntimeGame = /** @type {any} */ (runtimeGame);
+    const originalAreSceneAssetsReady =
+      runtimeGame.areSceneAssetsReady.bind(runtimeGame);
+    let slowLoadDone = false;
+    anyRuntimeGame.areSceneAssetsReady = (
+      /** @type {string} */ sceneName
+    ) =>
+      sceneName === 'Scene 2'
+        ? slowLoadDone
+        : originalAreSceneAssetsReady(sceneName);
+    anyRuntimeGame.loadSceneAssets = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      slowLoadDone = true;
+    };
+    const result = await runTestScript(
+      runtimeGame,
+      `
+      await harness.goToScene('Scene 1');
+      // Simulate the game's own logic changing the scene (a "Scene" action).
+      harness.getRuntimeGame().getSceneStack().replace({ sceneName: 'Scene 2', clear: true });
+      await harness.stepFrames(2);
+      harness.assert(
+        harness.getSceneName() === 'Scene 2',
+        'The new scene is running right after stepping through the switch'
+      );
+      `,
+      // Smaller than the scene load: the wait is loading, not budget.
+      { timeoutMs: 200 }
+    );
+
+    expect(result.status).to.be('passed');
+    expect(result.loadingMs >= 280).to.be(true);
+    // The transient empty stack is never recorded: Scene 1 (goToScene)
+    // then Scene 2 (the game's change), no '' scene in between.
+    const sceneEvents = result.eventLog.filter(
+      (event) =>
+        event.event === 'sceneChanged' || event.event === 'sceneReset'
+    );
+    expect(sceneEvents.length).to.be(2);
+    expect(sceneEvents[0].sceneName).to.be('Scene 1');
+    expect(sceneEvents[1].sceneName).to.be('Scene 2');
+  }).timeout(10000);
+
+  it('gives a clear error when the game removed its last scene (game over)', async () => {
+    const runtimeGame = makeRuntimeGame();
+    const result = await runTestScript(
+      runtimeGame,
+      `
+      await harness.goToScene('Scene 1');
+      // Simulate an ended game: an empty scene stack with no scene loading
+      // (SceneStack.pop() refuses to remove the last scene, so reach into
+      // the stack directly).
+      harness.getRuntimeGame().getSceneStack()._stack.pop();
+      await harness.stepFrames(1);
+      harness.getSceneName();
+      `
+    );
+
+    expect(result.status).to.be('error');
+    expect(result.errors[0]).to.contain('ended or quit');
+  });
+
   it('fails with a clear error when scene assets never finish loading', async () => {
     const runtimeGame = makeRuntimeGame();
     const anyRuntimeGame = /** @type {any} */ (runtimeGame);

--- a/GDJS/tests/tests/gameplaytestharness.js
+++ b/GDJS/tests/tests/gameplaytestharness.js
@@ -449,12 +449,14 @@ describe('gdjs.gameplayTests', () => {
 
   it('excludes slow scene-asset loading from the timeout budget', async () => {
     const runtimeGame = makeRuntimeGame();
-    // Simulate scene assets that take longer to load than the whole test
-    // budget (like the first run of a web preview downloading resources).
-    const anyRuntimeGame = /** @type {any} */ (runtimeGame);
+    // Override members to mock scene assets that take longer to load than
+    // the whole test budget (like the first run of a web preview
+    // downloading resources).
     let slowLoadDone = false;
-    anyRuntimeGame.areSceneAssetsReady = () => slowLoadDone;
-    anyRuntimeGame.loadSceneAssets = async () => {
+    // @ts-ignore
+    runtimeGame.areSceneAssetsReady = () => slowLoadDone;
+    // @ts-ignore
+    runtimeGame.loadSceneAssets = async () => {
       await new Promise((resolve) => setTimeout(resolve, 300));
       slowLoadDone = true;
     };
@@ -476,20 +478,20 @@ describe('gdjs.gameplayTests', () => {
 
   it('waits through a game-driven scene change whose scene is still loading', async () => {
     const runtimeGame = makeRuntimeGame();
-    // "Scene 2" assets take longer to load than the whole test budget: when
-    // the game changes to it, the scene stack stays empty until the load
-    // finishes (the gap that made real tests throw "No scene is running").
-    const anyRuntimeGame = /** @type {any} */ (runtimeGame);
+    // Override members to mock "Scene 2" assets that take longer to load
+    // than the whole test budget: when the game changes to it, the scene
+    // stack stays empty until the load finishes (the gap that made real
+    // tests throw "No scene is running").
     const originalAreSceneAssetsReady =
       runtimeGame.areSceneAssetsReady.bind(runtimeGame);
     let slowLoadDone = false;
-    anyRuntimeGame.areSceneAssetsReady = (
-      /** @type {string} */ sceneName
-    ) =>
+    // @ts-ignore
+    runtimeGame.areSceneAssetsReady = (/** @type {string} */ sceneName) =>
       sceneName === 'Scene 2'
         ? slowLoadDone
         : originalAreSceneAssetsReady(sceneName);
-    anyRuntimeGame.loadSceneAssets = async () => {
+    // @ts-ignore
+    runtimeGame.loadSceneAssets = async () => {
       await new Promise((resolve) => setTimeout(resolve, 300));
       slowLoadDone = true;
     };
@@ -524,14 +526,16 @@ describe('gdjs.gameplayTests', () => {
 
   it('gives a clear error when the game removed its last scene (game over)', async () => {
     const runtimeGame = makeRuntimeGame();
+    const sceneStack = runtimeGame.getSceneStack();
+    // Override members to mock a game that ended: a first scene was loaded
+    // but no scene is running anymore (and none is loading).
+    // @ts-ignore
+    sceneStack.getCurrentScene = () => null;
+    // @ts-ignore
+    sceneStack.wasFirstSceneLoaded = () => true;
     const result = await runTestScript(
       runtimeGame,
       `
-      await harness.goToScene('Scene 1');
-      // Simulate an ended game: an empty scene stack with no scene loading
-      // (SceneStack.pop() refuses to remove the last scene, so reach into
-      // the stack directly).
-      harness.getRuntimeGame().getSceneStack()._stack.pop();
       await harness.stepFrames(1);
       harness.getSceneName();
       `
@@ -543,9 +547,11 @@ describe('gdjs.gameplayTests', () => {
 
   it('fails with a clear error when scene assets never finish loading', async () => {
     const runtimeGame = makeRuntimeGame();
-    const anyRuntimeGame = /** @type {any} */ (runtimeGame);
-    anyRuntimeGame.areSceneAssetsReady = () => false;
-    anyRuntimeGame.loadSceneAssets = () => new Promise(() => {});
+    // Override members to mock a scene-asset load that never completes.
+    // @ts-ignore
+    runtimeGame.areSceneAssetsReady = () => false;
+    // @ts-ignore
+    runtimeGame.loadSceneAssets = () => new Promise(() => {});
     const result = await runTestScript(
       runtimeGame,
       `await harness.goToScene('Scene 1');`,


### PR DESCRIPTION
Fixes the scene-change gap surfaced by the production failure reports (66 reports in the first 15 hours): when the game's own logic changes scene (a `Scene("Game")` action from a Play button) and the next scene's assets are not loaded yet, `SceneStack.replace` pops the current scene and the stack stays **empty** until the load finishes. A test stepping through that window — `click Play; stepFrames(2); assert(getSceneName() === 'Game')` — threw a misleading `No scene is running. Call await harness.goToScene(sceneName) first.`, which testers (and the AI agent) misread as a script bug.

- `SceneStack` exposes `isNextSceneLoading()`: true while a requested scene is still loading its assets — the game is not over, a scene is on its way.
- After **each stepped frame** (in `stepFrames` and `stepUntil`, before any user callback, stuck-detection read or condition evaluation), the harness waits for such a switch to complete. The wait is loading time: excluded from the `timeoutMs` budget, counted in `loadingMs`, bounded by `loadingTimeoutMs`, with progress heartbeats (all per #8947's loading machinery, which this builds on).
- The transient empty stack is no longer recorded in the event log: it shows the departure scene then the arrival scene (with the game's own change cause, preserved by `SceneStack`'s deferred-cause attribution), never a `''` scene in between.
- `_getCurrentScene`'s error now tells the truth in the remaining cases: `the game removed its last scene (it likely ended or quit)` after a real game end, the `goToScene` hint only before any scene ran, and a race-safety message during a switch (normally unreachable since every step waits).

Tests: karma harness suite 34 → 36 — a game-driven `replace` to a scene loading longer than the whole `timeoutMs` budget now passes with `loadingMs` accounted and a clean two-entry event log, and an ended game yields the new clear error. `tsc` and prettier clean; the ai-prompts guide-alignment spec passes against this harness (private/underscore helpers are not part of the documented API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b)_