### PR TITLE
Fix color picker fields not being editable when opened from a dialog

### DIFF
--- a/newIDE/app/src/UI/ColorField/ColorPicker.js
+++ b/newIDE/app/src/UI/ColorField/ColorPicker.js
@@ -9,6 +9,7 @@ import muiZIndex from '@material-ui/core/styles/zIndex';
 import { type RGBColor } from '../../Utils/ColorTransformer';
 import PortalContainerContext from '../PortalContainerContext';
 import { shouldCloseOrCancel } from '../KeyboardShortcuts/InteractionKeys';
+import { getDialogFocusTrapContainer } from '../MaterialUISpecificUtil';
 
 export type ColorResult = {
   rgb: RGBColor,
@@ -85,6 +86,16 @@ const ColorPicker = ({
   );
   const portalContainer = React.useContext(PortalContainerContext);
 
+  // When the picker is opened from a dialog, it must be rendered inside it:
+  // dialogs are trapping the focus, so a picker rendered outside of them would
+  // never keep it - making the hexadecimal and RGB fields impossible to edit.
+  const pickerContainer = React.useMemo(
+    () =>
+      (swatchElement && getDialogFocusTrapContainer(swatchElement)) ||
+      portalContainer,
+    [swatchElement, portalContainer]
+  );
+
   const handleClick = () => {
     if (disabled || readOnly) return;
     setDisplayColorPicker(!displayColorPicker);
@@ -154,7 +165,7 @@ const ColorPicker = ({
           <Popper
             open
             anchorEl={swatchElement}
-            container={portalContainer}
+            container={pickerContainer}
             style={styles.popover}
             placement="bottom-start"
           >

--- a/newIDE/app/src/UI/ColorField/ColorPicker.js
+++ b/newIDE/app/src/UI/ColorField/ColorPicker.js
@@ -63,6 +63,8 @@ const styles = {
     // Ensure the popover is above everything (modal, dialog, snackbar, tooltips, etc).
     // There will be only one ColorPicker opened at a time, so it's fair to put the
     // highest z index. If this is breaking, check the z-index of material-ui.
+    // Note that when rendered inside a dialog (see `pickerContainer`), this only
+    // applies inside the stacking context of the dialog.
     zIndex: muiZIndex.tooltip + 100,
   },
 };
@@ -89,12 +91,9 @@ const ColorPicker = ({
   // When the picker is opened from a dialog, it must be rendered inside it:
   // dialogs are trapping the focus, so a picker rendered outside of them would
   // never keep it - making the hexadecimal and RGB fields impossible to edit.
-  const pickerContainer = React.useMemo(
-    () =>
-      (swatchElement && getDialogFocusTrapContainer(swatchElement)) ||
-      portalContainer,
-    [swatchElement, portalContainer]
-  );
+  const pickerContainer =
+    (swatchElement && getDialogFocusTrapContainer(swatchElement)) ||
+    portalContainer;
 
   const handleClick = () => {
     if (disabled || readOnly) return;

--- a/newIDE/app/src/UI/MaterialUISpecificUtil.js
+++ b/newIDE/app/src/UI/MaterialUISpecificUtil.js
@@ -84,19 +84,22 @@ export const isElementAMuiInput = (element: Element): boolean => {
 
 /**
  * Returns the element on which the Material UI dialog containing the given
- * element is "trapping" the focus, if any.
+ * element is "trapping" the focus, if any (this is the element that `Dialog`
+ * gives to the `TrapFocus` used internally by `Modal`).
  *
- * Material UI dialogs continuously give the focus back to this element as long
- * as the focused element is not one of its children. This means that anything
- * rendered in a portal outside of it (a `Popper` for example) can't be given
- * the focus: its text fields would be impossible to click on or to type in.
- * Rendering such a portal inside this element works around this.
+ * A dialog gives the focus back to this element as long as the focused element
+ * is not one of its children. So anything rendered in a portal outside of it (a
+ * `Popper` for example) can never keep the focus: its text fields are then
+ * impossible to click on or to type in. Rendering the portal inside this
+ * element works around this.
  */
 export const getDialogFocusTrapContainer = (element: Element): ?HTMLElement => {
-  // This is the element that Material UI dialogs pass to the `TrapFocus`
-  // used internally by `Modal`.
-  // Note that `instanceof HTMLElement` can't be used to check the result, as the
-  // element can come from another window (see `WindowPortal`), in which case it
-  // is built from a different constructor than the main window one.
-  return ((element.closest('.MuiDialog-container'): any): ?HTMLElement);
+  // The class name is matched by prefix, and not exactly: because themes are
+  // nested (see `FullThemeProvider`), Material UI appends a counter to its
+  // global class names (`MuiDialog-container-10242` for example).
+  // The result is not checked with `instanceof HTMLElement`, as it can come from
+  // another window (see `WindowPortal`) where constructors are different.
+  return ((element.closest(
+    '[class^="MuiDialog-container"], [class*=" MuiDialog-container"]'
+  ): any): ?HTMLElement);
 };

--- a/newIDE/app/src/UI/MaterialUISpecificUtil.js
+++ b/newIDE/app/src/UI/MaterialUISpecificUtil.js
@@ -81,3 +81,22 @@ export const doesPathContainDialog = (path: Array<Element>): boolean => {
 export const isElementAMuiInput = (element: Element): boolean => {
   return element.classList.contains('MuiInputBase-root');
 };
+
+/**
+ * Returns the element on which the Material UI dialog containing the given
+ * element is "trapping" the focus, if any.
+ *
+ * Material UI dialogs continuously give the focus back to this element as long
+ * as the focused element is not one of its children. This means that anything
+ * rendered in a portal outside of it (a `Popper` for example) can't be given
+ * the focus: its text fields would be impossible to click on or to type in.
+ * Rendering such a portal inside this element works around this.
+ */
+export const getDialogFocusTrapContainer = (element: Element): ?HTMLElement => {
+  // This is the element that Material UI dialogs pass to the `TrapFocus`
+  // used internally by `Modal`.
+  // Note that `instanceof HTMLElement` can't be used to check the result, as the
+  // element can come from another window (see `WindowPortal`), in which case it
+  // is built from a different constructor than the main window one.
+  return ((element.closest('.MuiDialog-container'): any): ?HTMLElement);
+};

--- a/newIDE/app/src/UI/MaterialUISpecificUtil.spec.js
+++ b/newIDE/app/src/UI/MaterialUISpecificUtil.spec.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+// @flow
+import { getDialogFocusTrapContainer } from './MaterialUISpecificUtil';
+
+// The class names are suffixed with a counter by Material UI when themes are
+// nested (see `FullThemeProvider`), so both forms must be recognized.
+const testCases: Array<{|
+  title: string,
+  html: string,
+  expectedClassName: string | null,
+|}> = [
+  {
+    title: 'the dialog container',
+    html:
+      '<div class="MuiDialog-container MuiDialog-scrollPaper"><i></i></div>',
+    expectedClassName: 'MuiDialog-container MuiDialog-scrollPaper',
+  },
+  {
+    title: 'the dialog container with suffixed class names',
+    html:
+      '<div class="MuiDialog-container-10242 MuiDialog-scrollPaper-10240"><i></i></div>',
+    expectedClassName: 'MuiDialog-container-10242 MuiDialog-scrollPaper-10240',
+  },
+  {
+    title: 'the innermost dialog container when dialogs are nested',
+    html:
+      '<div class="MuiDialog-container-1"><div class="MuiDialog-container-2"><i></i></div></div>',
+    expectedClassName: 'MuiDialog-container-2',
+  },
+  {
+    title: 'nothing when the element is not in a dialog',
+    html: '<div class="some-panel"><i></i></div>',
+    expectedClassName: null,
+  },
+  {
+    title: 'nothing for a class only containing the container class name',
+    html: '<div class="custom-MuiDialog-container"><i></i></div>',
+    expectedClassName: null,
+  },
+];
+
+describe('getDialogFocusTrapContainer', () => {
+  testCases.forEach(({ title, html, expectedClassName }) => {
+    it(`returns ${title}`, () => {
+      document.body.innerHTML = html;
+      const element = document.querySelector('i');
+      if (!element) throw new Error('The test element was not rendered.');
+
+      const container = getDialogFocusTrapContainer(element);
+      expect(container ? container.className : null).toBe(expectedClassName);
+    });
+  });
+});

--- a/newIDE/app/src/UI/MaterialUISpecificUtil.spec.js
+++ b/newIDE/app/src/UI/MaterialUISpecificUtil.spec.js
@@ -44,7 +44,10 @@ const testCases: Array<{|
 describe('getDialogFocusTrapContainer', () => {
   testCases.forEach(({ title, html, expectedClassName }) => {
     it(`returns ${title}`, () => {
-      document.body.innerHTML = html;
+      const documentBody = document.body;
+      if (!documentBody) throw new Error('The document body is missing.');
+
+      documentBody.innerHTML = html;
       const element = document.querySelector('i');
       if (!element) throw new Error('The test element was not rendered.');
 


### PR DESCRIPTION
Dialogs trap the focus inside them: since the color picker is rendered in a
`Popper` (portaled outside of the dialog), the dialog was continuously taking
the focus back, making the hexadecimal and RGB fields impossible to click on
or to type in.

Render the picker inside the dialog container when there is one, so that it
can keep the focus. Pickers displayed outside of a dialog (layers list,
properties panel, events sheet) are unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013T6UrohvVR77BsbfUXpfp4