### PR TITLE
Rotate 2D light fix

### DIFF
--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -72,19 +72,24 @@ namespace gdjs {
       this.updateTexture();
       this._center = new Float32Array([runtimeObject.x, runtimeObject.y]);
       this._defaultVertexBuffer = new Float32Array(8);
-      // Sized with the same sqrt(2) safety margin as the fallback quad in
-      // _updateBuffers, so a rotated texture isn't clipped on the first
-      // frame either.
-      const initialMeshHalfSize = this._radius * Math.SQRT2;
+      // Built from the light's square *rotated by the object's initial
+      // angle*, matching the fallback quad computed in _updateBuffers (see
+      // the comment there). At angle 0 this is identical to the original
+      // axis-aligned square.
+      const initialAngleRad = gdjs.toRad(runtimeObject.getAngle());
+      const initialCosA = Math.cos(initialAngleRad);
+      const initialSinA = Math.sin(initialAngleRad);
+      const initialA = this._radius * (initialCosA + initialSinA);
+      const initialB = this._radius * (initialCosA - initialSinA);
       this._vertexBuffer = new Float32Array([
-        runtimeObject.x - initialMeshHalfSize,
-        runtimeObject.y + initialMeshHalfSize,
-        runtimeObject.x + initialMeshHalfSize,
-        runtimeObject.y + initialMeshHalfSize,
-        runtimeObject.x + initialMeshHalfSize,
-        runtimeObject.y - initialMeshHalfSize,
-        runtimeObject.x - initialMeshHalfSize,
-        runtimeObject.y - initialMeshHalfSize,
+        runtimeObject.x - initialA,
+        runtimeObject.y + initialB,
+        runtimeObject.x + initialB,
+        runtimeObject.y + initialA,
+        runtimeObject.x + initialA,
+        runtimeObject.y - initialB,
+        runtimeObject.x - initialB,
+        runtimeObject.y - initialA,
       ]);
       this._indexBuffer = new Uint16Array([0, 1, 2, 0, 2, 3]);
       this.updateMesh();
@@ -344,7 +349,7 @@ namespace gdjs {
       const geometry = new PIXI.Geometry();
       geometry
         .addAttribute('aVertexPosition', this._vertexBuffer, 2)
-        .addIndex(this._indexBuffer as any);
+        .addIndex(this._indexBuffer);
       if (!this._light) {
         this._light = new PIXI.Mesh(geometry, shader);
         this._light.blendMode = PIXI.BLEND_MODES.ADD;
@@ -467,31 +472,36 @@ namespace gdjs {
 
       // Fallback to simple quad when there are no obstacles around.
       if (vertices.length === 0) {
-        // The shader now rotates the sampled texture coordinates with the
-        // object's angle, so the *mesh* must be large enough to cover the
-        // full rotated square, not just the axis-aligned one. Otherwise the
-        // rasterizer clips corners of the (correctly rotated) texture before
-        // the shader's own alpha mask gets a chance to shape it. A square of
-        // half-side `radius` rotated by any angle always fits within an
-        // axis-aligned square of half-side `radius * sqrt(2)`, so we build
-        // the mesh at that size and let the shader do the exact, rotated
-        // clipping.
-        const meshHalfSize = this._radius * Math.SQRT2;
-        this._defaultVertexBuffer[0] = this._object.x - meshHalfSize;
-        this._defaultVertexBuffer[1] = this._object.y + meshHalfSize;
-        this._defaultVertexBuffer[2] = this._object.x + meshHalfSize;
-        this._defaultVertexBuffer[3] = this._object.y + meshHalfSize;
-        this._defaultVertexBuffer[4] = this._object.x + meshHalfSize;
-        this._defaultVertexBuffer[5] = this._object.y - meshHalfSize;
-        this._defaultVertexBuffer[6] = this._object.x - meshHalfSize;
-        this._defaultVertexBuffer[7] = this._object.y - meshHalfSize;
+        // Build the mesh as the light's square *rotated by the object's
+        // angle*, so it exactly matches the rotated square the shader
+        // samples the texture from (see texturedFragmentShader). At angle 0
+        // this collapses to exactly the original axis-aligned square, so it
+        // doesn't change anything for unrotated lights; at other angles it
+        // avoids clipping the corners of the (correctly rotated) texture,
+        // without over-sizing the mesh beyond what's actually needed.
+        const angleRad = gdjs.toRad(this._object.getAngle());
+        const cosA = Math.cos(angleRad);
+        const sinA = Math.sin(angleRad);
+        const r = this._radius;
+        const cx = this._object.x;
+        const cy = this._object.y;
+        const a = r * (cosA + sinA);
+        const b = r * (cosA - sinA);
+        this._defaultVertexBuffer[0] = cx - a;
+        this._defaultVertexBuffer[1] = cy + b;
+        this._defaultVertexBuffer[2] = cx + b;
+        this._defaultVertexBuffer[3] = cy + a;
+        this._defaultVertexBuffer[4] = cx + a;
+        this._defaultVertexBuffer[5] = cy - b;
+        this._defaultVertexBuffer[6] = cx - b;
+        this._defaultVertexBuffer[7] = cy - a;
         this._light.shader.uniforms.center = this._center;
         this._light.geometry
           .getBuffer('aVertexPosition')
-          .update(this._defaultVertexBuffer as any);
+          .update(this._defaultVertexBuffer);
         this._light.geometry
           .getIndex()
-          .update(LightRuntimeObjectPixiRenderer._defaultIndexBuffer as any);
+          .update(LightRuntimeObjectPixiRenderer._defaultIndexBuffer);
         return;
       }
       const verticesCount = vertices.length;
@@ -545,8 +555,8 @@ namespace gdjs {
       if (!isSubArrayUsed) {
         this._light.geometry
           .getBuffer('aVertexPosition')
-          .update(this._vertexBuffer as any);
-        this._light.geometry.getIndex().update(this._indexBuffer as any);
+          .update(this._vertexBuffer);
+        this._light.geometry.getIndex().update(this._indexBuffer);
       } else {
         this._light.geometry
           .getBuffer('aVertexPosition')
@@ -607,16 +617,33 @@ namespace gdjs {
       }
 
       // Seed the self-boundary ("wall" that unoccluded rays terminate on)
-      // with a square large enough to circumscribe the light's square at any
-      // rotation angle (see the comment in the fallback branch above for why
-      // sqrt(2) is the right factor). Without this, rays that don't hit a
-      // real obstacle would be capped by an axis-aligned box that doesn't
-      // rotate with the object, clipping the corners of the rotated texture.
-      const selfBoundaryHalfSize = this._radius * Math.SQRT2;
-      let maxX = this._object.x + selfBoundaryHalfSize;
-      let minX = this._object.x - selfBoundaryHalfSize;
-      let maxY = this._object.y + selfBoundaryHalfSize;
-      let minY = this._object.y - selfBoundaryHalfSize;
+      // with the axis-aligned bounding box of the light's square *rotated by
+      // the object's angle* — i.e. the same rotated square the fallback quad
+      // and the shader use (see the fallback branch above). At angle 0 this
+      // is exactly [x-radius, x+radius] x [y-radius, y+radius], same as
+      // before; at other angles it grows just enough to avoid clipping the
+      // corners of the rotated texture, without over-sizing the search area.
+      const selfAngleRad = gdjs.toRad(this._object.getAngle());
+      const selfCosA = Math.cos(selfAngleRad);
+      const selfSinA = Math.sin(selfAngleRad);
+      const selfA = this._radius * (selfCosA + selfSinA);
+      const selfB = this._radius * (selfCosA - selfSinA);
+      const selfCornersX = [
+        this._object.x - selfA,
+        this._object.x + selfB,
+        this._object.x + selfA,
+        this._object.x - selfB,
+      ];
+      const selfCornersY = [
+        this._object.y + selfB,
+        this._object.y + selfA,
+        this._object.y - selfB,
+        this._object.y - selfA,
+      ];
+      let maxX = Math.max.apply(null, selfCornersX);
+      let minX = Math.min.apply(null, selfCornersX);
+      let maxY = Math.max.apply(null, selfCornersY);
+      let minY = Math.min.apply(null, selfCornersY);
       const flattenVertices = this._flattenVerticesTemp;
       flattenVertices.length = 0;
       for (let i = 1; i < obstaclePolygons.length; i++) {

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -344,7 +344,7 @@ namespace gdjs {
       const geometry = new PIXI.Geometry();
       geometry
         .addAttribute('aVertexPosition', this._vertexBuffer, 2)
-        .addIndex(this._indexBuffer);
+        .addIndex(this._indexBuffer as any);
       if (!this._light) {
         this._light = new PIXI.Mesh(geometry, shader);
         this._light.blendMode = PIXI.BLEND_MODES.ADD;
@@ -488,10 +488,10 @@ namespace gdjs {
         this._light.shader.uniforms.center = this._center;
         this._light.geometry
           .getBuffer('aVertexPosition')
-          .update(this._defaultVertexBuffer);
+          .update(this._defaultVertexBuffer as any);
         this._light.geometry
           .getIndex()
-          .update(LightRuntimeObjectPixiRenderer._defaultIndexBuffer);
+          .update(LightRuntimeObjectPixiRenderer._defaultIndexBuffer as any);
         return;
       }
       const verticesCount = vertices.length;
@@ -545,8 +545,8 @@ namespace gdjs {
       if (!isSubArrayUsed) {
         this._light.geometry
           .getBuffer('aVertexPosition')
-          .update(this._vertexBuffer);
-        this._light.geometry.getIndex().update(this._indexBuffer);
+          .update(this._vertexBuffer as any);
+        this._light.geometry.getIndex().update(this._indexBuffer as any);
       } else {
         this._light.geometry
           .getBuffer('aVertexPosition')

--- a/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
+++ b/Extensions/Lighting/lightruntimeobject-pixi-renderer.ts
@@ -72,15 +72,19 @@ namespace gdjs {
       this.updateTexture();
       this._center = new Float32Array([runtimeObject.x, runtimeObject.y]);
       this._defaultVertexBuffer = new Float32Array(8);
+      // Sized with the same sqrt(2) safety margin as the fallback quad in
+      // _updateBuffers, so a rotated texture isn't clipped on the first
+      // frame either.
+      const initialMeshHalfSize = this._radius * Math.SQRT2;
       this._vertexBuffer = new Float32Array([
-        runtimeObject.x - this._radius,
-        runtimeObject.y + this._radius,
-        runtimeObject.x + this._radius,
-        runtimeObject.y + this._radius,
-        runtimeObject.x + this._radius,
-        runtimeObject.y - this._radius,
-        runtimeObject.x - this._radius,
-        runtimeObject.y - this._radius,
+        runtimeObject.x - initialMeshHalfSize,
+        runtimeObject.y + initialMeshHalfSize,
+        runtimeObject.x + initialMeshHalfSize,
+        runtimeObject.y + initialMeshHalfSize,
+        runtimeObject.x + initialMeshHalfSize,
+        runtimeObject.y - initialMeshHalfSize,
+        runtimeObject.x - initialMeshHalfSize,
+        runtimeObject.y - initialMeshHalfSize,
       ]);
       this._indexBuffer = new Uint16Array([0, 1, 2, 0, 2, 3]);
       this.updateMesh();
@@ -326,6 +330,7 @@ namespace gdjs {
         center: this._center,
         radius: this._radius,
         color: this._color,
+        angle: gdjs.toRad(this._object.getAngle()),
       };
       if (this._texture) {
         // @ts-ignore
@@ -457,18 +462,29 @@ namespace gdjs {
       }
       this._center[0] = this._object.x;
       this._center[1] = this._object.y;
+      this._light.shader.uniforms.angle = gdjs.toRad(this._object.getAngle());
       const vertices = this._computeLightVertices();
 
       // Fallback to simple quad when there are no obstacles around.
       if (vertices.length === 0) {
-        this._defaultVertexBuffer[0] = this._object.x - this._radius;
-        this._defaultVertexBuffer[1] = this._object.y + this._radius;
-        this._defaultVertexBuffer[2] = this._object.x + this._radius;
-        this._defaultVertexBuffer[3] = this._object.y + this._radius;
-        this._defaultVertexBuffer[4] = this._object.x + this._radius;
-        this._defaultVertexBuffer[5] = this._object.y - this._radius;
-        this._defaultVertexBuffer[6] = this._object.x - this._radius;
-        this._defaultVertexBuffer[7] = this._object.y - this._radius;
+        // The shader now rotates the sampled texture coordinates with the
+        // object's angle, so the *mesh* must be large enough to cover the
+        // full rotated square, not just the axis-aligned one. Otherwise the
+        // rasterizer clips corners of the (correctly rotated) texture before
+        // the shader's own alpha mask gets a chance to shape it. A square of
+        // half-side `radius` rotated by any angle always fits within an
+        // axis-aligned square of half-side `radius * sqrt(2)`, so we build
+        // the mesh at that size and let the shader do the exact, rotated
+        // clipping.
+        const meshHalfSize = this._radius * Math.SQRT2;
+        this._defaultVertexBuffer[0] = this._object.x - meshHalfSize;
+        this._defaultVertexBuffer[1] = this._object.y + meshHalfSize;
+        this._defaultVertexBuffer[2] = this._object.x + meshHalfSize;
+        this._defaultVertexBuffer[3] = this._object.y + meshHalfSize;
+        this._defaultVertexBuffer[4] = this._object.x + meshHalfSize;
+        this._defaultVertexBuffer[5] = this._object.y - meshHalfSize;
+        this._defaultVertexBuffer[6] = this._object.x - meshHalfSize;
+        this._defaultVertexBuffer[7] = this._object.y - meshHalfSize;
         this._light.shader.uniforms.center = this._center;
         this._light.geometry
           .getBuffer('aVertexPosition')
@@ -590,10 +606,17 @@ namespace gdjs {
         }
       }
 
-      let maxX = this._object.x + this._radius;
-      let minX = this._object.x - this._radius;
-      let maxY = this._object.y + this._radius;
-      let minY = this._object.y - this._radius;
+      // Seed the self-boundary ("wall" that unoccluded rays terminate on)
+      // with a square large enough to circumscribe the light's square at any
+      // rotation angle (see the comment in the fallback branch above for why
+      // sqrt(2) is the right factor). Without this, rays that don't hit a
+      // real obstacle would be capped by an axis-aligned box that doesn't
+      // rotate with the object, clipping the corners of the rotated texture.
+      const selfBoundaryHalfSize = this._radius * Math.SQRT2;
+      let maxX = this._object.x + selfBoundaryHalfSize;
+      let minX = this._object.x - selfBoundaryHalfSize;
+      let maxY = this._object.y + selfBoundaryHalfSize;
+      let minY = this._object.y - selfBoundaryHalfSize;
       const flattenVertices = this._flattenVerticesTemp;
       flattenVertices.length = 0;
       for (let i = 1; i < obstaclePolygons.length; i++) {
@@ -776,12 +799,22 @@ namespace gdjs {
   uniform vec2 center;
   uniform float radius;
   uniform vec3 color;
+  uniform float angle;
   uniform sampler2D uSampler;
   varying vec2 vPos;
 
   void main() {
-    vec2 topleft = vec2(center.x - radius, center.y - radius);
-    vec2 texCoord = (vPos - topleft)/(2.0 * radius);
+    vec2 relativePos = vPos - center;
+    float cosA = cos(angle);
+    float sinA = sin(angle);
+    // Rotate the sampled point back by the object's angle so that the
+    // texture appears to rotate together with the light object.
+    vec2 rotatedPos = vec2(
+      relativePos.x * cosA + relativePos.y * sinA,
+      -relativePos.x * sinA + relativePos.y * cosA
+    );
+    vec2 topleft = vec2(-radius, -radius);
+    vec2 texCoord = (rotatedPos - topleft)/(2.0 * radius);
     gl_FragColor = (texCoord.x > 0.0 && texCoord.x < 1.0 && texCoord.y > 0.0 && texCoord.y < 1.0)
       ? vec4(color, 1.0) * texture2D(uSampler, texCoord)
       : vec4(0.0, 0.0, 0.0, 0.0);

--- a/Extensions/Lighting/tests/lightruntimeobject.spec.js
+++ b/Extensions/Lighting/tests/lightruntimeobject.spec.js
@@ -54,123 +54,6 @@ const addLightObstacle = (runtimeScene, width, height) => {
   return obstacle;
 };
 
-/**
- * Helper to compute the expected vertex and index buffers for a given
- * light and obstacle setup, using the same √2 scaling as the renderer.
- */
-function computeExpectedBuffers(lightX, lightY, radius, obstacleX, obstacleY, obstacleWidth, obstacleHeight) {
-  const centerX = lightX;
-  const centerY = lightY;
-  const halfSize = radius * Math.SQRT2; // self‑boundary square half‑size
-
-  // Build the self‑boundary polygon (a square)
-  const selfBoundary = gdjs.Polygon.createRectangle(2 * halfSize, 2 * halfSize);
-  selfBoundary.setPosition(centerX - halfSize, centerY - halfSize);
-
-  // Build the obstacle polygon (a rectangle)
-  const obstaclePoly = gdjs.Polygon.createRectangle(obstacleWidth, obstacleHeight);
-  obstaclePoly.setPosition(obstacleX - obstacleWidth / 2, obstacleY - obstacleHeight / 2);
-
-  // List of polygons: self‑boundary first, then the obstacle
-  const polygons = [selfBoundary, obstaclePoly];
-
-  // Collect all unique vertices from both polygons
-  const allVertices = [];
-  const pushUnique = (v) => {
-    const eps = 1e-6;
-    for (let existing of allVertices) {
-      if (Math.abs(existing[0] - v[0]) < eps && Math.abs(existing[1] - v[1]) < eps) {
-        return; // already present
-      }
-    }
-    allVertices.push([v[0], v[1]]);
-  };
-
-  for (let poly of polygons) {
-    for (let v of poly.vertices) {
-      pushUnique(v);
-    }
-  }
-
-  // Compute the farthest distance from center to any vertex (for ray length)
-  let maxDist = 0;
-  for (let v of allVertices) {
-    const dx = v[0] - centerX;
-    const dy = v[1] - centerY;
-    maxDist = Math.max(maxDist, Math.sqrt(dx * dx + dy * dy));
-  }
-  const boundingDiag = maxDist * 1.1; // safe margin
-
-  // For each vertex angle, cast a ray and find the closest intersection
-  const resultPoints = [];
-  const angleEpsilon = 0.0001; // same offset as in renderer
-
-  for (let v of allVertices) {
-    const dx = v[0] - centerX;
-    const dy = v[1] - centerY;
-    const angle = Math.atan2(dy, dx);
-    // cast at angle, angle + epsilon, angle - epsilon
-    for (let a of [angle, angle + angleEpsilon, angle - angleEpsilon]) {
-      const targetX = centerX + boundingDiag * Math.cos(a);
-      const targetY = centerY + boundingDiag * Math.sin(a);
-      let closestDist = Infinity;
-      let hitPoint = null;
-      for (let poly of polygons) {
-        const result = gdjs.Polygon.raycastTest(poly, centerX, centerY, targetX, targetY);
-        if (result.collision && result.closeSqDist < closestDist) {
-          closestDist = result.closeSqDist;
-          hitPoint = [result.closeX, result.closeY];
-        }
-      }
-      if (hitPoint) {
-        // Avoid duplicates by angle (same as renderer's filter)
-        let duplicate = false;
-        for (let existing of resultPoints) {
-          if (Math.abs(existing.angle - a) < 1e-6) {
-            duplicate = true;
-            break;
-          }
-        }
-        if (!duplicate) {
-          resultPoints.push({ vertex: hitPoint, angle: a });
-        }
-      }
-    }
-  }
-
-  // Sort by angle (like renderer's comparator)
-  resultPoints.sort((a, b) => a.angle - b.angle);
-
-  // Filter out points with same angle (renderer does this)
-  const filtered = [];
-  if (resultPoints.length > 0) {
-    filtered.push(resultPoints[0].vertex);
-    for (let i = 1; i < resultPoints.length; i++) {
-      if (Math.abs(resultPoints[i].angle - resultPoints[i-1].angle) > 1e-6) {
-        filtered.push(resultPoints[i].vertex);
-      }
-    }
-  }
-
-  // Build vertex buffer: center + all filtered vertices
-  const vertexList = [];
-  vertexList.push(centerX, centerY);
-  for (let v of filtered) {
-    vertexList.push(v[0], v[1]);
-  }
-  const vertexBuffer = new Float32Array(vertexList);
-
-  // Build index buffer: triangles (center, i, i+1)
-  const n = filtered.length;
-  const indexList = [];
-  for (let i = 0; i < n; i++) {
-    indexList.push(0, i+1, (i+1) % n + 1);
-  }
-  const indexBuffer = new Uint16Array(indexList);
-
-  return { vertexBuffer, indexBuffer };
-}
-
 describe('gdjs.LightRuntimeObject', function () {
   PIXI.settings.FAIL_IF_MAJOR_PERFORMANCE_CAVEAT = false;
   const runtimeGame = gdjs.getPixiRuntimeGame();
@@ -199,19 +82,11 @@ describe('gdjs.LightRuntimeObject', function () {
   it('bail out early while raycasting when there is no light obstacle', function () {
     expect(lightObj._renderer._computeLightVertices()).to.eql([]);
     lightObj._renderer._updateBuffers();
-    // Now the fallback quad uses radius * √2
-    const expected = new Float32Array([
-      200 - 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
-      200 + 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
-      200 + 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
-      200 - 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
-    ]);
-    const actual = lightObj._renderer._defaultVertexBuffer;
-    for (let i = 0; i < expected.length; i++) {
-      expect(actual[i]).to.be.closeTo(expected[i], 1e-6);
-    }
+    expect(lightObj._renderer._defaultVertexBuffer).to.eql(
+      new Float32Array([100, 300, 300, 300, 300, 100, 100, 100])
+    );
     expect(gdjs.LightRuntimeObjectPixiRenderer._defaultIndexBuffer).to.eql(
-      new Uint16Array([0, 1, 2, 0, 2, 3])
+      new Float32Array([0, 1, 2, 0, 2, 3])
     );
   });
 });
@@ -243,22 +118,29 @@ describe('Light with obstacles around it', function () {
     runtimeScene.renderAndStep(1000 / 60);
     light.update();
 
-    // Compute expected buffers using the same √2 scaling
-    const expected = computeExpectedBuffers(200, 200, 100, 250, 250, 50, 50);
     const vertexBuffer = light._renderer._vertexBuffer;
     const indexBuffer = light._renderer._indexBuffer;
+    // prettier-ignore
+    const expectedVertexBuffer = [
+      200, 200, 100, 100.0199966430664, 100, 100, 100.0199966430664, 100, 299.9800109863281,
+      100, 300, 100, 300, 100.0199966430664, 300, 249.9875030517578, 300, 250, 299.9750061035156,
+      250, 250.00999450683594, 250, 250, 250, 250,250.00999450683594, 250, 299.9750061035156, 250,
+      300, 249.9875030517578, 300, 100.0199966430664, 300, 100, 300, 100, 299.9800109863281,
+    ];
+    // prettier-ignore
+    const expectedIndexBuffer = [
+      0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 5, 0, 5, 6,
+      0, 6, 7, 0, 7, 8, 0, 8, 9, 0, 9, 10, 0, 10, 11,
+      0, 11, 12, 0, 12, 13, 0, 13, 14, 0, 14, 15, 0,
+      15, 16, 0, 16, 17, 0, 17, 18, 0, 18, 1,
+    ];
 
-    // Check lengths
-    expect(vertexBuffer.length).to.eql(expected.vertexBuffer.length);
-    expect(indexBuffer.length).to.eql(expected.indexBuffer.length);
-
-    // Check values with tolerance
-    for (let i = 0; i < expected.vertexBuffer.length; i++) {
-      expect(vertexBuffer[i]).to.be.closeTo(expected.vertexBuffer[i], 1e-4);
-    }
-    for (let i = 0; i < expected.indexBuffer.length; i++) {
-      expect(indexBuffer[i]).to.eql(expected.indexBuffer[i]); // indices are exact integers
-    }
+    expectedVertexBuffer.forEach((val, index) => {
+      expect(vertexBuffer[index]).to.be(val);
+    });
+    expectedIndexBuffer.forEach((val, index) => {
+      expect(indexBuffer[index]).to.be(val);
+    });
   });
 
   it('Vertex and index buffers after obstacle is moved.', function () {
@@ -266,19 +148,29 @@ describe('Light with obstacles around it', function () {
     runtimeScene.renderAndStep(1000 / 60);
     light.update();
 
-    const expected = computeExpectedBuffers(200, 200, 100, 150, 250, 50, 50);
     const vertexBuffer = light._renderer._vertexBuffer;
     const indexBuffer = light._renderer._indexBuffer;
+    // prettier-ignore
+    const expectedVertexBuffer = [
+      200, 200, 100, 100.0199966430664, 100, 100, 100.0199966430664, 100, 299.9800109863281,
+      100, 300, 100, 300, 100.0199966430664, 300, 299.9800109863281, 300, 300, 299.9800109863281,
+      300, 200.00999450683594, 300, 200, 250, 199.9949951171875, 250, 175.00625610351562, 250,
+      175, 250, 174.99374389648438, 250, 150.00999450683594, 250, 150, 250, 100, 299.9800109863281,
+    ];
+    // prettier-ignore
+    const expectedIndexBuffer = [
+      0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 5, 0, 5, 6, 0,
+      6, 7, 0, 7, 8, 0, 8, 9, 0, 9, 10, 0, 10, 11, 0,
+      11, 12, 0, 12, 13, 0, 13, 14, 0, 14, 15, 0, 15,
+      16, 0, 16, 17, 0, 17, 18, 0, 18, 1,
+    ];
 
-    expect(vertexBuffer.length).to.eql(expected.vertexBuffer.length);
-    expect(indexBuffer.length).to.eql(expected.indexBuffer.length);
-
-    for (let i = 0; i < expected.vertexBuffer.length; i++) {
-      expect(vertexBuffer[i]).to.be.closeTo(expected.vertexBuffer[i], 1e-4);
-    }
-    for (let i = 0; i < expected.indexBuffer.length; i++) {
-      expect(indexBuffer[i]).to.eql(expected.indexBuffer[i]);
-    }
+    expectedVertexBuffer.forEach((val, index) => {
+      expect(vertexBuffer[index]).to.be(val);
+    });
+    expectedIndexBuffer.forEach((val, index) => {
+      expect(indexBuffer[index]).to.be(val);
+    });
   });
 
   it("Obstacle moved outside light's radius.", function () {
@@ -291,18 +183,14 @@ describe('Light with obstacles around it', function () {
 
     const vertexBuffer = light._renderer._defaultVertexBuffer;
     const indexBuffer = gdjs.LightRuntimeObjectPixiRenderer._defaultIndexBuffer;
-    // Fallback quad uses √2 scaling
-    const expectedVertex = new Float32Array([
-      200 - 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
-      200 + 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
-      200 + 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
-      200 - 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
-    ]);
-    const expectedIndex = new Uint16Array([0, 1, 2, 0, 2, 3]);
+    const vertexData = [100, 300, 300, 300, 300, 100, 100, 100];
+    const indexData = [0, 1, 2, 0, 2, 3];
 
-    for (let i = 0; i < expectedVertex.length; i++) {
-      expect(vertexBuffer[i]).to.be.closeTo(expectedVertex[i], 1e-6);
-    }
-    expect(indexBuffer).to.eql(expectedIndex);
+    vertexData.forEach((val, index) => {
+      expect(vertexBuffer[index]).to.be(val);
+    });
+    indexData.forEach((val, index) => {
+      expect(indexBuffer[index]).to.be(val);
+    });
   });
 });

--- a/Extensions/Lighting/tests/lightruntimeobject.spec.js
+++ b/Extensions/Lighting/tests/lightruntimeobject.spec.js
@@ -54,6 +54,123 @@ const addLightObstacle = (runtimeScene, width, height) => {
   return obstacle;
 };
 
+/**
+ * Helper to compute the expected vertex and index buffers for a given
+ * light and obstacle setup, using the same √2 scaling as the renderer.
+ */
+function computeExpectedBuffers(lightX, lightY, radius, obstacleX, obstacleY, obstacleWidth, obstacleHeight) {
+  const centerX = lightX;
+  const centerY = lightY;
+  const halfSize = radius * Math.SQRT2; // self‑boundary square half‑size
+
+  // Build the self‑boundary polygon (a square)
+  const selfBoundary = gdjs.Polygon.createRectangle(2 * halfSize, 2 * halfSize);
+  selfBoundary.setPosition(centerX - halfSize, centerY - halfSize);
+
+  // Build the obstacle polygon (a rectangle)
+  const obstaclePoly = gdjs.Polygon.createRectangle(obstacleWidth, obstacleHeight);
+  obstaclePoly.setPosition(obstacleX - obstacleWidth / 2, obstacleY - obstacleHeight / 2);
+
+  // List of polygons: self‑boundary first, then the obstacle
+  const polygons = [selfBoundary, obstaclePoly];
+
+  // Collect all unique vertices from both polygons
+  const allVertices = [];
+  const pushUnique = (v) => {
+    const eps = 1e-6;
+    for (let existing of allVertices) {
+      if (Math.abs(existing[0] - v[0]) < eps && Math.abs(existing[1] - v[1]) < eps) {
+        return; // already present
+      }
+    }
+    allVertices.push([v[0], v[1]]);
+  };
+
+  for (let poly of polygons) {
+    for (let v of poly.vertices) {
+      pushUnique(v);
+    }
+  }
+
+  // Compute the farthest distance from center to any vertex (for ray length)
+  let maxDist = 0;
+  for (let v of allVertices) {
+    const dx = v[0] - centerX;
+    const dy = v[1] - centerY;
+    maxDist = Math.max(maxDist, Math.sqrt(dx * dx + dy * dy));
+  }
+  const boundingDiag = maxDist * 1.1; // safe margin
+
+  // For each vertex angle, cast a ray and find the closest intersection
+  const resultPoints = [];
+  const angleEpsilon = 0.0001; // same offset as in renderer
+
+  for (let v of allVertices) {
+    const dx = v[0] - centerX;
+    const dy = v[1] - centerY;
+    const angle = Math.atan2(dy, dx);
+    // cast at angle, angle + epsilon, angle - epsilon
+    for (let a of [angle, angle + angleEpsilon, angle - angleEpsilon]) {
+      const targetX = centerX + boundingDiag * Math.cos(a);
+      const targetY = centerY + boundingDiag * Math.sin(a);
+      let closestDist = Infinity;
+      let hitPoint = null;
+      for (let poly of polygons) {
+        const result = gdjs.Polygon.raycastTest(poly, centerX, centerY, targetX, targetY);
+        if (result.collision && result.closeSqDist < closestDist) {
+          closestDist = result.closeSqDist;
+          hitPoint = [result.closeX, result.closeY];
+        }
+      }
+      if (hitPoint) {
+        // Avoid duplicates by angle (same as renderer's filter)
+        let duplicate = false;
+        for (let existing of resultPoints) {
+          if (Math.abs(existing.angle - a) < 1e-6) {
+            duplicate = true;
+            break;
+          }
+        }
+        if (!duplicate) {
+          resultPoints.push({ vertex: hitPoint, angle: a });
+        }
+      }
+    }
+  }
+
+  // Sort by angle (like renderer's comparator)
+  resultPoints.sort((a, b) => a.angle - b.angle);
+
+  // Filter out points with same angle (renderer does this)
+  const filtered = [];
+  if (resultPoints.length > 0) {
+    filtered.push(resultPoints[0].vertex);
+    for (let i = 1; i < resultPoints.length; i++) {
+      if (Math.abs(resultPoints[i].angle - resultPoints[i-1].angle) > 1e-6) {
+        filtered.push(resultPoints[i].vertex);
+      }
+    }
+  }
+
+  // Build vertex buffer: center + all filtered vertices
+  const vertexList = [];
+  vertexList.push(centerX, centerY);
+  for (let v of filtered) {
+    vertexList.push(v[0], v[1]);
+  }
+  const vertexBuffer = new Float32Array(vertexList);
+
+  // Build index buffer: triangles (center, i, i+1)
+  const n = filtered.length;
+  const indexList = [];
+  for (let i = 0; i < n; i++) {
+    indexList.push(0, i+1, (i+1) % n + 1);
+  }
+  const indexBuffer = new Uint16Array(indexList);
+
+  return { vertexBuffer, indexBuffer };
+}
+
 describe('gdjs.LightRuntimeObject', function () {
   PIXI.settings.FAIL_IF_MAJOR_PERFORMANCE_CAVEAT = false;
   const runtimeGame = gdjs.getPixiRuntimeGame();
@@ -82,11 +199,19 @@ describe('gdjs.LightRuntimeObject', function () {
   it('bail out early while raycasting when there is no light obstacle', function () {
     expect(lightObj._renderer._computeLightVertices()).to.eql([]);
     lightObj._renderer._updateBuffers();
-    expect(lightObj._renderer._defaultVertexBuffer).to.eql(
-      new Float32Array([100, 300, 300, 300, 300, 100, 100, 100])
-    );
+    // Now the fallback quad uses radius * √2
+    const expected = new Float32Array([
+      200 - 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
+      200 + 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
+      200 + 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
+      200 - 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
+    ]);
+    const actual = lightObj._renderer._defaultVertexBuffer;
+    for (let i = 0; i < expected.length; i++) {
+      expect(actual[i]).to.be.closeTo(expected[i], 1e-6);
+    }
     expect(gdjs.LightRuntimeObjectPixiRenderer._defaultIndexBuffer).to.eql(
-      new Float32Array([0, 1, 2, 0, 2, 3])
+      new Uint16Array([0, 1, 2, 0, 2, 3])
     );
   });
 });
@@ -118,29 +243,22 @@ describe('Light with obstacles around it', function () {
     runtimeScene.renderAndStep(1000 / 60);
     light.update();
 
+    // Compute expected buffers using the same √2 scaling
+    const expected = computeExpectedBuffers(200, 200, 100, 250, 250, 50, 50);
     const vertexBuffer = light._renderer._vertexBuffer;
     const indexBuffer = light._renderer._indexBuffer;
-    // prettier-ignore
-    const expectedVertexBuffer = [
-      200, 200, 100, 100.0199966430664, 100, 100, 100.0199966430664, 100, 299.9800109863281,
-      100, 300, 100, 300, 100.0199966430664, 300, 249.9875030517578, 300, 250, 299.9750061035156,
-      250, 250.00999450683594, 250, 250, 250, 250,250.00999450683594, 250, 299.9750061035156, 250,
-      300, 249.9875030517578, 300, 100.0199966430664, 300, 100, 300, 100, 299.9800109863281,
-    ];
-    // prettier-ignore
-    const expectedIndexBuffer = [
-      0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 5, 0, 5, 6,
-      0, 6, 7, 0, 7, 8, 0, 8, 9, 0, 9, 10, 0, 10, 11,
-      0, 11, 12, 0, 12, 13, 0, 13, 14, 0, 14, 15, 0,
-      15, 16, 0, 16, 17, 0, 17, 18, 0, 18, 1,
-    ];
 
-    expectedVertexBuffer.forEach((val, index) => {
-      expect(vertexBuffer[index]).to.be(val);
-    });
-    expectedIndexBuffer.forEach((val, index) => {
-      expect(indexBuffer[index]).to.be(val);
-    });
+    // Check lengths
+    expect(vertexBuffer.length).to.eql(expected.vertexBuffer.length);
+    expect(indexBuffer.length).to.eql(expected.indexBuffer.length);
+
+    // Check values with tolerance
+    for (let i = 0; i < expected.vertexBuffer.length; i++) {
+      expect(vertexBuffer[i]).to.be.closeTo(expected.vertexBuffer[i], 1e-4);
+    }
+    for (let i = 0; i < expected.indexBuffer.length; i++) {
+      expect(indexBuffer[i]).to.eql(expected.indexBuffer[i]); // indices are exact integers
+    }
   });
 
   it('Vertex and index buffers after obstacle is moved.', function () {
@@ -148,29 +266,19 @@ describe('Light with obstacles around it', function () {
     runtimeScene.renderAndStep(1000 / 60);
     light.update();
 
+    const expected = computeExpectedBuffers(200, 200, 100, 150, 250, 50, 50);
     const vertexBuffer = light._renderer._vertexBuffer;
     const indexBuffer = light._renderer._indexBuffer;
-    // prettier-ignore
-    const expectedVertexBuffer = [
-      200, 200, 100, 100.0199966430664, 100, 100, 100.0199966430664, 100, 299.9800109863281,
-      100, 300, 100, 300, 100.0199966430664, 300, 299.9800109863281, 300, 300, 299.9800109863281,
-      300, 200.00999450683594, 300, 200, 250, 199.9949951171875, 250, 175.00625610351562, 250,
-      175, 250, 174.99374389648438, 250, 150.00999450683594, 250, 150, 250, 100, 299.9800109863281,
-    ];
-    // prettier-ignore
-    const expectedIndexBuffer = [
-      0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 5, 0, 5, 6, 0,
-      6, 7, 0, 7, 8, 0, 8, 9, 0, 9, 10, 0, 10, 11, 0,
-      11, 12, 0, 12, 13, 0, 13, 14, 0, 14, 15, 0, 15,
-      16, 0, 16, 17, 0, 17, 18, 0, 18, 1,
-    ];
 
-    expectedVertexBuffer.forEach((val, index) => {
-      expect(vertexBuffer[index]).to.be(val);
-    });
-    expectedIndexBuffer.forEach((val, index) => {
-      expect(indexBuffer[index]).to.be(val);
-    });
+    expect(vertexBuffer.length).to.eql(expected.vertexBuffer.length);
+    expect(indexBuffer.length).to.eql(expected.indexBuffer.length);
+
+    for (let i = 0; i < expected.vertexBuffer.length; i++) {
+      expect(vertexBuffer[i]).to.be.closeTo(expected.vertexBuffer[i], 1e-4);
+    }
+    for (let i = 0; i < expected.indexBuffer.length; i++) {
+      expect(indexBuffer[i]).to.eql(expected.indexBuffer[i]);
+    }
   });
 
   it("Obstacle moved outside light's radius.", function () {
@@ -183,14 +291,18 @@ describe('Light with obstacles around it', function () {
 
     const vertexBuffer = light._renderer._defaultVertexBuffer;
     const indexBuffer = gdjs.LightRuntimeObjectPixiRenderer._defaultIndexBuffer;
-    const vertexData = [100, 300, 300, 300, 300, 100, 100, 100];
-    const indexData = [0, 1, 2, 0, 2, 3];
+    // Fallback quad uses √2 scaling
+    const expectedVertex = new Float32Array([
+      200 - 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
+      200 + 100 * Math.SQRT2, 200 + 100 * Math.SQRT2,
+      200 + 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
+      200 - 100 * Math.SQRT2, 200 - 100 * Math.SQRT2,
+    ]);
+    const expectedIndex = new Uint16Array([0, 1, 2, 0, 2, 3]);
 
-    vertexData.forEach((val, index) => {
-      expect(vertexBuffer[index]).to.be(val);
-    });
-    indexData.forEach((val, index) => {
-      expect(indexBuffer[index]).to.be(val);
-    });
+    for (let i = 0; i < expectedVertex.length; i++) {
+      expect(vertexBuffer[i]).to.be.closeTo(expectedVertex[i], 1e-6);
+    }
+    expect(indexBuffer).to.eql(expectedIndex);
   });
 });


### PR DESCRIPTION
For many years, 2D light implementation had an issue, that prevented users from rotating it in GDevelop.

So, I fixed it.

![Screencast_20260824_123528.webm](https://github.com/user-attachments/assets/d03c979d-e1b5-4cdb-b719-7653e9633769)

![Screencast_20260824_123459.webm](https://github.com/user-attachments/assets/da1ae2a4-5d1c-453b-982e-50eb8dd4da7f)

https://forum.gdevelop.io/t/2d-light-object-texture-rotation/72909