### PR TITLE
Fix rapidjson build failure with GCC 15 (GenericStringRef assignment)

### DIFF
--- a/Core/GDCore/Serialization/rapidjson/document.h
+++ b/Core/GDCore/Serialization/rapidjson/document.h
@@ -316,8 +316,6 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
-
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 
@@ -328,6 +326,8 @@ private:
     //! Disallow construction from non-const array
     template<SizeType N>
     GenericStringRef(CharType (&str)[N]) /* = delete */;
+    //! Copy assignment operator not permitted - immutable type
+    GenericStringRef& operator=(const GenericStringRef& rhs) /* = delete */;
 };
 
 //! Mark a character pointer as constant string


### PR DESCRIPTION
The vendored rapidjson 1.1.0 ships a broken copy-assignment operator for `GenericStringRef`: it assigns to the `const` members `s` and `length`, and never returns anything. Both members are `const` by design, so the type is immutable and the operator can never have a valid instantiation.

Apply the same fix as rapidjson upstream: drop the definition and declare the copy-assignment operator private and undefined, so the immutability of the type is enforced instead of silently violated.