### PR TITLE
Simplified project: include the stored gameplay-test source (tests[*].source)

### DIFF
--- a/newIDE/app/src/EditorFunctions/SimplifiedProject/SimplifiedProject.js
+++ b/newIDE/app/src/EditorFunctions/SimplifiedProject/SimplifiedProject.js
@@ -60,6 +60,10 @@ type SimplifiedTest = {|
   testName: string,
   type: string,
   description?: string,
+  // The test source ("the body of `async (harness) => {...}`"). Served on
+  // demand by `read_game_project_json` (`tests[*].code`) — the backend strips
+  // it from the project embedded in prompts, so it costs nothing until read.
+  code?: string,
   lastRunStatus?: string,
   lastRunAt?: number,
 |};
@@ -450,6 +454,7 @@ export const makeSimplifiedProjectBuilder = (
         };
         if (test.getDescription())
           simplifiedTest.description = test.getDescription();
+        if (test.getSource()) simplifiedTest.code = test.getSource();
         if (test.getLastRunStatus()) {
           simplifiedTest.lastRunStatus = test.getLastRunStatus();
           simplifiedTest.lastRunAt = test.getLastRunAt();

--- a/newIDE/app/src/EditorFunctions/SimplifiedProject/SimplifiedProject.js
+++ b/newIDE/app/src/EditorFunctions/SimplifiedProject/SimplifiedProject.js
@@ -60,10 +60,7 @@ type SimplifiedTest = {|
   testName: string,
   type: string,
   description?: string,
-  // The test source ("the body of `async (harness) => {...}`"). Served on
-  // demand by `read_game_project_json` (`tests[*].code`) — the backend strips
-  // it from the project embedded in prompts, so it costs nothing until read.
-  code?: string,
+  source?: string,
   lastRunStatus?: string,
   lastRunAt?: number,
 |};
@@ -454,7 +451,7 @@ export const makeSimplifiedProjectBuilder = (
         };
         if (test.getDescription())
           simplifiedTest.description = test.getDescription();
-        if (test.getSource()) simplifiedTest.code = test.getSource();
+        if (test.getSource()) simplifiedTest.source = test.getSource();
         if (test.getLastRunStatus()) {
           simplifiedTest.lastRunStatus = test.getLastRunStatus();
           simplifiedTest.lastRunAt = test.getLastRunAt();


### PR DESCRIPTION
Companion to GDevelopApp/GDevelop-services#21: lets the AI read the source of a stored gameplay test on demand via `read_game_project_json` (`tests[*].source`, the canonical serialized field name) — e.g. to reuse a working aiming sequence in a new test — instead of rediscovering the logic with probe runs (observed in production).

Two lines in `SimplifiedProject.js`: the tests entries now carry `source: test.getSource()`. The backend strips `tests[*].source` from the project embedded in prompts and serves it only through `read_game_project_json`'s bounded reader, so the source costs nothing until actually read — **the services PR must be deployed before this ships** (an editor sending the sources to a backend without the strip would put them into every prompt).

Flow and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaQQdPZ68X8zkybtsxWE1b