### PR TITLE
Add a preview of color parameters in the events sheet

### DIFF
--- a/newIDE/app/src/EventsSheet/ParameterFields/ColorExpressionField.js
+++ b/newIDE/app/src/EventsSheet/ParameterFields/ColorExpressionField.js
@@ -5,9 +5,18 @@ import {
   type ParameterFieldInterface,
   type FieldFocusFunction,
 } from './ParameterFieldCommons';
+import { type ParameterInlineRendererProps } from './ParameterInlineRenderer.flow';
+import { renderInlineDefaultField } from './DefaultField';
 import GenericExpressionField from './GenericExpressionField';
 import ColorPicker from '../../UI/ColorField/ColorPicker';
 import { rgbStringAndAlphaToRGBColor } from '../../Utils/ColorTransformer';
+
+const inlineColorPickerStyle = {
+  width: 'var(--icon-size)',
+  height: 'var(--icon-size)',
+  verticalAlign: 'sub',
+  pointerEvents: 'none', // Prevents the color picker from being interactive in the inline renderer, otherwise the focus is steal by the popover react component and the color picker is visible but unsusable.
+};
 
 export default (React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   function ColorExpressionField(props: ParameterFieldProps, ref) {
@@ -53,3 +62,28 @@ export default (React.forwardRef<ParameterFieldProps, ParameterFieldInterface>(
   ...ParameterFieldProps,
   +ref?: React.RefSetter<ParameterFieldInterface>,
 }>);
+
+/**
+ * Display the color of the parameter next to its value, as a small square.
+ * This is only a preview: the color is edited by opening the parameter, like
+ * any other one.
+ */
+export const renderInlineColor = (
+  props: ParameterInlineRendererProps
+): React.Node => {
+  const rgbColor = props.expressionIsValid
+    ? rgbStringAndAlphaToRGBColor(props.value)
+    : null;
+  if (!rgbColor) return renderInlineDefaultField(props);
+
+  return (
+    <>
+      {renderInlineDefaultField(props)}{' '}
+      <ColorPicker
+        size="compact"
+        color={rgbColor}
+        style={inlineColorPickerStyle}
+      />
+    </>
+  );
+};

--- a/newIDE/app/src/EventsSheet/ParameterRenderingService.js
+++ b/newIDE/app/src/EventsSheet/ParameterRenderingService.js
@@ -62,7 +62,9 @@ import JsonResourceField from './ParameterFields/JsonResourceField';
 import SpineResourceField from './ParameterFields/SpineResourceField';
 import BitmapFontResourceField from './ParameterFields/BitmapFontResourceField';
 import FontResourceField from './ParameterFields/FontResourceField';
-import ColorExpressionField from './ParameterFields/ColorExpressionField';
+import ColorExpressionField, {
+  renderInlineColor,
+} from './ParameterFields/ColorExpressionField';
 import ForceMultiplierField, {
   renderInlineForceMultiplier,
 } from './ParameterFields/ForceMultiplierField';
@@ -172,6 +174,7 @@ const inlineRenderers: { [string]: ParameterInlineRenderer } = {
   operator: renderInlineOperator,
   relationalOperator: renderInlineRelationalOperator,
   leaderboardId: renderInlineLeaderboardIdField,
+  color: renderInlineColor,
 };
 const userFriendlyTypeName: { [string]: MessageDescriptor } = {
   mouse: t`Mouse button`,


### PR DESCRIPTION
Re-implement only the visual part of the inline color swatch next to their `R;G;B` value in the eventsheet.

This is a lighter take on #8927, which was reverted in #8975. That version made the swatch open the picker directly, which required replacing the `Popover` of `ColorPicker` with a raw `Popper` (losing the focus handling that Material UI modals provide), a module level flag to carry the click to the field mounted afterwards, and two extra props. Since `ColorPicker` is untouched here, the focus issue that #8966 was fixing cannot happen, and that pull request has been closed.
