### PR TITLE
Render only the visible variables in the variables list, and make its rows denser

### DIFF
--- a/newIDE/app/src/UI/SimpleTextField.module.css
+++ b/newIDE/app/src/UI/SimpleTextField.module.css
@@ -1,6 +1,9 @@
 /**
  * CSS classes for a text field, inspired from Material UI, but lightweight
  * and faster to render.
+ *
+ * The field is borderless until it's hovered or focused, so that a dense list
+ * of these fields does not look cluttered.
  */
 .simpleTextField {
   position: relative;
@@ -10,6 +13,7 @@
 .simpleTextField input {
   font-family: var(--gdevelop-modern-font-family);
   font-size: 14px;
+  line-height: 20px;
   outline: none;
   border: none;
   padding: 0;
@@ -19,11 +23,18 @@
   -moz-box-shadow: none;
   box-shadow: none;
   color: inherit;
+  caret-color: var(--theme-text-field-active-caret-color);
+  text-overflow: ellipsis;
   width: 100%;
+}
+
+.simpleTextField input::placeholder {
+  color: var(--theme-text-field-placeholder-color);
 }
 
 .disabled input {
   color: var(--theme-text-disabled-color);
+  text-overflow: clip;
 }
 
 .simpleTextField:before {
@@ -31,25 +42,21 @@
   left: 0;
   right: 0;
   content: '\00a0';
-  border-bottom: 1px solid var(--theme-text-default-color);
+  border-bottom: 1px solid transparent;
   display: block;
   position: absolute;
   pointer-events: none;
 }
+
 .simpleTextField:hover::before {
-  border-width: 2px;
+  border-bottom-color: var(--theme-text-field-hover-border-color);
 }
 .simpleTextField:focus-within::before {
-  border-width: 2px;
+  border-bottom-color: var(--theme-text-field-active-border-color);
 }
 
-.disabled:before {
-  border-bottom-style: dotted;
-  border-color: var(--theme-text-disabled-color);
-}
-.disabled:hover::before {
-  border-width: 1px;
-}
+/* A disabled field is not editable: never suggest that it can be edited. */
+.disabled:hover::before,
 .disabled:focus-within::before {
-  border-width: 1px;
+  border-bottom-color: transparent;
 }

--- a/newIDE/app/src/UI/useVisibleRowsRange.js
+++ b/newIDE/app/src/UI/useVisibleRowsRange.js
@@ -178,9 +178,15 @@ export const useVisibleRowsRange = ({
         scrollingAncestor.scrollBy(0, rowTop - top);
       } else if (rowBottom > bottom) {
         scrollingAncestor.scrollBy(0, rowBottom - bottom);
+      } else {
+        return;
       }
+
+      // Take the new scroll position into account right away, so that the row
+      // is rendered without waiting for the scroll event to be handled.
+      updateVisibleRowsRange();
     },
-    [containerRef, rowHeight]
+    [containerRef, rowHeight, updateVisibleRowsRange]
   );
 
   return { visibleRowsRange, scrollRowIntoView };

--- a/newIDE/app/src/UI/useVisibleRowsRange.js
+++ b/newIDE/app/src/UI/useVisibleRowsRange.js
@@ -1,0 +1,187 @@
+// @flow
+import * as React from 'react';
+
+export type VisibleRowsRange = {|
+  /** Index of the first row to render. */
+  firstRowIndex: number,
+  /** Index *after* the last row to render (so it's an exclusive bound). */
+  afterLastRowIndex: number,
+|};
+
+const emptyRange: VisibleRowsRange = { firstRowIndex: 0, afterLastRowIndex: 0 };
+
+/**
+ * All the ancestors clipping their content, from the closest to the farthest.
+ * The ancestors handling a scroll are a subset of these, so intersecting all of
+ * them gives the part of the screen where an element can actually be seen -
+ * without having to know which ancestor is the one handling the scroll.
+ */
+const getClippingAncestors = (element: Element): Array<Element> => {
+  const clippingAncestors: Array<Element> = [];
+  let ancestor = element.parentElement;
+  while (ancestor) {
+    if (window.getComputedStyle(ancestor).overflowY !== 'visible') {
+      clippingAncestors.push(ancestor);
+    }
+    ancestor = ancestor.parentElement;
+  }
+  return clippingAncestors;
+};
+
+/**
+ * The part of `container` that is on screen, in pixels from the top of
+ * `container` (so `top` is negative when the container starts above the screen).
+ */
+const getVisibleBand = (
+  container: Element,
+  clippingAncestors: Array<Element>
+): {| top: number, bottom: number |} => {
+  let top = 0;
+  let bottom = window.innerHeight;
+  for (const clippingAncestor of clippingAncestors) {
+    const ancestorRect = clippingAncestor.getBoundingClientRect();
+    top = Math.max(top, ancestorRect.top);
+    bottom = Math.min(bottom, ancestorRect.bottom);
+  }
+
+  const containerTop = container.getBoundingClientRect().top;
+  return { top: top - containerTop, bottom: bottom - containerTop };
+};
+
+type Props = {|
+  /**
+   * The element containing all the rows - including the ones that are not
+   * rendered (so its height must be `rowCount * rowHeight`).
+   */
+  containerRef: {| +current: ?Element |},
+  rowCount: number,
+  rowHeight: number,
+  /** Number of rows rendered before and after the ones on screen. */
+  overscanRowCount?: number,
+|};
+
+/**
+ * Compute the range of rows to render, so that only the rows that are on screen
+ * (plus a few of them around) have to be rendered.
+ *
+ * Contrary to most virtualized lists, the scroll is *not* handled by this hook:
+ * it can be handled by any ancestor (typically a properties panel scrolling all
+ * its sections at once, or a scroll view in a dialog), which is found by
+ * inspecting the DOM.
+ */
+export const useVisibleRowsRange = ({
+  containerRef,
+  rowCount,
+  rowHeight,
+  overscanRowCount = 4,
+}: Props): {|
+  visibleRowsRange: VisibleRowsRange,
+  scrollRowIntoView: (rowIndex: number) => void,
+|} => {
+  const [
+    visibleRowsRange,
+    setVisibleRowsRange,
+  ] = React.useState<VisibleRowsRange>(emptyRange);
+  // Finding the clipping ancestors reads the computed style of every ancestor,
+  // which is expensive: only do it when the container is (re)mounted.
+  const clippingAncestorsRef = React.useRef<Array<Element>>([]);
+
+  const updateVisibleRowsRange = React.useCallback(
+    () => {
+      const container = containerRef.current;
+      const newRange =
+        !container || rowCount === 0
+          ? emptyRange
+          : (() => {
+              const { top, bottom } = getVisibleBand(
+                container,
+                clippingAncestorsRef.current
+              );
+              return {
+                firstRowIndex: Math.max(
+                  0,
+                  Math.floor(top / rowHeight) - overscanRowCount
+                ),
+                afterLastRowIndex: Math.max(
+                  0,
+                  Math.min(
+                    rowCount,
+                    Math.ceil(bottom / rowHeight) + overscanRowCount
+                  )
+                ),
+              };
+            })();
+
+      setVisibleRowsRange(range =>
+        range.firstRowIndex === newRange.firstRowIndex &&
+        range.afterLastRowIndex === newRange.afterLastRowIndex
+          ? range
+          : newRange
+      );
+    },
+    [containerRef, rowCount, rowHeight, overscanRowCount]
+  );
+
+  React.useLayoutEffect(
+    () => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      clippingAncestorsRef.current = getClippingAncestors(container);
+      updateVisibleRowsRange();
+
+      let animationFrameId: AnimationFrameID | null = null;
+      const scheduleUpdate = () => {
+        if (animationFrameId !== null) return;
+        animationFrameId = requestAnimationFrame(() => {
+          animationFrameId = null;
+          updateVisibleRowsRange();
+        });
+      };
+
+      // Scroll events don't bubble, but they are dispatched to capturing
+      // listeners: this catches the scroll of any ancestor.
+      window.addEventListener('scroll', scheduleUpdate, true);
+      window.addEventListener('resize', scheduleUpdate);
+      const resizeObserver = new ResizeObserver(scheduleUpdate);
+      resizeObserver.observe(container);
+      for (const clippingAncestor of clippingAncestorsRef.current) {
+        resizeObserver.observe(clippingAncestor);
+      }
+
+      return () => {
+        if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
+        window.removeEventListener('scroll', scheduleUpdate, true);
+        window.removeEventListener('resize', scheduleUpdate);
+        resizeObserver.disconnect();
+      };
+    },
+    [containerRef, updateVisibleRowsRange]
+  );
+
+  const scrollRowIntoView = React.useCallback(
+    (rowIndex: number) => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const clippingAncestors = clippingAncestorsRef.current;
+      const scrollingAncestor = clippingAncestors.find(
+        clippingAncestor =>
+          clippingAncestor.scrollHeight > clippingAncestor.clientHeight
+      );
+      if (!scrollingAncestor) return;
+
+      const { top, bottom } = getVisibleBand(container, clippingAncestors);
+      const rowTop = rowIndex * rowHeight;
+      const rowBottom = rowTop + rowHeight;
+      if (rowTop < top) {
+        scrollingAncestor.scrollBy(0, rowTop - top);
+      } else if (rowBottom > bottom) {
+        scrollingAncestor.scrollBy(0, rowBottom - bottom);
+      }
+    },
+    [containerRef, rowHeight]
+  );
+
+  return { visibleRowsRange, scrollRowIntoView };
+};

--- a/newIDE/app/src/UI/useVisibleRowsRange.js
+++ b/newIDE/app/src/UI/useVisibleRowsRange.js
@@ -82,36 +82,35 @@ export const useVisibleRowsRange = ({
     visibleRowsRange,
     setVisibleRowsRange,
   ] = React.useState<VisibleRowsRange>(emptyRange);
-  // Finding the clipping ancestors reads the computed style of every ancestor,
-  // which is expensive: only do it when the container is (re)mounted.
   const clippingAncestorsRef = React.useRef<Array<Element>>([]);
+
+  const getRange = React.useCallback(
+    (): VisibleRowsRange => {
+      const container = containerRef.current;
+      if (!container || rowCount === 0) return emptyRange;
+
+      const { top, bottom } = getVisibleBand(
+        container,
+        clippingAncestorsRef.current
+      );
+      const firstRowIndex = Math.max(
+        0,
+        Math.min(rowCount, Math.floor(top / rowHeight) - overscanRowCount)
+      );
+      return {
+        firstRowIndex,
+        afterLastRowIndex: Math.max(
+          firstRowIndex,
+          Math.min(rowCount, Math.ceil(bottom / rowHeight) + overscanRowCount)
+        ),
+      };
+    },
+    [containerRef, rowCount, rowHeight, overscanRowCount]
+  );
 
   const updateVisibleRowsRange = React.useCallback(
     () => {
-      const container = containerRef.current;
-      const newRange =
-        !container || rowCount === 0
-          ? emptyRange
-          : (() => {
-              const { top, bottom } = getVisibleBand(
-                container,
-                clippingAncestorsRef.current
-              );
-              return {
-                firstRowIndex: Math.max(
-                  0,
-                  Math.floor(top / rowHeight) - overscanRowCount
-                ),
-                afterLastRowIndex: Math.max(
-                  0,
-                  Math.min(
-                    rowCount,
-                    Math.ceil(bottom / rowHeight) + overscanRowCount
-                  )
-                ),
-              };
-            })();
-
+      const newRange = getRange();
       setVisibleRowsRange(range =>
         range.firstRowIndex === newRange.firstRowIndex &&
         range.afterLastRowIndex === newRange.afterLastRowIndex
@@ -119,7 +118,7 @@ export const useVisibleRowsRange = ({
           : newRange
       );
     },
-    [containerRef, rowCount, rowHeight, overscanRowCount]
+    [getRange]
   );
 
   React.useLayoutEffect(
@@ -127,6 +126,10 @@ export const useVisibleRowsRange = ({
       const container = containerRef.current;
       if (!container) return;
 
+      // Finding the clipping ancestors reads the computed style of every
+      // ancestor: it's done again when the list changes size (a variable added,
+      // a search...), which is rare and also picks up a change of the layout
+      // around the list.
       clippingAncestorsRef.current = getClippingAncestors(container);
       updateVisibleRowsRange();
 

--- a/newIDE/app/src/VariablesList/FlattenVariables.js
+++ b/newIDE/app/src/VariablesList/FlattenVariables.js
@@ -1,0 +1,192 @@
+// @flow
+import { mapFor } from '../Utils/MapFor';
+import { inheritedPrefix, separator } from './VariableToTreeNodeHandling';
+
+const gd: libGDevelop = global.gd;
+
+/**
+ * A variable to be displayed as a row of the variables list. The tree of
+ * variables is flattened into a list of these, so that only the rows that
+ * are visible on screen have to be rendered.
+ */
+export type FlattenedVariable = {|
+  nodeId: string,
+  name: string,
+  /** Position of the variable in its parent (or in the container, for a root variable). */
+  index: number,
+  depth: number,
+  variable: gdVariable,
+  parentVariable: gdVariable | null,
+  isInherited: boolean,
+  type: Variable_Type,
+  isCollection: boolean,
+  isExpanded: boolean,
+|};
+
+/**
+ * Node ids of the variables to display, according to a search: the ones matching
+ * the search and all their ancestors (the descendants of a matching variable are
+ * displayed too, which is handled while walking the tree).
+ */
+const getNodeIdsToDisplay = (
+  searchMatchingNodeIds: Array<string>
+): Set<string> => {
+  const nodeIdsToDisplay = new Set<string>();
+  for (const matchingNodeId of searchMatchingNodeIds) {
+    let nodeId = '';
+    for (const nodeIdPart of matchingNodeId.split(separator)) {
+      nodeId = nodeId ? nodeId + separator + nodeIdPart : nodeIdPart;
+      nodeIdsToDisplay.add(nodeId);
+    }
+  }
+  return nodeIdsToDisplay;
+};
+
+const flattenVariable = ({
+  name,
+  index,
+  variable,
+  parentVariable,
+  parentNodeId,
+  depth,
+  isInherited,
+  hasMatchingAncestor,
+  searchFilter,
+  flattenedVariables,
+}: {|
+  name: string,
+  index: number,
+  variable: gdVariable,
+  parentVariable: gdVariable | null,
+  parentNodeId: string | null,
+  depth: number,
+  isInherited: boolean,
+  hasMatchingAncestor: boolean,
+  searchFilter: ?{|
+    matchingNodeIds: Set<string>,
+    nodeIdsToDisplay: Set<string>,
+  |},
+  flattenedVariables: Array<FlattenedVariable>,
+|}) => {
+  const nodeId = parentNodeId
+    ? `${parentNodeId}${separator}${name}`
+    : isInherited
+    ? `${inheritedPrefix}${name}`
+    : name;
+
+  if (
+    searchFilter &&
+    !hasMatchingAncestor &&
+    !searchFilter.nodeIdsToDisplay.has(nodeId)
+  ) {
+    // Neither this variable nor any of its descendants match the search.
+    return;
+  }
+
+  const type = variable.getType();
+  const isCollection =
+    type === gd.Variable.Structure || type === gd.Variable.Array;
+  const isExpanded = isCollection && !variable.isFolded();
+
+  flattenedVariables.push({
+    nodeId,
+    name,
+    index,
+    depth,
+    variable,
+    parentVariable,
+    isInherited,
+    type,
+    isCollection,
+    isExpanded,
+  });
+
+  if (!isExpanded) return;
+
+  const childHasMatchingAncestor =
+    hasMatchingAncestor ||
+    (!!searchFilter && searchFilter.matchingNodeIds.has(nodeId));
+  const flattenChild = (childName: string, childIndex: number) =>
+    flattenVariable({
+      name: childName,
+      index: childIndex,
+      variable:
+        type === gd.Variable.Structure
+          ? variable.getChild(childName)
+          : variable.getAtIndex(childIndex),
+      parentVariable: variable,
+      parentNodeId: nodeId,
+      depth: depth + 1,
+      isInherited,
+      hasMatchingAncestor: childHasMatchingAncestor,
+      searchFilter,
+      flattenedVariables,
+    });
+
+  if (type === gd.Variable.Structure) {
+    variable
+      .getAllChildrenNames()
+      .toJSArray()
+      .forEach(flattenChild);
+  } else {
+    mapFor(0, variable.getChildrenCount(), childIndex =>
+      flattenChild(childIndex.toString(), childIndex)
+    );
+  }
+};
+
+/**
+ * Flatten the tree of variables (folded variables have their children hidden)
+ * into the list of rows to display, in order: first the inherited variables
+ * that are not overridden, then the variables of the container itself.
+ */
+export const flattenVariablesContainers = ({
+  variablesContainer,
+  inheritedVariablesContainer,
+  searchMatchingNodeIds,
+}: {|
+  variablesContainer: gdVariablesContainer,
+  inheritedVariablesContainer: ?gdVariablesContainer,
+  /** If set, only the variables matching the search are displayed. */
+  searchMatchingNodeIds: ?Array<string>,
+|}): Array<FlattenedVariable> => {
+  const searchFilter = searchMatchingNodeIds
+    ? {
+        matchingNodeIds: new Set(searchMatchingNodeIds),
+        nodeIdsToDisplay: getNodeIdsToDisplay(searchMatchingNodeIds),
+      }
+    : null;
+
+  const flattenedVariables: Array<FlattenedVariable> = [];
+  const flattenContainer = (
+    container: gdVariablesContainer,
+    isInherited: boolean
+  ) => {
+    mapFor(0, container.count(), index => {
+      const name = container.getNameAt(index);
+      // An inherited variable that is overridden is displayed by the container
+      // itself, not as an inherited variable.
+      if (isInherited && variablesContainer.has(name)) return;
+
+      flattenVariable({
+        name,
+        index,
+        variable: container.getAt(index),
+        parentVariable: null,
+        parentNodeId: null,
+        depth: 0,
+        isInherited,
+        hasMatchingAncestor: false,
+        searchFilter,
+        flattenedVariables,
+      });
+    });
+  };
+
+  if (inheritedVariablesContainer) {
+    flattenContainer(inheritedVariablesContainer, true);
+  }
+  flattenContainer(variablesContainer, false);
+
+  return flattenedVariables;
+};

--- a/newIDE/app/src/VariablesList/FlattenVariables.spec.js
+++ b/newIDE/app/src/VariablesList/FlattenVariables.spec.js
@@ -1,0 +1,194 @@
+// @flow
+import { flattenVariablesContainers } from './FlattenVariables';
+import {
+  generateListOfNodesMatchingSearchInVariablesContainer,
+  inheritedPrefix,
+  separator,
+} from './VariableToTreeNodeHandling';
+
+const gd: libGDevelop = global.gd;
+
+const makeStructure = (
+  children: { [string]: string },
+  { isFolded }: {| isFolded: boolean |} = { isFolded: false }
+) => {
+  const variable = new gd.Variable();
+  variable.castTo('structure');
+  variable.setFolded(isFolded);
+  for (const childName in children) {
+    variable.getChild(childName).setString(children[childName]);
+  }
+  return variable;
+};
+
+const describeRows = (rows: Array<Object>) =>
+  rows.map(({ nodeId, depth, isInherited }) => ({
+    nodeId,
+    depth,
+    isInherited,
+  }));
+
+describe('flattenVariablesContainers', () => {
+  let variablesContainer;
+  beforeEach(() => {
+    /*
+    variablesContainer
+    ├── Text 'Hello'
+    ├── Structure
+    │   ├── Child1 'first'
+    │   └── Child2 'second'
+    ├── FoldedStructure (folded)
+    │   └── HiddenChild 'hidden'
+    └── Array
+        ├── 0 'zero'
+        └── 1 'one'
+    */
+    variablesContainer = new gd.VariablesContainer(
+      gd.VariablesContainer.Unknown
+    );
+    const text = new gd.Variable();
+    text.setString('Hello');
+    variablesContainer.insert('Text', text, 0);
+    variablesContainer.insert(
+      'Structure',
+      makeStructure({ Child1: 'first', Child2: 'second' }),
+      1
+    );
+    variablesContainer.insert(
+      'FoldedStructure',
+      makeStructure({ HiddenChild: 'hidden' }, { isFolded: true }),
+      2
+    );
+    const array = new gd.Variable();
+    array.castTo('array');
+    array.pushNew().setString('zero');
+    array.pushNew().setString('one');
+    variablesContainer.insert('Array', array, 3);
+  });
+
+  test('the tree is flattened in the order it is displayed, and folded variables hide their children', () => {
+    expect(
+      describeRows(
+        flattenVariablesContainers({
+          variablesContainer,
+          inheritedVariablesContainer: null,
+          searchMatchingNodeIds: null,
+        })
+      )
+    ).toEqual([
+      { nodeId: 'Text', depth: 0, isInherited: false },
+      { nodeId: 'Structure', depth: 0, isInherited: false },
+      { nodeId: `Structure${separator}Child1`, depth: 1, isInherited: false },
+      { nodeId: `Structure${separator}Child2`, depth: 1, isInherited: false },
+      { nodeId: 'FoldedStructure', depth: 0, isInherited: false },
+      { nodeId: 'Array', depth: 0, isInherited: false },
+      { nodeId: `Array${separator}0`, depth: 1, isInherited: false },
+      { nodeId: `Array${separator}1`, depth: 1, isInherited: false },
+    ]);
+  });
+
+  test('a row holds what is needed to display the variable', () => {
+    const rows = flattenVariablesContainers({
+      variablesContainer,
+      inheritedVariablesContainer: null,
+      searchMatchingNodeIds: null,
+    });
+
+    expect(rows[0]).toMatchObject({
+      name: 'Text',
+      index: 0,
+      type: gd.Variable.String,
+      isCollection: false,
+      isExpanded: false,
+      parentVariable: null,
+    });
+    expect(rows[1]).toMatchObject({
+      name: 'Structure',
+      index: 1,
+      type: gd.Variable.Structure,
+      isCollection: true,
+      isExpanded: true,
+    });
+    expect(rows[2]).toMatchObject({ name: 'Child1', index: 0 });
+    expect(rows[2].parentVariable).toBe(rows[1].variable);
+    expect(rows[4]).toMatchObject({
+      name: 'FoldedStructure',
+      isCollection: true,
+      isExpanded: false,
+    });
+    // Array children are named by their index.
+    expect(rows[6]).toMatchObject({ name: '0', index: 0 });
+    expect(rows[7]).toMatchObject({ name: '1', index: 1 });
+  });
+
+  test('the inherited variables are displayed first, without the ones being overridden', () => {
+    const inheritedVariablesContainer = new gd.VariablesContainer(
+      gd.VariablesContainer.Unknown
+    );
+    const inheritedOnly = new gd.Variable();
+    inheritedOnly.setString('inherited');
+    inheritedVariablesContainer.insert('InheritedOnly', inheritedOnly, 0);
+    // Overridden by the variable of the same name of the container itself.
+    const overridden = new gd.Variable();
+    overridden.setString('overridden');
+    inheritedVariablesContainer.insert('Text', overridden, 1);
+
+    expect(
+      describeRows(
+        flattenVariablesContainers({
+          variablesContainer,
+          inheritedVariablesContainer,
+          searchMatchingNodeIds: null,
+        })
+      )
+    ).toEqual([
+      {
+        nodeId: `${inheritedPrefix}InheritedOnly`,
+        depth: 0,
+        isInherited: true,
+      },
+      { nodeId: 'Text', depth: 0, isInherited: false },
+      { nodeId: 'Structure', depth: 0, isInherited: false },
+      { nodeId: `Structure${separator}Child1`, depth: 1, isInherited: false },
+      { nodeId: `Structure${separator}Child2`, depth: 1, isInherited: false },
+      { nodeId: 'FoldedStructure', depth: 0, isInherited: false },
+      { nodeId: 'Array', depth: 0, isInherited: false },
+      { nodeId: `Array${separator}0`, depth: 1, isInherited: false },
+      { nodeId: `Array${separator}1`, depth: 1, isInherited: false },
+    ]);
+  });
+
+  const flattenWithSearch = (searchText: string) =>
+    describeRows(
+      flattenVariablesContainers({
+        variablesContainer,
+        inheritedVariablesContainer: null,
+        searchMatchingNodeIds: generateListOfNodesMatchingSearchInVariablesContainer(
+          variablesContainer,
+          searchText
+        ),
+      })
+    ).map(({ nodeId }) => nodeId);
+
+  test('a search displays the matching variables, their ancestors and their descendants', () => {
+    // A matching child: it is displayed, and so is its parent.
+    expect(flattenWithSearch('child2')).toEqual([
+      'Structure',
+      `Structure${separator}Child2`,
+    ]);
+
+    // A matching parent: its children are displayed too.
+    expect(flattenWithSearch('structure')).toEqual([
+      'Structure',
+      `Structure${separator}Child1`,
+      `Structure${separator}Child2`,
+      // The children of a folded variable stay hidden.
+      'FoldedStructure',
+    ]);
+
+    // A value can match too.
+    expect(flattenWithSearch('zero')).toEqual(['Array', `Array${separator}0`]);
+
+    expect(flattenWithSearch('nothing matches this')).toEqual([]);
+  });
+});

--- a/newIDE/app/src/VariablesList/VariableTypeSelector.js
+++ b/newIDE/app/src/VariablesList/VariableTypeSelector.js
@@ -1,9 +1,11 @@
 // @flow
 import * as React from 'react';
 import { t } from '@lingui/macro';
+import { I18n } from '@lingui/react';
+import Tooltip from '@material-ui/core/Tooltip';
 
 import { type MessageDescriptor } from '../Utils/i18n/MessageDescriptor.flow';
-import SelectField from '../UI/SelectField';
+import CompactSelectField from '../UI/CompactSelectField';
 import SelectOption from '../UI/SelectOption';
 import VariableStringIcon from './Icons/VariableStringIcon';
 import VariableNumberIcon from './Icons/VariableNumberIcon';
@@ -12,16 +14,21 @@ import VariableArrayIcon from './Icons/VariableArrayIcon';
 import VariableStructureIcon from './Icons/VariableStructureIcon';
 import VariableMixedTypesIcon from '../UI/CustomSvgIcons/Cross';
 import WarningIcon from '../UI/CustomSvgIcons/Warning';
-import { Line, Spacer } from '../UI/Grid';
 import GDevelopThemeContext from '../UI/Theme/GDevelopThemeContext';
-import Tooltip from '@material-ui/core/Tooltip';
-const gd = global.gd;
+import { tooltipEnterDelay } from '../UI/Tooltip';
+import classes from './VariablesList.module.css';
+
+const gd: libGDevelop = global.gd;
 
 type Props = {|
   variableType: Variable_Type,
   onChange: (newVariableType: string, nodeId: string) => void,
   nodeId: string,
-  isHighlighted?: boolean,
+  /**
+   * If true, only the icon of the type is displayed (and clicking on it opens
+   * the type selection): useful when the horizontal space is scarce.
+   */
+  hideTypeName?: boolean,
   readOnlyWithIcon?: boolean,
   id?: string,
   errorMessage: MessageDescriptor | null,
@@ -31,8 +38,9 @@ type Props = {|
 let options;
 let variableTypeToIcon;
 let variableTypeToString;
+let variableTypeToLabel;
 
-const getOptions = () => {
+const getOptions = (variableType: Variable_Type) => {
   if (!options) {
     options = [
       <SelectOption key="string" label={t`Text`} value={gd.Variable.String} />,
@@ -54,7 +62,19 @@ const getOptions = () => {
       />,
     ];
   }
-  return options;
+  // A variable with mixed types must be displayed as such, but this can't be
+  // chosen: it's only the result of multiple variables being edited at once.
+  return variableType === gd.Variable.MixedTypes
+    ? [
+        <SelectOption
+          key="mixed-types"
+          label={t`Mixed types`}
+          value={gd.Variable.MixedTypes}
+          disabled
+        />,
+        ...options,
+      ]
+    : options;
 };
 
 export const getVariableTypeToIcon = (): { [Variable_Type]: any } => {
@@ -71,7 +91,7 @@ export const getVariableTypeToIcon = (): { [Variable_Type]: any } => {
   return variableTypeToIcon;
 };
 
-const getVariableTypeToString = () => {
+const getVariableTypeToString = (): { [string]: string } => {
   if (!variableTypeToString) {
     variableTypeToString = {
       [gd.Variable.String]: 'string',
@@ -84,58 +104,117 @@ const getVariableTypeToString = () => {
   return variableTypeToString;
 };
 
+const getVariableTypeToLabel = (): { [Variable_Type]: MessageDescriptor } => {
+  if (!variableTypeToLabel) {
+    variableTypeToLabel = {
+      [gd.Variable.MixedTypes]: t`Mixed types`,
+      [gd.Variable.String]: t`Text`,
+      [gd.Variable.Number]: t`Number`,
+      [gd.Variable.Boolean]: t`Boolean`,
+      [gd.Variable.Array]: t`Array`,
+      [gd.Variable.Structure]: t`Structure`,
+    };
+  }
+  return variableTypeToLabel;
+};
+
 const VariableTypeSelector: React.ComponentType<Props> = React.memo<Props>(
-  (props: Props) => {
+  ({
+    variableType,
+    onChange,
+    nodeId,
+    hideTypeName,
+    readOnlyWithIcon,
+    id,
+    errorMessage,
+    disabled,
+  }: Props) => {
     const gdevelopTheme = React.useContext(GDevelopThemeContext);
-    const Icon = getVariableTypeToIcon()[props.variableType];
+    const Icon = getVariableTypeToIcon()[variableType];
+
+    const renderIcon = (className?: string) =>
+      errorMessage ? (
+        <WarningIcon
+          className={className}
+          fontSize="small"
+          htmlColor={gdevelopTheme.message.warning}
+        />
+      ) : (
+        <Icon
+          className={className}
+          fontSize="small"
+          htmlColor={
+            variableType === gd.Variable.MixedTypes
+              ? gdevelopTheme.message.error
+              : undefined
+          }
+        />
+      );
+    const tooltipTitle = errorMessage || getVariableTypeToLabel()[variableType];
+
+    if (readOnlyWithIcon || (disabled && hideTypeName)) {
+      return (
+        <I18n>
+          {({ i18n }) => (
+            <Tooltip
+              title={i18n._(tooltipTitle)}
+              placement="bottom"
+              enterDelay={tooltipEnterDelay}
+            >
+              <div className={classes.typeSelectorReadOnly}>
+                {renderIcon()}
+                {!hideTypeName && (
+                  <span className={classes.typeSelectorReadOnlyLabel}>
+                    {i18n._(getVariableTypeToLabel()[variableType])}
+                  </span>
+                )}
+              </div>
+            </Tooltip>
+          )}
+        </I18n>
+      );
+    }
+
+    const onChangeType = (newVariableType: string) =>
+      onChange(getVariableTypeToString()[newVariableType], nodeId);
+
+    if (hideTypeName) {
+      return (
+        <I18n>
+          {({ i18n }) => (
+            <Tooltip
+              title={i18n._(tooltipTitle)}
+              placement="bottom"
+              enterDelay={tooltipEnterDelay}
+            >
+              <div className={classes.typeSelectorIconOnly}>
+                {renderIcon()}
+                <select
+                  id={id}
+                  value={variableType.toString()}
+                  onChange={event => onChangeType(event.currentTarget.value)}
+                  aria-label={i18n._(t`Variable type`)}
+                >
+                  {getOptions(variableType)}
+                </select>
+              </div>
+            </Tooltip>
+          )}
+        </I18n>
+      );
+    }
 
     return (
-      <Line alignItems="center" noMargin>
-        {props.errorMessage ? (
-          <Tooltip title={props.errorMessage}>
-            <WarningIcon
-              fontSize="small"
-              htmlColor={gdevelopTheme.message.warning}
-            />
-          </Tooltip>
-        ) : (
-          <Icon
-            fontSize="small"
-            htmlColor={
-              props.isHighlighted
-                ? gdevelopTheme.message.selectedTextColor
-                : undefined
-            }
-          />
-        )}
-        {!props.readOnlyWithIcon && (
-          <>
-            <Spacer />
-            <SelectField
-              value={props.variableType}
-              translatableHintText={t`Mixed`}
-              margin="none"
-              stopPropagationOnClick
-              onChange={event =>
-                props.onChange(
-                  getVariableTypeToString()[event.target.value],
-                  props.nodeId
-                )
-              }
-              inputStyle={{
-                fontSize: 14,
-                color: props.isHighlighted
-                  ? gdevelopTheme.listItem.selectedTextColor
-                  : undefined,
-              }}
-              id={props.id}
-              disabled={props.disabled}
-            >
-              {getOptions()}
-            </SelectField>
-          </>
-        )}
-      </Line>
+      <CompactSelectField
+        value={variableType.toString()}
+        onChange={onChangeType}
+        id={id}
+        disabled={disabled}
+        errored={!!errorMessage}
+        renderOptionIcon={renderIcon}
+      >
+        {getOptions(variableType)}
+      </CompactSelectField>
     );
   }
 );

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import Measure from 'react-measure';
 import memoizeOne from 'memoize-one';
+import classNames from 'classnames';
 import { t, Trans } from '@lingui/macro';
 import { type I18n as I18nType } from '@lingui/core';
 import { ClickAwayListener } from '@material-ui/core';
@@ -14,20 +15,18 @@ import ChevronArrowRight from '../UI/CustomSvgIcons/ChevronArrowRight';
 import ChevronArrowBottom from '../UI/CustomSvgIcons/ChevronArrowBottom';
 import ButtonBase from '@material-ui/core/ButtonBase';
 
-import { Column, Line, Spacer } from '../UI/Grid';
+import { Column, Line } from '../UI/Grid';
 import IconButton from '../UI/IconButton';
 import { DragHandleIcon } from '../UI/DragHandle';
 import { makeDragSourceAndDropTarget } from '../UI/DragAndDrop/DragSourceAndDropTarget';
-import DropIndicator from '../UI/SortableVirtualizedItemList/DropIndicator';
 import { EmptyPlaceholder } from '../UI/EmptyPlaceholder';
 import ScrollView from '../UI/ScrollView';
 import GDevelopThemeContext from '../UI/Theme/GDevelopThemeContext';
 import { type GDevelopTheme } from '../UI/Theme';
-import { ResponsiveLineStackLayout } from '../UI/Layout';
 import KeyboardShortcuts from '../UI/KeyboardShortcuts';
+import { useVisibleRowsRange } from '../UI/useVisibleRowsRange';
 
 import useForceUpdate from '../Utils/UseForceUpdate';
-import { mapFor } from '../Utils/MapFor';
 import newNameGenerator from '../Utils/NewNameGenerator';
 import Clipboard from '../Utils/Clipboard';
 import { SafeExtractor } from '../Utils/SafeExtractor';
@@ -65,6 +64,10 @@ import {
   separator,
   updateListOfNodesFollowingChangeName,
 } from './VariableToTreeNodeHandling';
+import {
+  flattenVariablesContainers,
+  type FlattenedVariable,
+} from './FlattenVariables';
 
 import VariableTypeSelector from './VariableTypeSelector';
 import { CLIPBOARD_KIND } from './ClipboardKind';
@@ -86,6 +89,7 @@ import Paper from '../UI/Paper';
 import { ProjectScopedContainersAccessor } from '../InstructionOrExpression/EventsScope';
 import ContextMenu, { type ContextMenuInterface } from '../UI/Menu/ContextMenu';
 import { exceptionallyGuardAgainstDeadObject } from '../Utils/IsNullPtr';
+import classes from './VariablesList.module.css';
 
 const gd: libGDevelop = global.gd;
 
@@ -98,7 +102,31 @@ const stopEventPropagation = (event: SyntheticPointerEvent<HTMLInputElement>) =>
 // $FlowFixMe[missing-local-annot]
 const memoized = memoizeOne((initialValue, callback) => callback());
 
-const styles = { inlineIcon: { padding: 0 }, handlePlaceholder: { width: 24 } };
+/**
+ * Every row has this exact height, which is what allows to render only the rows
+ * that are visible on screen: the position of a row is `index * this height`.
+ */
+const VARIABLE_ROW_HEIGHT = 30;
+const rowContainerStyle = { height: VARIABLE_ROW_HEIGHT };
+const actionButtonStyle = { padding: 2 };
+
+/** Below this width, the name of the variable type is replaced by its icon only. */
+const MIN_WIDTH_TO_DISPLAY_TYPE_NAME = 650;
+
+const getIndent = ({
+  depth,
+  isNarrow,
+  containerWidth,
+}: {|
+  depth: number,
+  isNarrow: boolean,
+  containerWidth: ?number,
+|}): number =>
+  Math.min(
+    depth * (isNarrow ? 12 : 20),
+    // Never let the indentation eat too much of the available width.
+    containerWidth ? Math.round(0.3 * containerWidth) : 200
+  );
 
 export type HistoryHandler = {|
   saveToHistory: () => void,
@@ -143,15 +171,11 @@ type Props = {|
   isListLocked: boolean,
 |};
 
-const variableRowStyles = {
-  chevron: { width: 15, alignSelf: 'stretch' },
-};
-
 type VariableRowProps = {|
   // Context:
   depth: number,
-  isNarrow: boolean,
-  containerWidth: ?number,
+  indent: number,
+  hideTypeName: boolean,
   shouldHideExpandIcons: boolean,
   isExpanded: boolean,
   onExpand: (shouldExpand: boolean, nodeId: string) => void,
@@ -179,7 +203,7 @@ type VariableRowProps = {|
 
   // Variable information:
   onChangeName: (string, string, reason: 'blur' | 'change') => void,
-  overwritesInheritedVariable: boolean | void,
+  overwritesInheritedVariable: boolean,
   name: string,
   index: number,
   isTopLevel: boolean,
@@ -187,7 +211,7 @@ type VariableRowProps = {|
   typeErrorMessage: MessageDescriptor | null,
   onChangeType: (string, nodeId: string) => void,
   isLoopIndexVariable: boolean,
-  onRemoveLoopIndexVariable: () => void,
+  removeLoopIndexVariable: (nodeId: string) => void,
   hasMixedValues: boolean,
   valueAsString: string | null,
   valueAsBool: boolean | null,
@@ -203,8 +227,8 @@ type VariableRowProps = {|
 const VariableRow = React.memo<VariableRowProps>(
   ({
     depth,
-    isNarrow,
-    containerWidth,
+    indent,
+    hideTypeName,
     shouldHideExpandIcons,
     isExpanded,
     onExpand,
@@ -230,7 +254,7 @@ const VariableRow = React.memo<VariableRowProps>(
     type,
     typeErrorMessage,
     isLoopIndexVariable,
-    onRemoveLoopIndexVariable,
+    removeLoopIndexVariable,
     onChangeType,
     hasMixedValues,
     valueAsString,
@@ -248,17 +272,6 @@ const VariableRow = React.memo<VariableRowProps>(
     const [whereToDrop, setWhereToDrop] = React.useState<'before' | 'after'>(
       'before'
     );
-    const shouldWrap =
-      isNarrow ||
-      (!containerWidth
-        ? false
-        : containerWidth <= 750
-        ? depth >= 5
-        : containerWidth <= 850
-        ? depth >= 6
-        : containerWidth <= 950
-        ? depth >= 7
-        : depth >= 8);
     const [editInMultilineEditor, setEditInMultilineEditor] = React.useState(
       false
     );
@@ -276,7 +289,11 @@ const VariableRow = React.memo<VariableRowProps>(
     }, []);
 
     return (
-      <div ref={containerRef}>
+      <div
+        ref={containerRef}
+        className={classes.rowContainer}
+        style={rowContainerStyle}
+      >
         <DragSourceAndDropTarget
           beginDrag={() => {
             draggedNodeId.current = nodeId;
@@ -307,13 +324,11 @@ const VariableRow = React.memo<VariableRowProps>(
           {({ connectDragSource, connectDropTarget, isOver, canDrop }) =>
             connectDropTarget(
               <div
-                style={{
-                  marginLeft: (isNarrow ? 16 : 32) * depth,
-                  backgroundColor: isSelected
-                    ? gdevelopTheme.listItem.selectedBackgroundColor
-                    : gdevelopTheme.list.itemsBackgroundColor,
-                  marginBottom: 1,
-                }}
+                className={classNames({
+                  [classes.row]: true,
+                  [classes.selected]: isSelected,
+                })}
+                style={{ marginLeft: indent }}
                 aria-selected={isSelected}
                 aria-expanded={isExpanded}
                 onPointerUp={event => {
@@ -329,310 +344,233 @@ const VariableRow = React.memo<VariableRowProps>(
                   }
                 }}
               >
-                {isOver && whereToDrop === 'before' && (
-                  <DropIndicator canDrop={canDrop} />
-                )}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    padding: isNarrow ? '4px 4px 4px 0px' : '6px 30px 6px 6px',
-                  }}
-                >
-                  {shouldHideExpandIcons ? null : isCollection ? (
-                    <ButtonBase
-                      onClick={() => onExpand(!isExpanded, nodeId)}
-                      focusRipple
-                      style={variableRowStyles.chevron}
-                    >
-                      {isExpanded ? (
-                        <ChevronArrowBottom />
-                      ) : (
-                        <ChevronArrowRight />
-                      )}
-                    </ButtonBase>
-                  ) : (
-                    <div style={variableRowStyles.chevron} />
-                  )}
-
-                  {isInherited ? (
-                    <span style={styles.handlePlaceholder} />
-                  ) : (
-                    connectDragSource(
-                      <span>
-                        <DragHandleIcon
-                          color={
-                            isSelected
-                              ? gdevelopTheme.listItem.selectedTextColor
-                              : '#AAA'
-                          }
-                        />
-                      </span>
-                    )
-                  )}
-                  <ResponsiveLineStackLayout
-                    expand
-                    noMargin
-                    forceMobileLayout={shouldWrap}
+                {shouldHideExpandIcons ? null : isCollection ? (
+                  <ButtonBase
+                    onClick={() => onExpand(!isExpanded, nodeId)}
+                    focusRipple
+                    className={classes.chevron}
                   >
-                    <Line alignItems="center" noMargin expand>
-                      {shouldWrap ? null : <Spacer />}
+                    {isExpanded ? (
+                      <ChevronArrowBottom />
+                    ) : (
+                      <ChevronArrowRight />
+                    )}
+                  </ButtonBase>
+                ) : (
+                  <span className={classes.chevron} />
+                )}
+                {isInherited || isLoopIndexVariable ? (
+                  <span className={classes.dragHandle} />
+                ) : (
+                  connectDragSource(
+                    <span className={classes.dragHandle}>
+                      <DragHandleIcon color="inherit" />
+                    </span>
+                  )
+                )}
+                <div className={classes.nameField}>
+                  <SimpleTextField
+                    type="text"
+                    ref={element => {
+                      if (element) {
+                        variableNameInputRefs.current[
+                          variablePointer
+                        ] = element;
+                      }
+                    }}
+                    directlyStoreValueChangesWhileEditing={
+                      directlyStoreValueChangesWhileEditing
+                    }
+                    disabled={
+                      isNameLocked ||
+                      isInherited ||
+                      parentType === gd.Variable.Array
+                    }
+                    onChange={onChangeName}
+                    additionalContext={JSON.stringify({ nodeId, depth })}
+                    italic={overwritesInheritedVariable}
+                    value={name}
+                    id={`variable-${index}-name`}
+                  />
+                </div>
+                <div className={classes.rowRightSide} style={rowRightSideStyle}>
+                  <div
+                    className={classNames({
+                      [classes.typeSelector]: true,
+                      [classes.withTypeName]: !hideTypeName,
+                    })}
+                  >
+                    <VariableTypeSelector
+                      variableType={
+                        isLoopIndexVariable ? gd.Variable.Number : type
+                      }
+                      onChange={onChangeType}
+                      nodeId={nodeId}
+                      hideTypeName={hideTypeName}
+                      readOnlyWithIcon={
+                        isInherited || overwritesInheritedVariable
+                      }
+                      id={`variable-${index}-type`}
+                      errorMessage={typeErrorMessage}
+                      disabled={isTypeLocked || isLoopIndexVariable}
+                    />
+                  </div>
+                  {isLoopIndexVariable ? (
+                    <span className={classes.valueLabel}>
+                      <Trans>Counter of the loop</Trans>
+                    </span>
+                  ) : type === gd.Variable.Boolean ? (
+                    <>
+                      <span className={classes.valueLabel}>
+                        {hasMixedValues ? (
+                          <Trans>Mixed values</Trans>
+                        ) : valueAsBool ? (
+                          <Trans>True</Trans>
+                        ) : (
+                          <Trans>False</Trans>
+                        )}
+                      </span>
+                      {isInherited && !isTopLevel ? null : (
+                        // $FlowFixMe[incompatible-type]
+                        <IconButton
+                          size="small"
+                          color="inherit"
+                          className={classes.actionButton}
+                          style={actionButtonStyle}
+                          onClick={() => {
+                            onChangeValue(
+                              !valueAsBool ? 'true' : 'false',
+                              nodeId
+                            );
+                            forceUpdate();
+                          }}
+                          tooltip={
+                            !valueAsBool ? t`Set to true` : t`Set to false`
+                          }
+                        >
+                          <SwitchHorizontal />
+                        </IconButton>
+                      )}
+                    </>
+                  ) : (
+                    <div className={classes.valueField}>
                       <SimpleTextField
-                        type="text"
                         ref={element => {
-                          if (element) {
-                            variableNameInputRefs.current[
+                          if (depth === 0 && element) {
+                            topLevelVariableValueInputRefs.current[
                               variablePointer
                             ] = element;
                           }
                         }}
+                        type={type === gd.Variable.Number ? 'number' : 'text'}
                         directlyStoreValueChangesWhileEditing={
                           directlyStoreValueChangesWhileEditing
                         }
+                        key="value"
                         disabled={
-                          isNameLocked ||
-                          isInherited ||
-                          parentType === gd.Variable.Array
+                          type === gd.Variable.MixedTypes ||
+                          isCollection ||
+                          (isInherited && !isTopLevel) ||
+                          hasLineBreaks
                         }
-                        onChange={onChangeName}
-                        additionalContext={JSON.stringify({ nodeId, depth })}
-                        italic={!!overwritesInheritedVariable}
-                        value={name}
-                        id={`variable-${index}-name`}
+                        hint={hasMixedValues ? i18n._(t`Mixed values`) : ''}
+                        onChange={onChangeValue}
+                        value={
+                          hasMixedValues
+                            ? ''
+                            : // If line breaks are present, disable the field (as it's
+                            // single line only) and make line breaks visible.
+                            hasLineBreaks
+                            ? (valueAsString || '').replace(/\n/g, '↵')
+                            : valueAsString || ''
+                        }
+                        additionalContext={nodeId}
+                        id={`variable-${index}-text-value`}
                       />
-                      <Spacer />
-                    </Line>
-                    <div style={shouldWrap ? undefined : rowRightSideStyle}>
-                      <Line noMargin alignItems="center">
-                        <Column noMargin>
-                          <VariableTypeSelector
-                            variableType={
-                              isLoopIndexVariable ? gd.Variable.Number : type
-                            }
-                            onChange={onChangeType}
-                            nodeId={nodeId}
-                            isHighlighted={isSelected}
-                            readOnlyWithIcon={
-                              isInherited || overwritesInheritedVariable
-                            }
-                            id={`variable-${index}-type`}
-                            errorMessage={typeErrorMessage}
-                            disabled={isTypeLocked || isLoopIndexVariable}
-                          />
-                        </Column>
-                        <Column expand>
-                          {isLoopIndexVariable ? (
-                            <Line noMargin alignItems="center">
-                              <span
-                                style={
-                                  isSelected
-                                    ? {
-                                        color:
-                                          gdevelopTheme.listItem
-                                            .selectedTextColor,
-                                      }
-                                    : undefined
-                                }
-                              >
-                                <Text
-                                  displayInlineAsSpan
-                                  noMargin
-                                  color="inherit"
-                                >
-                                  <Trans>Counter of the loop</Trans>
-                                </Text>
-                              </span>
-                            </Line>
-                          ) : type === gd.Variable.Boolean ? (
-                            <Line noMargin alignItems="center">
-                              <span
-                                style={
-                                  isSelected
-                                    ? {
-                                        color:
-                                          gdevelopTheme.listItem
-                                            .selectedTextColor,
-                                      }
-                                    : undefined
-                                }
-                              >
-                                <Text
-                                  displayInlineAsSpan
-                                  noMargin
-                                  color="inherit"
-                                >
-                                  {hasMixedValues ? (
-                                    <Trans>Mixed values</Trans>
-                                  ) : valueAsBool ? (
-                                    <Trans>True</Trans>
-                                  ) : (
-                                    <Trans>False</Trans>
-                                  )}
-                                </Text>
-                              </span>
-                              {isInherited && !isTopLevel ? null : (
-                                <>
-                                  <Spacer />
-                                  {/* $FlowFixMe[incompatible-type] */}
-                                  <IconButton
-                                    size="small"
-                                    style={styles.inlineIcon}
-                                    onClick={() => {
-                                      onChangeValue(
-                                        !valueAsBool ? 'true' : 'false',
-                                        nodeId
-                                      );
-                                      forceUpdate();
-                                    }}
-                                    tooltip={
-                                      !valueAsBool
-                                        ? t`Set to true`
-                                        : t`Set to false`
-                                    }
-                                  >
-                                    <SwitchHorizontal
-                                      htmlColor={
-                                        isSelected
-                                          ? gdevelopTheme.listItem
-                                              .selectedTextColor
-                                          : undefined
-                                      }
-                                    />
-                                  </IconButton>
-                                </>
-                              )}
-                            </Line>
-                          ) : (
-                            <SimpleTextField
-                              ref={element => {
-                                if (depth === 0 && element) {
-                                  topLevelVariableValueInputRefs.current[
-                                    variablePointer
-                                  ] = element;
-                                }
-                              }}
-                              type={
-                                type === gd.Variable.Number ? 'number' : 'text'
-                              }
-                              directlyStoreValueChangesWhileEditing={
-                                directlyStoreValueChangesWhileEditing
-                              }
-                              key="value"
-                              disabled={
-                                type === gd.Variable.MixedTypes ||
-                                isCollection ||
-                                (isInherited && !isTopLevel) ||
-                                hasLineBreaks
-                              }
-                              hint={
-                                hasMixedValues ? i18n._(t`Mixed values`) : ''
-                              }
-                              onChange={onChangeValue}
-                              value={
-                                hasMixedValues
-                                  ? ''
-                                  : // If line breaks are present, disable the field (as it's
-                                  // single line only) and make line breaks visible.
-                                  hasLineBreaks
-                                  ? (valueAsString || '').replace(/\n/g, '↵')
-                                  : valueAsString || ''
-                              }
-                              additionalContext={nodeId}
-                              id={`variable-${index}-text-value`}
-                            />
-                          )}
-                        </Column>
-                        {// Only show the large edit button for string variables,
-                        // and not for those who are in an inherited structure or array.
-                        type === gd.Variable.String &&
-                        !(isInherited && !isTopLevel) ? (
-                          // $FlowFixMe[incompatible-type]
-                          <IconButton
-                            size="small"
-                            style={styles.inlineIcon}
-                            tooltip={t`Open in a larger editor`}
-                            onClick={event => {
-                              stopEventPropagation(event);
-                              setEditInMultilineEditor(true);
-                            }}
-                          >
-                            <Edit
-                              htmlColor={
-                                isSelected
-                                  ? gdevelopTheme.listItem.selectedTextColor
-                                  : undefined
-                              }
-                            />
-                          </IconButton>
-                        ) : null}
-                        {isCollection && !isInherited ? (
-                          // $FlowFixMe[incompatible-type]
-                          <IconButton
-                            size="small"
-                            style={styles.inlineIcon}
-                            tooltip={t`Add child`}
-                            onClick={event => {
-                              stopEventPropagation(event);
-                              onAddChild(nodeId);
-                            }}
-                          >
-                            <Add
-                              htmlColor={
-                                isSelected
-                                  ? gdevelopTheme.listItem.selectedTextColor
-                                  : undefined
-                              }
-                            />
-                          </IconButton>
-                        ) : null}
-                        {isCollection && isInherited && isTopLevel ? (
-                          // $FlowFixMe[incompatible-type]
-                          <IconButton
-                            size="small"
-                            tooltip={t`Edit`}
-                            style={styles.inlineIcon}
-                            onClick={event => {
-                              stopEventPropagation(event);
-                              editInheritedVariable(nodeId);
-                            }}
-                          >
-                            <Edit
-                              htmlColor={
-                                isSelected
-                                  ? gdevelopTheme.listItem.selectedTextColor
-                                  : undefined
-                              }
-                            />
-                          </IconButton>
-                        ) : null}
-                        {overwritesInheritedVariable && isTopLevel ? (
-                          // $FlowFixMe[incompatible-type]
-                          <IconButton
-                            size="small"
-                            tooltip={t`Reset`}
-                            style={styles.inlineIcon}
-                            onClick={event => {
-                              stopEventPropagation(event);
-                              deleteNode(nodeId);
-                            }}
-                          >
-                            <Undo
-                              htmlColor={
-                                isSelected
-                                  ? gdevelopTheme.listItem.selectedTextColor
-                                  : undefined
-                              }
-                            />
-                          </IconButton>
-                        ) : null}
-                      </Line>
                     </div>
-                  </ResponsiveLineStackLayout>
+                  )}
+                  {// Only show the large edit button for string variables,
+                  // and not for those who are in an inherited structure or array.
+                  type === gd.Variable.String &&
+                  !(isInherited && !isTopLevel) ? (
+                    // $FlowFixMe[incompatible-type]
+                    <IconButton
+                      size="small"
+                      color="inherit"
+                      className={classes.actionButton}
+                      style={actionButtonStyle}
+                      tooltip={t`Open in a larger editor`}
+                      onClick={event => {
+                        stopEventPropagation(event);
+                        setEditInMultilineEditor(true);
+                      }}
+                    >
+                      <Edit />
+                    </IconButton>
+                  ) : null}
+                  {isCollection && !isInherited ? (
+                    // $FlowFixMe[incompatible-type]
+                    <IconButton
+                      size="small"
+                      color="inherit"
+                      className={classes.actionButton}
+                      style={actionButtonStyle}
+                      tooltip={t`Add child`}
+                      onClick={event => {
+                        stopEventPropagation(event);
+                        onAddChild(nodeId);
+                      }}
+                    >
+                      <Add />
+                    </IconButton>
+                  ) : null}
+                  {isCollection && isInherited && isTopLevel ? (
+                    // $FlowFixMe[incompatible-type]
+                    <IconButton
+                      size="small"
+                      color="inherit"
+                      className={classes.actionButton}
+                      style={actionButtonStyle}
+                      tooltip={t`Edit`}
+                      onClick={event => {
+                        stopEventPropagation(event);
+                        editInheritedVariable(nodeId);
+                      }}
+                    >
+                      <Edit />
+                    </IconButton>
+                  ) : null}
+                  {overwritesInheritedVariable && isTopLevel ? (
+                    // $FlowFixMe[incompatible-type]
+                    <IconButton
+                      size="small"
+                      color="inherit"
+                      className={classes.actionButton}
+                      style={actionButtonStyle}
+                      tooltip={t`Reset`}
+                      onClick={event => {
+                        stopEventPropagation(event);
+                        deleteNode(nodeId);
+                      }}
+                    >
+                      <Undo />
+                    </IconButton>
+                  ) : null}
                 </div>
-                {isOver && whereToDrop === 'after' && (
-                  <DropIndicator canDrop={canDrop} />
+                {isOver && (
+                  <div
+                    className={classNames({
+                      [classes.dropIndicator]: true,
+                      [classes.dropIndicatorBefore]: whereToDrop === 'before',
+                      [classes.dropIndicatorAfter]: whereToDrop === 'after',
+                    })}
+                    style={{
+                      backgroundColor: canDrop
+                        ? gdevelopTheme.dropIndicator.canDrop
+                        : gdevelopTheme.dropIndicator.cannotDrop,
+                    }}
+                  />
                 )}
-
                 {editInMultilineEditor && (
                   <MultilineVariableEditorDialog
                     initialValue={valueAsString || ''}
@@ -649,7 +587,7 @@ const VariableRow = React.memo<VariableRowProps>(
                     buildMenuTemplate={i18n => [
                       {
                         label: i18n._(t`Remove this counter of the loop`),
-                        click: onRemoveLoopIndexVariable,
+                        click: () => removeLoopIndexVariable(nodeId),
                       },
                     ]}
                   />
@@ -767,6 +705,12 @@ const VariablesList: React.ComponentType<{
       return initialSelectedNodeId ? [initialSelectedNodeId] : [];
     }
   );
+  // A variable that must be rendered and scrolled to, even if it's outside of
+  // the rows that are visible on screen: this is needed when a variable is
+  // added or initially selected, so that its name field can be focused.
+  const [nodeIdToReveal, setNodeIdToReveal] = React.useState<?string>(
+    () => selectedNodes[0] || null
+  );
   const setSelectedNodes = React.useCallback(
     (nodes: Array<string> | ((nodes: Array<string>) => Array<string>)) => {
       doSetSelectedNodes(selectedNodes => {
@@ -817,18 +761,24 @@ const VariablesList: React.ComponentType<{
       ? !hasVariablesContainerSubChildren(aliveInheritedVariablesContainer)
       : true);
 
-  const rowRightSideStyle = React.useMemo(
-    () => ({
-      minWidth: containerWidth ? Math.round(0.6 * containerWidth) : 600,
-      flexShrink: 0,
-    }),
-    [containerWidth]
-  );
   const isNarrow = React.useMemo(
     () =>
       props.size === 'compact' ||
-      (containerWidth ? containerWidth < 650 : false),
+      (containerWidth
+        ? containerWidth < MIN_WIDTH_TO_DISPLAY_TYPE_NAME
+        : false),
     [containerWidth, props.size]
+  );
+  const rowRightSideStyle = React.useMemo(
+    () => ({
+      // A fixed width keeps the types and the values aligned, whatever the
+      // indentation of the row is.
+      width: containerWidth
+        ? Math.round((isNarrow ? 0.5 : 0.6) * containerWidth)
+        : 400,
+      flexShrink: 0,
+    }),
+    [containerWidth, isNarrow]
   );
 
   const undefinedVariableNames =
@@ -1535,6 +1485,7 @@ const VariablesList: React.ComponentType<{
       );
       _onChange();
       setSelectedNodes([inheritedVariableName]);
+      setNodeIdToReveal(inheritedVariableName);
       newVariable.delete();
     },
     [
@@ -1567,6 +1518,7 @@ const VariablesList: React.ComponentType<{
         );
         _onChange();
         setSelectedNodes([newName]);
+        setNodeIdToReveal(newName);
         refocusNameField({ identifier: variable.ptr });
         return;
       }
@@ -1593,6 +1545,7 @@ const VariablesList: React.ComponentType<{
       );
       _onChange();
       setSelectedNodes([newName]);
+      setNodeIdToReveal(newName);
       refocusNameField({ identifier: variable.ptr });
     },
     [
@@ -1629,198 +1582,6 @@ const VariablesList: React.ComponentType<{
     },
     [setSelectedNodes]
   );
-
-  const renderVariableAndChildrenRows = (
-    {
-      name,
-      variable,
-      parentNodeId,
-      parentVariable,
-      isInherited,
-      index,
-    }: {|
-      name: string,
-      variable: gdVariable,
-      parentNodeId?: string,
-      parentVariable?: gdVariable,
-      isInherited: boolean,
-      index: number,
-    |},
-    i18n: I18nType
-  ): Array<React.Node> => {
-    const isCollection = isCollectionVariable(variable);
-    const type = variable.getType();
-    const isExpanded = !variable.isFolded();
-    const variablePointer = variable.ptr;
-
-    const depth = parentNodeId ? parentNodeId.split(separator).length : 0;
-    const isTopLevel = depth === 0;
-
-    let nodeId;
-    if (!parentNodeId) {
-      if (isInherited) {
-        nodeId = `${inheritedPrefix}${name}`;
-      } else {
-        nodeId = name;
-      }
-    } else {
-      nodeId = `${parentNodeId}${separator}${name}`;
-    }
-    const parentType = parentVariable ? parentVariable.getType() : null;
-    const isSelected = selectedNodes.includes(nodeId);
-    const isLoopIndexVariable =
-      !isInherited &&
-      isTopLevel &&
-      !!currentIndexVariableName &&
-      name === currentIndexVariableName;
-    const overwritesInheritedVariable =
-      isTopLevel &&
-      !isInherited &&
-      !!aliveInheritedVariablesContainer &&
-      aliveInheritedVariablesContainer.has(name);
-
-    const typeErrorMessage =
-      parentType === gd.Variable.Array &&
-      parentVariable &&
-      parentVariable.getChildrenCount() > 1 &&
-      parentVariable.getAtIndex(0).getType() !== type
-        ? i18n._(t`Every child of an array must be the same type.`)
-        : null;
-
-    if (!!searchText) {
-      if (
-        !(
-          searchMatchingNodes.includes(nodeId) ||
-          searchMatchingNodes.some(matchingNodeId =>
-            matchingNodeId.startsWith(nodeId)
-          ) ||
-          searchMatchingNodes.some(matchingNodeId =>
-            nodeId.startsWith(matchingNodeId + separator)
-          )
-        )
-      ) {
-        // Display node if one of these is true:
-        // - node is in the list of nodes matching search
-        // - node is an ancestor of a node in the list of nodes matching search
-        // - node is a descendant of a node in the list of nodes matching search
-        return [];
-      }
-    }
-
-    const hasMixedValues = variable.hasMixedValues();
-    const valueAsString = isCollection
-      ? i18n._(
-          variable.getChildrenCount() === 0
-            ? t`No children`
-            : variable.getChildrenCount() === 1
-            ? t`1 child`
-            : t`${variable.getChildrenCount()} children`
-        )
-      : type === gd.Variable.String
-      ? variable.getString()
-      : type === gd.Variable.Number
-      ? variable.getValue().toString()
-      : null;
-
-    const valueAsBool =
-      type === gd.Variable.Boolean ? variable.getBool() : null;
-
-    const variableRow = (
-      <VariableRow
-        key={nodeId}
-        depth={depth}
-        isNarrow={isNarrow}
-        containerWidth={containerWidth}
-        shouldHideExpandIcons={shouldHideExpandIcons}
-        isExpanded={isExpanded}
-        onExpand={onExpand}
-        draggedNodeId={draggedNodeId}
-        nodeId={nodeId}
-        isInherited={isInherited}
-        isNameLocked={props.isListLocked && isTopLevel}
-        isTypeLocked={props.isListLocked && isTopLevel}
-        canDrop={canDrop}
-        dropNode={dropNode}
-        isSelected={isSelected}
-        onSelect={onSelect}
-        gdevelopTheme={gdevelopTheme}
-        variableNameInputRefs={variableNameInputRefs}
-        topLevelVariableValueInputRefs={topLevelVariableValueInputRefs}
-        parentType={parentType}
-        onChangeName={onChangeName}
-        overwritesInheritedVariable={overwritesInheritedVariable}
-        name={name}
-        index={index}
-        rowRightSideStyle={rowRightSideStyle}
-        isTopLevel={isTopLevel}
-        type={type}
-        typeErrorMessage={typeErrorMessage}
-        isLoopIndexVariable={isLoopIndexVariable}
-        onRemoveLoopIndexVariable={() => removeLoopIndexVariable(nodeId)}
-        variablePointer={variablePointer}
-        onChangeType={onChangeType}
-        hasMixedValues={hasMixedValues}
-        valueAsString={valueAsString}
-        valueAsBool={valueAsBool}
-        onChangeValue={onChangeValue}
-        isCollection={isCollection}
-        onAddChild={onAddChild}
-        editInheritedVariable={editInheritedVariable}
-        deleteNode={deleteNode}
-        directlyStoreValueChangesWhileEditing={
-          !!props.directlyStoreValueChangesWhileEditing
-        }
-        i18n={i18n}
-      />
-    );
-
-    if (type === gd.Variable.Structure) {
-      return [
-        variableRow,
-        ...(isExpanded
-          ? variable
-              .getAllChildrenNames()
-              .toJSArray()
-              .map((childName, index) => {
-                const childVariable = variable.getChild(childName);
-                return renderVariableAndChildrenRows(
-                  {
-                    name: childName,
-                    variable: childVariable,
-                    parentNodeId: nodeId,
-                    parentVariable: variable,
-                    isInherited,
-                    index,
-                  },
-                  i18n
-                );
-              })
-          : []),
-      ];
-    } else if (type === gd.Variable.Array) {
-      return [
-        variableRow,
-        ...(isExpanded
-          ? mapFor(0, variable.getChildrenCount(), index => {
-              const childVariable = variable.getAtIndex(index);
-              return renderVariableAndChildrenRows(
-                {
-                  name: index.toString(),
-                  variable: childVariable,
-                  parentNodeId: nodeId,
-                  parentVariable: variable,
-                  isInherited,
-                  index,
-                },
-                i18n
-              );
-            })
-          : []),
-      ];
-    } else {
-      return [variableRow];
-    }
-  };
 
   const onChangeName = React.useCallback(
     (newName: string, additionalContext: any, reason: 'blur' | 'change') => {
@@ -2052,42 +1813,155 @@ const VariablesList: React.ComponentType<{
     ]
   );
 
-  const renderTree = (i18n: I18nType, isInherited: boolean = false) => {
-    // $FlowFixMe[missing-empty-array-annot]
-    const allRows = [];
-    const variablesContainer =
-      isInherited && aliveInheritedVariablesContainer
-        ? aliveInheritedVariablesContainer
-        : aliveVariablesContainer;
-    if (!variablesContainer) return allRows;
-    mapFor(0, variablesContainer.count(), index => {
-      const variable = variablesContainer.getAt(index);
-      const name = variablesContainer.getNameAt(index);
-      if (isInherited) {
-        if (aliveVariablesContainer && aliveVariablesContainer.has(name)) {
-          return null;
-        }
-      }
-
-      // $FlowFixMe[incompatible-type]
-      allRows.push(
-        ...renderVariableAndChildrenRows(
-          {
-            name,
-            variable,
-            isInherited,
-            index,
-          },
-          i18n
-        )
-      );
-    });
-    return allRows;
-  };
-
   React.useImperativeHandle(ref, () => ({
     addVariable,
   }));
+
+  // The whole tree of variables is flattened into the list of rows to display,
+  // so that only the rows visible on screen have to be rendered. This is done
+  // at every render because the variables are mutated in place (in the C++
+  // objects), so the result can't be memoized.
+  const flattenedVariables = aliveVariablesContainer
+    ? flattenVariablesContainers({
+        variablesContainer: aliveVariablesContainer,
+        inheritedVariablesContainer: aliveInheritedVariablesContainer,
+        searchMatchingNodeIds: searchText ? searchMatchingNodes : null,
+      })
+    : [];
+
+  const rowsContainerRef = React.useRef<?HTMLDivElement>(null);
+  const { visibleRowsRange, scrollRowIntoView } = useVisibleRowsRange({
+    containerRef: rowsContainerRef,
+    rowCount: flattenedVariables.length,
+    rowHeight: VARIABLE_ROW_HEIGHT,
+  });
+  const { firstRowIndex, afterLastRowIndex } = visibleRowsRange;
+  const rowIndexToReveal = nodeIdToReveal
+    ? flattenedVariables.findIndex(({ nodeId }) => nodeId === nodeIdToReveal)
+    : -1;
+  const shouldRenderRevealedRowApart =
+    rowIndexToReveal >= 0 &&
+    (rowIndexToReveal < firstRowIndex || rowIndexToReveal >= afterLastRowIndex);
+
+  React.useLayoutEffect(
+    () => {
+      if (rowIndexToReveal < 0) return;
+      scrollRowIntoView(rowIndexToReveal);
+      // Only stop rendering the revealed row once it's part of the rows visible
+      // on screen, so that it never gets unmounted while being focused.
+      if (!shouldRenderRevealedRowApart) setNodeIdToReveal(null);
+    },
+    [rowIndexToReveal, shouldRenderRevealedRowApart, scrollRowIntoView]
+  );
+
+  const selectedNodesSet = React.useMemo(() => new Set(selectedNodes), [
+    selectedNodes,
+  ]);
+  const hideTypeName = isNarrow;
+
+  const renderRow = (
+    flattenedVariable: FlattenedVariable,
+    i18n: I18nType
+  ): React.Node => {
+    const {
+      nodeId,
+      name,
+      index,
+      depth,
+      variable,
+      parentVariable,
+      isInherited,
+      type,
+      isCollection,
+      isExpanded,
+    } = flattenedVariable;
+    const isTopLevel = depth === 0;
+    const parentType = parentVariable ? parentVariable.getType() : null;
+    const isLoopIndexVariable =
+      !isInherited &&
+      isTopLevel &&
+      !!currentIndexVariableName &&
+      name === currentIndexVariableName;
+    const overwritesInheritedVariable =
+      isTopLevel &&
+      !isInherited &&
+      !!aliveInheritedVariablesContainer &&
+      aliveInheritedVariablesContainer.has(name);
+
+    const typeErrorMessage =
+      parentType === gd.Variable.Array &&
+      parentVariable &&
+      parentVariable.getChildrenCount() > 1 &&
+      parentVariable.getAtIndex(0).getType() !== type
+        ? i18n._(t`Every child of an array must be the same type.`)
+        : null;
+
+    const hasMixedValues = variable.hasMixedValues();
+    const valueAsString = isCollection
+      ? i18n._(
+          variable.getChildrenCount() === 0
+            ? t`No children`
+            : variable.getChildrenCount() === 1
+            ? t`1 child`
+            : t`${variable.getChildrenCount()} children`
+        )
+      : type === gd.Variable.String
+      ? variable.getString()
+      : type === gd.Variable.Number
+      ? variable.getValue().toString()
+      : null;
+    const valueAsBool =
+      type === gd.Variable.Boolean ? variable.getBool() : null;
+
+    return (
+      <VariableRow
+        key={nodeId}
+        depth={depth}
+        indent={getIndent({ depth, isNarrow, containerWidth })}
+        hideTypeName={hideTypeName}
+        shouldHideExpandIcons={shouldHideExpandIcons}
+        isExpanded={isExpanded}
+        onExpand={onExpand}
+        draggedNodeId={draggedNodeId}
+        nodeId={nodeId}
+        isInherited={isInherited}
+        isNameLocked={props.isListLocked && isTopLevel}
+        isTypeLocked={props.isListLocked && isTopLevel}
+        canDrop={canDrop}
+        dropNode={dropNode}
+        isSelected={selectedNodesSet.has(nodeId)}
+        onSelect={onSelect}
+        gdevelopTheme={gdevelopTheme}
+        variableNameInputRefs={variableNameInputRefs}
+        topLevelVariableValueInputRefs={topLevelVariableValueInputRefs}
+        parentType={parentType}
+        onChangeName={onChangeName}
+        overwritesInheritedVariable={overwritesInheritedVariable}
+        name={name}
+        index={index}
+        rowRightSideStyle={rowRightSideStyle}
+        isTopLevel={isTopLevel}
+        type={type}
+        typeErrorMessage={typeErrorMessage}
+        isLoopIndexVariable={isLoopIndexVariable}
+        removeLoopIndexVariable={removeLoopIndexVariable}
+        variablePointer={variable.ptr}
+        onChangeType={onChangeType}
+        hasMixedValues={hasMixedValues}
+        valueAsString={valueAsString}
+        valueAsBool={valueAsBool}
+        onChangeValue={onChangeValue}
+        isCollection={isCollection}
+        onAddChild={onAddChild}
+        editInheritedVariable={editInheritedVariable}
+        deleteNode={deleteNode}
+        directlyStoreValueChangesWhileEditing={
+          !!props.directlyStoreValueChangesWhileEditing
+        }
+        i18n={i18n}
+      />
+    );
+  };
 
   if (
     !aliveVariablesContainer ||
@@ -2198,10 +2072,38 @@ const VariablesList: React.ComponentType<{
                       </Column>
                     ) : (
                       <ScrollView autoHideScrollbar>
-                        {aliveInheritedVariablesContainer
-                          ? renderTree(i18n, true)
-                          : null}
-                        {renderTree(i18n)}
+                        <div
+                          ref={rowsContainerRef}
+                          className={classes.rowsContainer}
+                          style={{
+                            height:
+                              flattenedVariables.length * VARIABLE_ROW_HEIGHT,
+                          }}
+                        >
+                          <div
+                            className={classes.renderedRows}
+                            style={{ top: firstRowIndex * VARIABLE_ROW_HEIGHT }}
+                          >
+                            {flattenedVariables
+                              .slice(firstRowIndex, afterLastRowIndex)
+                              .map(flattenedVariable =>
+                                renderRow(flattenedVariable, i18n)
+                              )}
+                          </div>
+                          {shouldRenderRevealedRowApart && (
+                            <div
+                              className={classes.renderedRows}
+                              style={{
+                                top: rowIndexToReveal * VARIABLE_ROW_HEIGHT,
+                              }}
+                            >
+                              {renderRow(
+                                flattenedVariables[rowIndexToReveal],
+                                i18n
+                              )}
+                            </div>
+                          )}
+                        </div>
                         {!!undefinedVariableNames.length && (
                           <Paper background="dark" variant="outlined">
                             <Column>

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -109,20 +109,25 @@ const memoized = memoizeOne((initialValue, callback) => callback());
 const VARIABLE_ROW_HEIGHT = 30;
 const actionButtonStyle = { padding: 2 };
 
-/** Below this width, the name of the variable type is replaced by its icon only. */
-const MIN_WIDTH_TO_DISPLAY_TYPE_NAME = 650;
+/**
+ * Below this width, the rows are laid out more tightly: a smaller indentation,
+ * and the type of a variable displayed as its icon only.
+ */
+const MIN_WIDTH_FOR_WIDE_ROWS = 450;
+/** Below this width, the toolbar shows icons instead of labelled buttons. */
+const MIN_WIDTH_FOR_TOOLBAR_LABELS = 650;
 
 const getIndent = ({
   depth,
-  isNarrow,
+  hasNarrowRows,
   containerWidth,
 }: {|
   depth: number,
-  isNarrow: boolean,
+  hasNarrowRows: boolean,
   containerWidth: ?number,
 |}): number =>
   Math.min(
-    depth * (isNarrow ? 12 : 20),
+    depth * (hasNarrowRows ? 12 : 20),
     // Never let the indentation eat too much of the available width.
     containerWidth ? Math.round(0.3 * containerWidth) : 200
   );
@@ -770,24 +775,24 @@ const VariablesList: React.ComponentType<{
       ? !hasVariablesContainerSubChildren(aliveInheritedVariablesContainer)
       : true);
 
-  const isNarrow = React.useMemo(
-    () =>
-      props.size === 'compact' ||
-      (containerWidth
-        ? containerWidth < MIN_WIDTH_TO_DISPLAY_TYPE_NAME
-        : false),
-    [containerWidth, props.size]
-  );
+  const isToolbarNarrow =
+    props.size === 'compact' ||
+    (containerWidth ? containerWidth < MIN_WIDTH_FOR_TOOLBAR_LABELS : false);
+  // The properties panel can be resized, so how the rows are laid out is based
+  // on the width the list actually has, not on it being a compact one.
+  const hasNarrowRows = containerWidth
+    ? containerWidth < MIN_WIDTH_FOR_WIDE_ROWS
+    : props.size === 'compact';
   const rowRightSideStyle = React.useMemo(
     () => ({
       // A fixed width keeps the types and the values aligned, whatever the
       // indentation of the row is.
       width: containerWidth
-        ? Math.round((isNarrow ? 0.5 : 0.6) * containerWidth)
+        ? Math.round((hasNarrowRows ? 0.5 : 0.6) * containerWidth)
         : 400,
       flexShrink: 0,
     }),
-    [containerWidth, isNarrow]
+    [containerWidth, hasNarrowRows]
   );
 
   const undefinedVariableNames =
@@ -1906,7 +1911,6 @@ const VariablesList: React.ComponentType<{
   const selectedNodesSet = React.useMemo(() => new Set(selectedNodes), [
     selectedNodes,
   ]);
-  const hideTypeName = isNarrow;
 
   const renderRow = (
     flattenedVariable: FlattenedVariable,
@@ -1967,9 +1971,9 @@ const VariablesList: React.ComponentType<{
       <VariableRow
         key={nodeId}
         depth={depth}
-        indent={getIndent({ depth, isNarrow, containerWidth })}
+        indent={getIndent({ depth, hasNarrowRows, containerWidth })}
         top={rowIndex * VARIABLE_ROW_HEIGHT}
-        hideTypeName={hideTypeName}
+        hideTypeName={hasNarrowRows}
         shouldHideExpandIcons={shouldHideExpandIcons}
         isExpanded={isExpanded}
         onExpand={onExpand}
@@ -2023,7 +2027,7 @@ const VariablesList: React.ComponentType<{
 
   const toolbar = (
     <VariablesListToolbar
-      isNarrow={isNarrow}
+      isNarrow={isToolbarNarrow}
       isCompact={props.size === 'compact'}
       onCopy={copySelection}
       onPaste={pasteClipboardContent}

--- a/newIDE/app/src/VariablesList/VariablesList.js
+++ b/newIDE/app/src/VariablesList/VariablesList.js
@@ -107,7 +107,6 @@ const memoized = memoizeOne((initialValue, callback) => callback());
  * that are visible on screen: the position of a row is `index * this height`.
  */
 const VARIABLE_ROW_HEIGHT = 30;
-const rowContainerStyle = { height: VARIABLE_ROW_HEIGHT };
 const actionButtonStyle = { padding: 2 };
 
 /** Below this width, the name of the variable type is replaced by its icon only. */
@@ -175,6 +174,8 @@ type VariableRowProps = {|
   // Context:
   depth: number,
   indent: number,
+  /** Position of the row in the container holding all of them. */
+  top: number,
   hideTypeName: boolean,
   shouldHideExpandIcons: boolean,
   isExpanded: boolean,
@@ -228,6 +229,7 @@ const VariableRow = React.memo<VariableRowProps>(
   ({
     depth,
     indent,
+    top,
     hideTypeName,
     shouldHideExpandIcons,
     isExpanded,
@@ -292,7 +294,7 @@ const VariableRow = React.memo<VariableRowProps>(
       <div
         ref={containerRef}
         className={classes.rowContainer}
-        style={rowContainerStyle}
+        style={{ top, height: VARIABLE_ROW_HEIGHT }}
       >
         <DragSourceAndDropTarget
           beginDrag={() => {
@@ -372,11 +374,14 @@ const VariableRow = React.memo<VariableRowProps>(
                   <SimpleTextField
                     type="text"
                     ref={element => {
-                      if (element) {
+                      // The pointers of deleted variables get reused, so an
+                      // unmounted field must not be left behind.
+                      if (element)
                         variableNameInputRefs.current[
                           variablePointer
                         ] = element;
-                      }
+                      else
+                        delete variableNameInputRefs.current[variablePointer];
                     }}
                     directlyStoreValueChangesWhileEditing={
                       directlyStoreValueChangesWhileEditing
@@ -456,11 +461,15 @@ const VariableRow = React.memo<VariableRowProps>(
                     <div className={classes.valueField}>
                       <SimpleTextField
                         ref={element => {
-                          if (depth === 0 && element) {
+                          if (depth !== 0) return;
+                          if (element)
                             topLevelVariableValueInputRefs.current[
                               variablePointer
                             ] = element;
-                          }
+                          else
+                            delete topLevelVariableValueInputRefs.current[
+                              variablePointer
+                            ];
                         }}
                         type={type === gd.Variable.Number ? 'number' : 'text'}
                         directlyStoreValueChangesWhileEditing={
@@ -660,8 +669,6 @@ const VariablesList: React.ComponentType<{
   |}>({});
   // $FlowFixMe[incompatible-type] - Hard to fix issue regarding strict checking with interface.
   const refocusNameField = useRefocusField(variableNameInputRefs);
-  // $FlowFixMe[incompatible-type] - Hard to fix issue regarding strict checking with interface.
-  const refocusValueField = useRefocusField(topLevelVariableValueInputRefs);
   const gdevelopTheme = React.useContext(GDevelopThemeContext);
   const draggedNodeId = React.useRef<?string>(null);
   const forceUpdate = useForceUpdate();
@@ -696,20 +703,22 @@ const VariablesList: React.ComponentType<{
       if (!variableContext.variable) {
         variableContext = getParentVariableContext(variableContext);
       }
-      if (variableContext.variable) {
-        refocusNameField({ identifier: variableContext.variable.ptr });
-      }
       const initialSelectedNodeId = variableContext.variable
         ? getNodeIdFromVariableContext(variableContext)
         : null;
       return initialSelectedNodeId ? [initialSelectedNodeId] : [];
     }
   );
-  // A variable that must be rendered and scrolled to, even if it's outside of
-  // the rows that are visible on screen: this is needed when a variable is
-  // added or initially selected, so that its name field can be focused.
-  const [nodeIdToReveal, setNodeIdToReveal] = React.useState<?string>(
-    () => selectedNodes[0] || null
+  // A variable that must be scrolled to - because it was just added, or is the
+  // one the editor was opened on - and the field of it to focus once it's
+  // displayed. Only the rows visible on screen are rendered, so the focus can
+  // only be given after the list scrolled to the variable.
+  const [variableToReveal, setVariableToReveal] = React.useState<?{|
+    nodeId: string,
+    fieldToFocus: 'name' | 'value' | null,
+    caretPosition?: ?number,
+  |}>(() =>
+    selectedNodes[0] ? { nodeId: selectedNodes[0], fieldToFocus: 'name' } : null
   );
   const setSelectedNodes = React.useCallback(
     (nodes: Array<string> | ((nodes: Array<string>) => Array<string>)) => {
@@ -1485,7 +1494,10 @@ const VariablesList: React.ComponentType<{
       );
       _onChange();
       setSelectedNodes([inheritedVariableName]);
-      setNodeIdToReveal(inheritedVariableName);
+      setVariableToReveal({
+        nodeId: inheritedVariableName,
+        fieldToFocus: null,
+      });
       newVariable.delete();
     },
     [
@@ -1509,7 +1521,7 @@ const VariablesList: React.ComponentType<{
         selectedNodes.some(node => node.startsWith(inheritedPrefix));
 
       if (addAtTopLevel) {
-        const { name: newName, variable } = insertInVariablesContainer(
+        const { name: newName } = insertInVariablesContainer(
           variablesContainer,
           'Variable',
           null,
@@ -1518,8 +1530,7 @@ const VariablesList: React.ComponentType<{
         );
         _onChange();
         setSelectedNodes([newName]);
-        setNodeIdToReveal(newName);
-        refocusNameField({ identifier: variable.ptr });
+        setVariableToReveal({ nodeId: newName, fieldToFocus: 'name' });
         return;
       }
 
@@ -1536,7 +1547,7 @@ const VariablesList: React.ComponentType<{
       } else {
         position = variablesContainer.getPosition(oldestAncestry.name) + 1;
       }
-      const { name: newName, variable } = insertInVariablesContainer(
+      const { name: newName } = insertInVariablesContainer(
         props.variablesContainer,
         'Variable',
         null,
@@ -1545,14 +1556,12 @@ const VariablesList: React.ComponentType<{
       );
       _onChange();
       setSelectedNodes([newName]);
-      setNodeIdToReveal(newName);
-      refocusNameField({ identifier: variable.ptr });
+      setVariableToReveal({ nodeId: newName, fieldToFocus: 'name' });
     },
     [
       _onChange,
       props.inheritedVariablesContainer,
       props.variablesContainer,
-      refocusNameField,
       selectedNodes,
       setSelectedNodes,
     ]
@@ -1761,8 +1770,9 @@ const VariablesList: React.ComponentType<{
         });
         const currentlyFocusedValueField =
           topLevelVariableValueInputRefs.current[changedInheritedVariable.ptr];
-        refocusValueField({
-          identifier: variable.ptr,
+        setVariableToReveal({
+          nodeId: name,
+          fieldToFocus: 'value',
           caretPosition: currentlyFocusedValueField
             ? currentlyFocusedValueField.getCaretPosition()
             : null,
@@ -1808,7 +1818,6 @@ const VariablesList: React.ComponentType<{
       forceUpdate,
       props.inheritedVariablesContainer,
       props.variablesContainer,
-      refocusValueField,
       setSelectedNodes,
     ]
   );
@@ -1836,22 +1845,62 @@ const VariablesList: React.ComponentType<{
     rowHeight: VARIABLE_ROW_HEIGHT,
   });
   const { firstRowIndex, afterLastRowIndex } = visibleRowsRange;
-  const rowIndexToReveal = nodeIdToReveal
-    ? flattenedVariables.findIndex(({ nodeId }) => nodeId === nodeIdToReveal)
-    : -1;
-  const shouldRenderRevealedRowApart =
-    rowIndexToReveal >= 0 &&
-    (rowIndexToReveal < firstRowIndex || rowIndexToReveal >= afterLastRowIndex);
 
+  const rowIndexToReveal = variableToReveal
+    ? flattenedVariables.findIndex(
+        ({ nodeId }) => nodeId === variableToReveal.nodeId
+      )
+    : -1;
+  const variablePointerToReveal =
+    rowIndexToReveal >= 0
+      ? flattenedVariables[rowIndexToReveal].variable.ptr
+      : 0;
+
+  // Scroll to the variable to reveal, then - once its row is rendered, which
+  // only happens after the scroll - focus the field of it to focus.
   React.useLayoutEffect(
     () => {
-      if (rowIndexToReveal < 0) return;
+      if (!variableToReveal) return;
+      if (rowIndexToReveal < 0) {
+        // The variable is gone (renamed, deleted, filtered out by a search...).
+        setVariableToReveal(null);
+        return;
+      }
+
       scrollRowIntoView(rowIndexToReveal);
-      // Only stop rendering the revealed row once it's part of the rows visible
-      // on screen, so that it never gets unmounted while being focused.
-      if (!shouldRenderRevealedRowApart) setNodeIdToReveal(null);
+      if (
+        rowIndexToReveal < firstRowIndex ||
+        rowIndexToReveal >= afterLastRowIndex
+      ) {
+        // Not rendered yet: wait for the scroll to be taken into account.
+        return;
+      }
+
+      const { fieldToFocus, caretPosition } = variableToReveal;
+      if (fieldToFocus) {
+        const fieldRefs =
+          fieldToFocus === 'name'
+            ? variableNameInputRefs
+            : topLevelVariableValueInputRefs;
+        const field = fieldRefs.current[variablePointerToReveal];
+        if (field) {
+          field.focus(
+            caretPosition === null || caretPosition === undefined
+              ? null
+              : { caretPosition }
+          );
+        }
+      }
+      setVariableToReveal(null);
     },
-    [rowIndexToReveal, shouldRenderRevealedRowApart, scrollRowIntoView]
+    [
+      variableToReveal,
+      rowIndexToReveal,
+      variablePointerToReveal,
+      scrollRowIntoView,
+      firstRowIndex,
+      afterLastRowIndex,
+    ]
   );
 
   const selectedNodesSet = React.useMemo(() => new Set(selectedNodes), [
@@ -1861,6 +1910,7 @@ const VariablesList: React.ComponentType<{
 
   const renderRow = (
     flattenedVariable: FlattenedVariable,
+    rowIndex: number,
     i18n: I18nType
   ): React.Node => {
     const {
@@ -1918,6 +1968,7 @@ const VariablesList: React.ComponentType<{
         key={nodeId}
         depth={depth}
         indent={getIndent({ depth, isNarrow, containerWidth })}
+        top={rowIndex * VARIABLE_ROW_HEIGHT}
         hideTypeName={hideTypeName}
         shouldHideExpandIcons={shouldHideExpandIcons}
         isExpanded={isExpanded}
@@ -2080,29 +2131,15 @@ const VariablesList: React.ComponentType<{
                               flattenedVariables.length * VARIABLE_ROW_HEIGHT,
                           }}
                         >
-                          <div
-                            className={classes.renderedRows}
-                            style={{ top: firstRowIndex * VARIABLE_ROW_HEIGHT }}
-                          >
-                            {flattenedVariables
-                              .slice(firstRowIndex, afterLastRowIndex)
-                              .map(flattenedVariable =>
-                                renderRow(flattenedVariable, i18n)
-                              )}
-                          </div>
-                          {shouldRenderRevealedRowApart && (
-                            <div
-                              className={classes.renderedRows}
-                              style={{
-                                top: rowIndexToReveal * VARIABLE_ROW_HEIGHT,
-                              }}
-                            >
-                              {renderRow(
-                                flattenedVariables[rowIndexToReveal],
+                          {flattenedVariables
+                            .slice(firstRowIndex, afterLastRowIndex)
+                            .map((flattenedVariable, index) =>
+                              renderRow(
+                                flattenedVariable,
+                                firstRowIndex + index,
                                 i18n
-                              )}
-                            </div>
-                          )}
+                              )
+                            )}
                         </div>
                         {!!undefinedVariableNames.length && (
                           <Paper background="dark" variant="outlined">

--- a/newIDE/app/src/VariablesList/VariablesList.module.css
+++ b/newIDE/app/src/VariablesList/VariablesList.module.css
@@ -8,14 +8,11 @@
   position: relative;
 }
 
-/* Holds the rows that are rendered, positioned at the first of them. */
-.renderedRows {
+/* Every row is positioned at `index * VARIABLE_ROW_HEIGHT` of the container. */
+.rowContainer {
   position: absolute;
   left: 0;
   right: 0;
-}
-
-.rowContainer {
   /* Leave a thin gap between two rows. */
   padding-bottom: 1px;
   box-sizing: border-box;

--- a/newIDE/app/src/VariablesList/VariablesList.module.css
+++ b/newIDE/app/src/VariablesList/VariablesList.module.css
@@ -1,0 +1,203 @@
+/**
+ * Styles for the (virtualized) list of variables. All the rows have the exact
+ * same height, which is set by the component (see `VARIABLE_ROW_HEIGHT`), so
+ * that the position of a row can be computed without rendering it.
+ */
+
+.rowsContainer {
+  position: relative;
+}
+
+/* Holds the rows that are rendered, positioned at the first of them. */
+.renderedRows {
+  position: absolute;
+  left: 0;
+  right: 0;
+}
+
+.rowContainer {
+  /* Leave a thin gap between two rows. */
+  padding-bottom: 1px;
+  box-sizing: border-box;
+}
+
+.row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  gap: 2px;
+  padding-right: 4px;
+  border-radius: 4px;
+  background-color: var(
+    --theme-surface-alternate-canvas-light-background-color
+  );
+  color: var(--theme-text-default-color);
+}
+
+.row:not(.selected):hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 4px;
+  background-color: var(--theme-hover-background-color);
+  pointer-events: none;
+}
+
+.row.selected {
+  background-color: var(--theme-selection-background-color);
+  color: var(--theme-selection-color);
+}
+
+/* The type selector sets its own colors: make it follow the selected row. */
+.row.selected .typeSelector select,
+.row.selected .typeSelector svg {
+  color: var(--theme-selection-color);
+}
+
+.chevron {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 100%;
+  border-radius: 4px 0 0 4px;
+}
+
+.chevron svg {
+  font-size: 16px;
+}
+
+.dragHandle {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  width: 16px;
+  color: var(--theme-text-secondary-color);
+  opacity: 0.5;
+}
+
+.row:hover .dragHandle {
+  opacity: 1;
+}
+
+.dragHandle svg {
+  font-size: 16px;
+}
+
+.nameField {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding-left: 2px;
+}
+
+.rowRightSide {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.typeSelector {
+  flex: 0 0 auto;
+  /* Only the icon of the type is displayed. */
+  width: 30px;
+}
+
+.typeSelector.withTypeName {
+  width: 124px;
+}
+
+/* Clicking anywhere on the icon of the type opens the type selection: the
+   select itself is stretched over the icon, and made invisible. */
+.typeSelectorIconOnly {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 22px;
+  border-radius: 4px;
+  background-color: var(--theme-text-field-default-background-color);
+}
+
+.typeSelectorIconOnly svg {
+  font-size: 18px;
+  pointer-events: none;
+}
+
+.typeSelectorIconOnly select {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  appearance: none;
+  border: none;
+  outline: none;
+}
+
+.typeSelectorReadOnly {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding-left: 4px;
+  overflow: hidden;
+}
+
+.typeSelectorReadOnly svg {
+  flex: 0 0 auto;
+  font-size: 18px;
+}
+
+.typeSelectorReadOnlyLabel {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--theme-text-secondary-color);
+}
+
+.valueField {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.valueLabel {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.actionButton {
+  flex: 0 0 auto;
+}
+
+.actionButton svg {
+  font-size: 18px;
+}
+
+.dropIndicator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.dropIndicatorBefore {
+  top: -1px;
+}
+
+.dropIndicatorAfter {
+  bottom: -1px;
+}

--- a/newIDE/app/src/VariablesList/VariablesList.module.css
+++ b/newIDE/app/src/VariablesList/VariablesList.module.css
@@ -116,7 +116,13 @@
   width: 100%;
   height: 22px;
   border-radius: 4px;
+}
+
+/* Show that the icon of the type can be clicked to change it. */
+.row:hover .typeSelectorIconOnly,
+.typeSelectorIconOnly:focus-within {
   background-color: var(--theme-text-field-default-background-color);
+  outline: 1px solid var(--theme-text-field-hover-border-color);
 }
 
 .typeSelectorIconOnly svg {

--- a/newIDE/app/src/VariablesList/VariablesList.module.css
+++ b/newIDE/app/src/VariablesList/VariablesList.module.css
@@ -30,6 +30,9 @@
     --theme-surface-alternate-canvas-light-background-color
   );
   color: var(--theme-text-default-color);
+  /* The font is otherwise only set by the Text components, which the rows don't
+     use: the labels of a row would fall back to the font of the browser. */
+  font-family: var(--gdevelop-modern-font-family);
 }
 
 .row:not(.selected):hover::after {

--- a/newIDE/app/src/stories/FixedHeightFlexContainer.js
+++ b/newIDE/app/src/stories/FixedHeightFlexContainer.js
@@ -8,6 +8,7 @@ const style = {
 type Props = {
   children: React.Node,
   height: number | string,
+  width?: number | string,
   alignItems?: 'center',
   justifyContent?: 'center',
 };
@@ -15,10 +16,13 @@ type Props = {
 const FixedHeightFlexContainer = ({
   children,
   height,
+  width,
   alignItems,
   justifyContent,
 }: Props): React.MixedElement => (
-  <div style={{ ...style, height, alignItems, justifyContent }}>{children}</div>
+  <div style={{ ...style, height, width, alignItems, justifyContent }}>
+    {children}
+  </div>
 );
 
 export default FixedHeightFlexContainer;

--- a/newIDE/app/src/stories/componentStories/VariablesList.stories.js
+++ b/newIDE/app/src/stories/componentStories/VariablesList.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { Trans } from '@lingui/macro';
 import paperDecorator from '../PaperDecorator';
 import GDevelopJsInitializerDecorator, {
   testProject,
@@ -7,6 +8,49 @@ import GDevelopJsInitializerDecorator, {
 import VariablesList from '../../VariablesList/VariablesList';
 import DragAndDropContextProvider from '../../UI/DragAndDrop/DragAndDropContextProvider';
 import FixedHeightFlexContainer from '../FixedHeightFlexContainer';
+import ScrollView from '../../UI/ScrollView';
+import { Column, Line } from '../../UI/Grid';
+import Text from '../../UI/Text';
+import { useRefWithInit } from '../../Utils/UseRefInitHook';
+
+const gd: libGDevelop = global.gd;
+
+/**
+ * A variables container with a lot of variables, including nested ones, to
+ * check that the list stays fast and that virtualization behaves properly.
+ */
+const useManyVariablesContainer = (count: number): gdVariablesContainer => {
+  const variablesContainerRef = useRefWithInit(() => {
+    const variablesContainer = new gd.VariablesContainer(
+      gd.VariablesContainer.Scene
+    );
+    for (let index = 0; index < count; index++) {
+      const variable = new gd.Variable();
+      if (index % 10 === 0) {
+        variable.castTo('structure');
+        for (let childIndex = 0; childIndex < 5; childIndex++) {
+          variable.getChild(`Child${childIndex}`).setValue(childIndex);
+        }
+      } else if (index % 10 === 5) {
+        variable.castTo('array');
+        for (let childIndex = 0; childIndex < 3; childIndex++) {
+          variable.pushNew().setString(`Item ${childIndex}`);
+        }
+      } else if (index % 3 === 0) {
+        variable.setString(`Some text value ${index}`);
+      } else if (index % 3 === 1) {
+        variable.setValue(index);
+      } else {
+        variable.setBool(index % 2 === 0);
+      }
+      variablesContainer.insert(`Variable${index}`, variable, index);
+      variable.delete();
+    }
+    return variablesContainer;
+  });
+
+  return variablesContainerRef.current;
+};
 
 export const Default = (): React.Node => (
   <DragAndDropContextProvider>
@@ -145,6 +189,74 @@ export const LockedInstanceWithObjectVariables = (): React.Node => (
     </FixedHeightFlexContainer>
   </DragAndDropContextProvider>
 );
+
+export const WithManyVariables = (): React.Node => {
+  const variablesContainer = useManyVariablesContainer(500);
+  return (
+    <DragAndDropContextProvider>
+      <FixedHeightFlexContainer height={600}>
+        <VariablesList
+          projectScopedContainersAccessor={
+            testProject.testSceneProjectScopedContainersAccessor
+          }
+          variablesContainer={variablesContainer}
+          emptyPlaceholderDescription="Variables help you store data"
+          emptyPlaceholderTitle="Variables"
+          helpPagePath="/variables"
+          isListLocked={false}
+        />
+      </FixedHeightFlexContainer>
+    </DragAndDropContextProvider>
+  );
+};
+
+/**
+ * Reproduces the properties panel: the variables list is displayed in a
+ * section of a panel which is the one handling the scroll.
+ */
+export const CompactWithManyVariablesInScrollingPanel = (): React.Node => {
+  const variablesContainer = useManyVariablesContainer(500);
+  return (
+    <DragAndDropContextProvider>
+      <FixedHeightFlexContainer height={600} width={280}>
+        <ScrollView>
+          <Column>
+            <Text size="block-title">
+              <Trans>Some other section</Trans>
+            </Text>
+            <Line>
+              <Text noMargin>
+                <Trans>
+                  Content displayed before the variables, in the same scrolling
+                  panel.
+                </Trans>
+              </Text>
+            </Line>
+            <Text size="block-title">
+              <Trans>Scene Variables</Trans>
+            </Text>
+          </Column>
+          <VariablesList
+            projectScopedContainersAccessor={
+              testProject.testSceneProjectScopedContainersAccessor
+            }
+            size="compact"
+            directlyStoreValueChangesWhileEditing
+            variablesContainer={variablesContainer}
+            compactEmptyPlaceholderText="There are no variables on this scene."
+            helpPagePath="/variables"
+            isListLocked={false}
+          />
+          <Column>
+            <Text size="block-title">
+              <Trans>Some section after the variables</Trans>
+            </Text>
+          </Column>
+        </ScrollView>
+      </FixedHeightFlexContainer>
+    </DragAndDropContextProvider>
+  );
+};
 
 export default {
   title: 'VariablesList',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A scene with 500 variables made the properties panel (and the variables dialog) slow to display and slow to react to any change, because every row of the list was rendered. The list now renders only the rows that are on screen, and its rows were redesigned to be denser.

## Rendering only the visible rows

The scroll of the variables list is not always handled by the list itself: in the properties panel, the panel scrolls all its sections at once. So instead of using a virtualized list component (which would own the scroll), the list keeps rendering into a container as tall as all its rows, and only fills it with the rows that are on screen:

- `FlattenVariables.js` flattens the tree of variables (both the inherited ones and the ones of the container) into the list of rows to display, applying the search filter and hiding the children of folded variables.
- `useVisibleRowsRange.js` computes which of these rows are on screen. It does not care about which ancestor scrolls: it walks up the DOM once to collect the ancestors that clip their content, and intersects their rectangles with the window to know the band of the container that can actually be seen. A capturing `scroll` listener on `window` catches the scroll of any of them, and a `ResizeObserver` catches the panel being resized.
- All the rows are absolutely positioned at `index * VARIABLE_ROW_HEIGHT` in that container, so a row keeps its DOM node when the visible range changes — which matters when a variable is added at the end of a long list: the list scrolls to it and its name field is focused, and it must not be remounted in between.

Every row therefore has the exact same height, which is what makes a row's position computable without rendering the ones before it.

## Denser and tidier rows

A row used to be laid out on one or two lines depending on the available width, with a text field showing a border at all times. It is now always a single line of 30px (instead of 36px in a dialog and 53px in the properties panel):

- the type of a variable uses `CompactSelectField`, the select field used in the rest of the editor, and is reduced to its icon (with a tooltip, and a box appearing on hover) when the list is too narrow for the name of the type to fit;
- the text fields only show their underline when hovered or focused;
- the indentation is smaller, and capped so that it never eats more than 30% of the width;
- the rows have rounded corners, a hover state and a selected state taken from the theme;
- how tightly a row is laid out is decided from the width the list is measured to have, instead of it being a "compact" list, since the properties panel can be resized.

[The variables of an instance in a dialog, before and after](https://cursor.com/agents/bc-c5c01669-3698-4c2c-82de-6e261c3a843f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariables_dialog_before_after.png)

[The variables of a scene in the properties panel, before and after](https://cursor.com/agents/bc-c5c01669-3698-4c2c-82de-6e261c3a843f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariables_panel_before_after.png)

## Checks

500 variables (900 rows once the structures and arrays are expanded): 23 rows rendered instead of 900, and a change in the list (a keystroke, a type changed, a variable folded) takes ~20ms instead of ~2.1s.

[variables_list_500_variables_scrolling_adding_and_searching.mp4](https://cursor.com/agents/bc-c5c01669-3698-4c2c-82de-6e261c3a843f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariables_list_500_variables_scrolling_adding_and_searching.mp4)

The Storybook stories got two additions used to check this: `WithManyVariables` (a scene with 500 variables) and `CompactWithManyVariablesInScrollingPanel` (the same variables in a narrow panel which is the one handling the scroll). Both were driven in a real browser to check that scrolling anywhere in the list displays exactly the expected variables, that no more rows than needed are rendered, that all the rows have the same height, that the type and value columns stay aligned whatever the indentation, that adding a variable scrolls to it and focuses its name, that the search filters correctly, and that drag and drop still moves variables.

`FlattenVariables.spec.js` covers the flattening itself: the order of the rows, folded variables hiding their children, inherited variables being displayed first without the ones being overridden, and what a search displays.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5c01669-3698-4c2c-82de-6e261c3a843f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5c01669-3698-4c2c-82de-6e261c3a843f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

