### PR TITLE
Allow resizing the gameplay test frame when no test is running

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -2908,42 +2908,44 @@ namespace gdjs {
     /** The game left frozen by the last finished test, if any. */
     let frozenRuntimeGame: gdjs.RuntimeGame | null = null;
     let freezeResizeLayoutListenerInstalled = false;
+    let freezeResizeLayoutScheduled = false;
 
     /**
      * A game frozen by `freezeWhenFinished` keeps rendering its last frame but
      * runs no logic: nothing re-lays it out when the window is resized (anchor
      * behavior, objects sized by events...). Run a single frame with a zero
-     * time delta on resize: the game is laid out for the new size without
-     * anything moving or animating.
+     * time delta: the game is laid out for the new size without anything
+     * moving or animating.
      */
-    const installFreezeResizeLayoutListener = () => {
+    const layOutFrozenGameForNewWindowSize = () => {
+      freezeResizeLayoutScheduled = false;
+      if (!frozenRuntimeGame || currentlyRunningHarness) return;
+
+      // The renderer already adapted the game resolution (its own resize
+      // listener ran first): adapt the cameras before stepping.
+      frozenRuntimeGame.getSceneStack().onGameResolutionResized();
+      frozenRuntimeGame.getSceneStack().step(0);
+    };
+
+    const onWindowResizedWhileFrozen = () => {
       if (
-        freezeResizeLayoutListenerInstalled ||
-        typeof window === 'undefined'
+        !frozenRuntimeGame ||
+        currentlyRunningHarness ||
+        freezeResizeLayoutScheduled
       ) {
         return;
       }
+
+      // Lay the game out at most once per animation frame, for the latest size.
+      freezeResizeLayoutScheduled = true;
+      requestAnimationFrame(layOutFrozenGameForNewWindowSize);
+    };
+
+    const installFreezeResizeLayoutListener = () => {
+      if (freezeResizeLayoutListenerInstalled) return;
       freezeResizeLayoutListenerInstalled = true;
 
-      let layoutScheduled = false;
-      window.addEventListener('resize', () => {
-        if (!frozenRuntimeGame || currentlyRunningHarness || layoutScheduled) {
-          return;
-        }
-        // Lay the game out at most once per animation frame, for the
-        // latest size.
-        layoutScheduled = true;
-        requestAnimationFrame(() => {
-          layoutScheduled = false;
-          if (!frozenRuntimeGame || currentlyRunningHarness) {
-            return;
-          }
-          // The renderer already adapted the game resolution (its own
-          // resize listener ran first): adapt the cameras before stepping.
-          frozenRuntimeGame.getSceneStack().onGameResolutionResized();
-          frozenRuntimeGame.getSceneStack().step(0);
-        });
-      });
+      window.addEventListener('resize', onWindowResizedWhileFrozen);
     };
 
     /**

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -1356,6 +1356,12 @@ namespace gdjs {
        * this size. Useful to test layouts made for other screen sizes,
        * before asserting positions or taking a screenshot.
        *
+       * This is the ONLY way the game resolution changes during a test:
+       * a gameplay test always runs in a game window of the project's game
+       * resolution, and moving, resizing or minimizing the gameplay test
+       * frame in the editor is never visible to the game (the frame is
+       * only a zoomed view of that fixed window).
+       *
        * The engine sees a game window of this size until the end of the
        * test: a game adapting its resolution to the game window size would
        * otherwise recompute it from the real window, ignoring the size

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -2906,47 +2906,6 @@ namespace gdjs {
       !!currentlyRunningHarness;
 
     /**
-     * The game left paused (frozen) by the last finished test, if any.
-     * See `installFreezeResizeStepListener`.
-     */
-    let frozenRuntimeGame: gdjs.RuntimeGame | null = null;
-    let freezeResizeStepListenerInstalled = false;
-
-    /**
-     * When a test finished with `freezeWhenFinished`, the game stays paused,
-     * showing the last frame. If the game window is then resized, run a
-     * single game frame so that everything adapting to the window size
-     * (anchored objects, cameras...) updates the displayed frame. This does
-     * not change the results of the test: they were already computed and
-     * reported when the test finished.
-     */
-    const installFreezeResizeStepListener = () => {
-      if (freezeResizeStepListenerInstalled || typeof window === 'undefined') {
-        return;
-      }
-      freezeResizeStepListenerInstalled = true;
-
-      let stepScheduled = false;
-      window.addEventListener('resize', () => {
-        if (!frozenRuntimeGame || currentlyRunningHarness || stepScheduled) {
-          return;
-        }
-        // Coalesce to at most one game frame per animation frame, but run
-        // the frame synchronously so the adaptation is rendered in the same
-        // paint as the resize (no trailing while dragging a window border).
-        stepScheduled = true;
-        requestAnimationFrame(() => {
-          stepScheduled = false;
-        });
-        // The game renderer's own resize listener ran first (it was
-        // registered at game startup): the game resolution is already
-        // adapted. Adapt the cameras now, then run a single game frame.
-        frozenRuntimeGame.getSceneStack().onGameResolutionResized();
-        frozenRuntimeGame.getSceneStack().step(1000 / 60);
-      });
-    };
-
-    /**
      * Run a gameplay test script against the game and return its result.
      *
      * The game main loop keeps rendering (paused) while the test steps the
@@ -2971,8 +2930,6 @@ namespace gdjs {
 
       const harness = new GameplayTestHarness(runtimeGame, payload);
       currentlyRunningHarness = harness;
-      // The game is not frozen anymore: the test owns the game stepping.
-      frozenRuntimeGame = null;
       harness._onProgress = onProgress || null;
 
       // The source must be the BODY of `async (harness) => { ... }`, but
@@ -3205,9 +3162,6 @@ namespace gdjs {
           } catch (error) {
             // Ignore errors while muting the game.
           }
-          // Still adapt the displayed last frame if the window is resized.
-          frozenRuntimeGame = runtimeGame;
-          installFreezeResizeStepListener();
         } else {
           runtimeGame.pause(wasPaused);
         }

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -2905,26 +2905,16 @@ namespace gdjs {
     export const isGameplayTestRunning = (): boolean =>
       !!currentlyRunningHarness;
 
-    /**
-     * The game left paused (frozen) by the last finished test, if any.
-     * See `installFreezeResizeLayoutListener`.
-     */
+    /** The game left frozen by the last finished test, if any. */
     let frozenRuntimeGame: gdjs.RuntimeGame | null = null;
     let freezeResizeLayoutListenerInstalled = false;
 
     /**
-     * When a test finished with `freezeWhenFinished`, the game stays paused:
-     * its main loop keeps rendering the last frame (`renderWithoutStep`), but
-     * runs no game logic at all. If the game window is then resized, this
-     * rendering is not enough: everything laying the game out from the window
-     * size (objects with the anchor behavior, objects resized by events...) is
-     * only updated when the game logic runs, so the last frame would be
-     * rendered with a layout made for the previous window size.
-     *
-     * Run a single frame with a zero time delta when this happens: the game is
-     * laid out for the new window size without any time passing, so nothing
-     * moves, no timer advances and no animation plays. The results of the test
-     * are untouched: they were already computed and reported when it finished.
+     * A game frozen by `freezeWhenFinished` keeps rendering its last frame but
+     * runs no logic: nothing re-lays it out when the window is resized (anchor
+     * behavior, objects sized by events...). Run a single frame with a zero
+     * time delta on resize: the game is laid out for the new size without
+     * anything moving or animating.
      */
     const installFreezeResizeLayoutListener = () => {
       if (
@@ -2940,20 +2930,16 @@ namespace gdjs {
         if (!frozenRuntimeGame || currentlyRunningHarness || layoutScheduled) {
           return;
         }
-        // The resize event can fire more often than the display refreshes:
-        // lay the game out at most once per animation frame while a window
-        // border is dragged, always for the latest size.
+        // Lay the game out at most once per animation frame, for the
+        // latest size.
         layoutScheduled = true;
         requestAnimationFrame(() => {
           layoutScheduled = false;
           if (!frozenRuntimeGame || currentlyRunningHarness) {
             return;
           }
-          // The game renderer's own resize listener already ran (it was
-          // registered at game startup): the game resolution is already
-          // adapted. Adapt the cameras to it before stepping, as the paused
-          // main loop would only do it on its next frame - too late for the
-          // frame stepped here.
+          // The renderer already adapted the game resolution (its own
+          // resize listener ran first): adapt the cameras before stepping.
           frozenRuntimeGame.getSceneStack().onGameResolutionResized();
           frozenRuntimeGame.getSceneStack().step(0);
         });
@@ -2985,7 +2971,7 @@ namespace gdjs {
 
       const harness = new GameplayTestHarness(runtimeGame, payload);
       currentlyRunningHarness = harness;
-      // The game is not frozen anymore: the test owns the game stepping.
+      // The test owns the game stepping from now on.
       frozenRuntimeGame = null;
       harness._onProgress = onProgress || null;
 

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -1348,6 +1348,42 @@ namespace gdjs {
         return this._runtimeGame.getGameResolutionHeight();
       }
 
+      /** Undo the game window size override (see `setGameResolutionSize`). */
+      _uninstallGameWindowSizeOverride: () => void = () => {};
+
+      /**
+       * Change the game resolution, as if the game window was resized to
+       * this size. Useful to test layouts made for other screen sizes,
+       * before asserting positions or taking a screenshot.
+       *
+       * The engine sees a game window of this size until the end of the
+       * test: a game adapting its resolution to the game window size would
+       * otherwise recompute it from the real window, ignoring the size
+       * requested here.
+       */
+      setGameResolutionSize(width: float, height: float): void {
+        this._uninstallGameWindowSizeOverride();
+        const original = {
+          getWindowInnerWidth: gdjs.RuntimeGameRenderer.getWindowInnerWidth,
+          getWindowInnerHeight: gdjs.RuntimeGameRenderer.getWindowInnerHeight,
+        };
+        gdjs.RuntimeGameRenderer.getWindowInnerWidth = () => width;
+        gdjs.RuntimeGameRenderer.getWindowInnerHeight = () => height;
+        this._uninstallGameWindowSizeOverride = () => {
+          gdjs.RuntimeGameRenderer.getWindowInnerWidth =
+            original.getWindowInnerWidth;
+          gdjs.RuntimeGameRenderer.getWindowInnerHeight =
+            original.getWindowInnerHeight;
+          this._uninstallGameWindowSizeOverride = () => {};
+        };
+
+        this._runtimeGame.setGameResolutionSize(width, height);
+        // The paused main loop would only adapt the cameras on its next
+        // animation frame: do it now, so the next stepped frame is laid out
+        // for the new resolution.
+        this._runtimeGame.getSceneStack().onGameResolutionResized();
+      }
+
       /**
        * Release all pressed keys, mouse buttons and touches.
        */
@@ -2905,49 +2941,6 @@ namespace gdjs {
     export const isGameplayTestRunning = (): boolean =>
       !!currentlyRunningHarness;
 
-    /** The game left frozen by the last finished test, if any. */
-    let frozenRuntimeGame: gdjs.RuntimeGame | null = null;
-    let freezeResizeLayoutListenerInstalled = false;
-    let freezeResizeLayoutScheduled = false;
-
-    /**
-     * A game frozen by `freezeWhenFinished` keeps rendering its last frame but
-     * runs no logic: nothing re-lays it out when the window is resized (anchor
-     * behavior, objects sized by events...). Run a single frame with a zero
-     * time delta: the game is laid out for the new size without anything
-     * moving or animating.
-     */
-    const layOutFrozenGameForNewWindowSize = () => {
-      freezeResizeLayoutScheduled = false;
-      if (!frozenRuntimeGame || currentlyRunningHarness) return;
-
-      // The renderer already adapted the game resolution (its own resize
-      // listener ran first): adapt the cameras before stepping.
-      frozenRuntimeGame.getSceneStack().onGameResolutionResized();
-      frozenRuntimeGame.getSceneStack().step(0);
-    };
-
-    const onWindowResizedWhileFrozen = () => {
-      if (
-        !frozenRuntimeGame ||
-        currentlyRunningHarness ||
-        freezeResizeLayoutScheduled
-      ) {
-        return;
-      }
-
-      // Lay the game out at most once per animation frame, for the latest size.
-      freezeResizeLayoutScheduled = true;
-      requestAnimationFrame(layOutFrozenGameForNewWindowSize);
-    };
-
-    const installFreezeResizeLayoutListener = () => {
-      if (freezeResizeLayoutListenerInstalled) return;
-      freezeResizeLayoutListenerInstalled = true;
-
-      window.addEventListener('resize', onWindowResizedWhileFrozen);
-    };
-
     /**
      * Run a gameplay test script against the game and return its result.
      *
@@ -2973,8 +2966,6 @@ namespace gdjs {
 
       const harness = new GameplayTestHarness(runtimeGame, payload);
       currentlyRunningHarness = harness;
-      // The test owns the game stepping from now on.
-      frozenRuntimeGame = null;
       harness._onProgress = onProgress || null;
 
       // The source must be the BODY of `async (harness) => { ... }`, but
@@ -3197,6 +3188,7 @@ namespace gdjs {
         inputManager.onFrameEnded = originalOnFrameEnded;
         harness._uninstallPointerLockShim();
         harness._uninstallSoundLog();
+        harness._uninstallGameWindowSizeOverride();
         gdjs.Logger.setLoggerOutput(existingLoggerOutput);
         if (payload.freezeWhenFinished) {
           // Keep the game paused (the main loop keeps rendering the last
@@ -3207,9 +3199,6 @@ namespace gdjs {
           } catch (error) {
             // Ignore errors while muting the game.
           }
-          // Still lay out the displayed last frame if the window is resized.
-          frozenRuntimeGame = runtimeGame;
-          installFreezeResizeLayoutListener();
         } else {
           runtimeGame.pause(wasPaused);
         }

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -2906,6 +2906,61 @@ namespace gdjs {
       !!currentlyRunningHarness;
 
     /**
+     * The game left paused (frozen) by the last finished test, if any.
+     * See `installFreezeResizeLayoutListener`.
+     */
+    let frozenRuntimeGame: gdjs.RuntimeGame | null = null;
+    let freezeResizeLayoutListenerInstalled = false;
+
+    /**
+     * When a test finished with `freezeWhenFinished`, the game stays paused:
+     * its main loop keeps rendering the last frame (`renderWithoutStep`), but
+     * runs no game logic at all. If the game window is then resized, this
+     * rendering is not enough: everything laying the game out from the window
+     * size (objects with the anchor behavior, objects resized by events...) is
+     * only updated when the game logic runs, so the last frame would be
+     * rendered with a layout made for the previous window size.
+     *
+     * Run a single frame with a zero time delta when this happens: the game is
+     * laid out for the new window size without any time passing, so nothing
+     * moves, no timer advances and no animation plays. The results of the test
+     * are untouched: they were already computed and reported when it finished.
+     */
+    const installFreezeResizeLayoutListener = () => {
+      if (
+        freezeResizeLayoutListenerInstalled ||
+        typeof window === 'undefined'
+      ) {
+        return;
+      }
+      freezeResizeLayoutListenerInstalled = true;
+
+      let alreadySteppedForThisAnimationFrame = false;
+      window.addEventListener('resize', () => {
+        if (
+          !frozenRuntimeGame ||
+          currentlyRunningHarness ||
+          alreadySteppedForThisAnimationFrame
+        ) {
+          return;
+        }
+        // The resize event can fire more often than the display refreshes:
+        // lay the game out at most once per animation frame while a window
+        // border is dragged.
+        alreadySteppedForThisAnimationFrame = true;
+        requestAnimationFrame(() => {
+          alreadySteppedForThisAnimationFrame = false;
+        });
+        // The game renderer's own resize listener ran first (it was registered
+        // at game startup): the game resolution is already adapted. Adapt the
+        // cameras to it before stepping, as the paused main loop would only do
+        // it on its next frame - too late for the frame stepped here.
+        frozenRuntimeGame.getSceneStack().onGameResolutionResized();
+        frozenRuntimeGame.getSceneStack().step(0);
+      });
+    };
+
+    /**
      * Run a gameplay test script against the game and return its result.
      *
      * The game main loop keeps rendering (paused) while the test steps the
@@ -2930,6 +2985,8 @@ namespace gdjs {
 
       const harness = new GameplayTestHarness(runtimeGame, payload);
       currentlyRunningHarness = harness;
+      // The game is not frozen anymore: the test owns the game stepping.
+      frozenRuntimeGame = null;
       harness._onProgress = onProgress || null;
 
       // The source must be the BODY of `async (harness) => { ... }`, but
@@ -3162,6 +3219,9 @@ namespace gdjs {
           } catch (error) {
             // Ignore errors while muting the game.
           }
+          // Still lay out the displayed last frame if the window is resized.
+          frozenRuntimeGame = runtimeGame;
+          installFreezeResizeLayoutListener();
         } else {
           runtimeGame.pause(wasPaused);
         }

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -2935,28 +2935,28 @@ namespace gdjs {
       }
       freezeResizeLayoutListenerInstalled = true;
 
-      let alreadySteppedForThisAnimationFrame = false;
+      let layoutScheduled = false;
       window.addEventListener('resize', () => {
-        if (
-          !frozenRuntimeGame ||
-          currentlyRunningHarness ||
-          alreadySteppedForThisAnimationFrame
-        ) {
+        if (!frozenRuntimeGame || currentlyRunningHarness || layoutScheduled) {
           return;
         }
         // The resize event can fire more often than the display refreshes:
         // lay the game out at most once per animation frame while a window
-        // border is dragged.
-        alreadySteppedForThisAnimationFrame = true;
+        // border is dragged, always for the latest size.
+        layoutScheduled = true;
         requestAnimationFrame(() => {
-          alreadySteppedForThisAnimationFrame = false;
+          layoutScheduled = false;
+          if (!frozenRuntimeGame || currentlyRunningHarness) {
+            return;
+          }
+          // The game renderer's own resize listener already ran (it was
+          // registered at game startup): the game resolution is already
+          // adapted. Adapt the cameras to it before stepping, as the paused
+          // main loop would only do it on its next frame - too late for the
+          // frame stepped here.
+          frozenRuntimeGame.getSceneStack().onGameResolutionResized();
+          frozenRuntimeGame.getSceneStack().step(0);
         });
-        // The game renderer's own resize listener ran first (it was registered
-        // at game startup): the game resolution is already adapted. Adapt the
-        // cameras to it before stepping, as the paused main loop would only do
-        // it on its next frame - too late for the frame stepped here.
-        frozenRuntimeGame.getSceneStack().onGameResolutionResized();
-        frozenRuntimeGame.getSceneStack().step(0);
       });
     };
 

--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -2906,6 +2906,47 @@ namespace gdjs {
       !!currentlyRunningHarness;
 
     /**
+     * The game left paused (frozen) by the last finished test, if any.
+     * See `installFreezeResizeStepListener`.
+     */
+    let frozenRuntimeGame: gdjs.RuntimeGame | null = null;
+    let freezeResizeStepListenerInstalled = false;
+
+    /**
+     * When a test finished with `freezeWhenFinished`, the game stays paused,
+     * showing the last frame. If the game window is then resized, run a
+     * single game frame so that everything adapting to the window size
+     * (anchored objects, cameras...) updates the displayed frame. This does
+     * not change the results of the test: they were already computed and
+     * reported when the test finished.
+     */
+    const installFreezeResizeStepListener = () => {
+      if (freezeResizeStepListenerInstalled || typeof window === 'undefined') {
+        return;
+      }
+      freezeResizeStepListenerInstalled = true;
+
+      let stepScheduled = false;
+      window.addEventListener('resize', () => {
+        if (!frozenRuntimeGame || currentlyRunningHarness || stepScheduled) {
+          return;
+        }
+        // Coalesce to at most one game frame per animation frame, but run
+        // the frame synchronously so the adaptation is rendered in the same
+        // paint as the resize (no trailing while dragging a window border).
+        stepScheduled = true;
+        requestAnimationFrame(() => {
+          stepScheduled = false;
+        });
+        // The game renderer's own resize listener ran first (it was
+        // registered at game startup): the game resolution is already
+        // adapted. Adapt the cameras now, then run a single game frame.
+        frozenRuntimeGame.getSceneStack().onGameResolutionResized();
+        frozenRuntimeGame.getSceneStack().step(1000 / 60);
+      });
+    };
+
+    /**
      * Run a gameplay test script against the game and return its result.
      *
      * The game main loop keeps rendering (paused) while the test steps the
@@ -2930,6 +2971,8 @@ namespace gdjs {
 
       const harness = new GameplayTestHarness(runtimeGame, payload);
       currentlyRunningHarness = harness;
+      // The game is not frozen anymore: the test owns the game stepping.
+      frozenRuntimeGame = null;
       harness._onProgress = onProgress || null;
 
       // The source must be the BODY of `async (harness) => { ... }`, but
@@ -3162,6 +3205,9 @@ namespace gdjs {
           } catch (error) {
             // Ignore errors while muting the game.
           }
+          // Still adapt the displayed last frame if the window is resized.
+          frozenRuntimeGame = runtimeGame;
+          installFreezeResizeStepListener();
         } else {
           runtimeGame.pause(wasPaused);
         }

--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
@@ -312,8 +312,8 @@ export default class BrowserSWPreviewLauncher extends React.Component<
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation:
             outputDir + '/index.html?previewId=' + previewId,
-          // The frame opens with a game window of the project resolution,
-          // displayed zoomed out.
+          // The game window of the frame is fixed at the project
+          // resolution: the frame only zooms its display.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
@@ -312,6 +312,12 @@ export default class BrowserSWPreviewLauncher extends React.Component<
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation:
             outputDir + '/index.html?previewId=' + previewId,
+          // The game runs at the resolution of the project, like in a normal
+          // preview window: the frame only displays it scaled down.
+          gameResolution: {
+            width: project.getGameResolutionWidth(),
+            height: project.getGameResolutionHeight(),
+          },
         });
       } else if (shouldHotReload) {
         const projectDataElement = new gd.SerializerElement();

--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
@@ -312,8 +312,9 @@ export default class BrowserSWPreviewLauncher extends React.Component<
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation:
             outputDir + '/index.html?previewId=' + previewId,
-          // The game runs at the resolution of the project, like in a normal
-          // preview window: the frame only displays it scaled down.
+          // The frame shows the game zoomed out, in a game window that has
+          // the resolution of the project when the frame is opened, like a
+          // normal preview window.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
@@ -312,9 +312,8 @@ export default class BrowserSWPreviewLauncher extends React.Component<
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation:
             outputDir + '/index.html?previewId=' + previewId,
-          // The frame shows the game zoomed out, in a game window that has
-          // the resolution of the project when the frame is opened, like a
-          // normal preview window.
+          // The frame opens with a game window of the project resolution,
+          // displayed zoomed out.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
@@ -461,6 +461,12 @@ export default class LocalPreviewLauncher extends React.Component<
         // reload the game when the same preview is re-exported.
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation: `file://${outputDir}/index.html?previewId=${previewId}`,
+          // The game runs at the resolution of the project, like in a normal
+          // preview window: the frame only displays it scaled down.
+          gameResolution: {
+            width: project.getGameResolutionWidth(),
+            height: project.getGameResolutionHeight(),
+          },
         });
       } else if (previewOptions.numberOfWindows >= 1) {
         this._openPreviewWindow(project, outputDir, previewOptions);

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
@@ -461,9 +461,8 @@ export default class LocalPreviewLauncher extends React.Component<
         // reload the game when the same preview is re-exported.
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation: `file://${outputDir}/index.html?previewId=${previewId}`,
-          // The frame shows the game zoomed out, in a game window that has
-          // the resolution of the project when the frame is opened, like a
-          // normal preview window.
+          // The frame opens with a game window of the project resolution,
+          // displayed zoomed out.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
@@ -461,8 +461,8 @@ export default class LocalPreviewLauncher extends React.Component<
         // reload the game when the same preview is re-exported.
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation: `file://${outputDir}/index.html?previewId=${previewId}`,
-          // The frame opens with a game window of the project resolution,
-          // displayed zoomed out.
+          // The game window of the frame is fixed at the project
+          // resolution: the frame only zooms its display.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
@@ -461,8 +461,9 @@ export default class LocalPreviewLauncher extends React.Component<
         // reload the game when the same preview is re-exported.
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation: `file://${outputDir}/index.html?previewId=${previewId}`,
-          // The game runs at the resolution of the project, like in a normal
-          // preview window: the frame only displays it scaled down.
+          // The frame shows the game zoomed out, in a game window that has
+          // the resolution of the project when the frame is opened, like a
+          // normal preview window.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -60,8 +60,28 @@ const clampPositionToWindow = (
   };
 };
 
-const defaultGameAreaSize = { width: 320, height: 180 };
+// The resolution assumed for the game before knowing the one of the project
+// (only used if the frame is shown without a preview being launched).
+const fallbackGameResolution = { width: 1280, height: 720 };
+
+// The game is displayed scaled down: the frame is a small floating window,
+// while the game itself keeps running at the resolution of the project.
+const defaultGameAreaWidth = 320;
 const minGameAreaSize = { width: 240, height: 135 };
+
+/**
+ * The default size of the game area: small enough to stay unobtrusive, with
+ * the aspect ratio of the game so that it is displayed without black bars.
+ */
+const getDefaultGameAreaSize = (gameResolution: Size): Size => ({
+  width: defaultGameAreaWidth,
+  height: Math.max(
+    minGameAreaSize.height,
+    Math.round(
+      (defaultGameAreaWidth * gameResolution.height) / gameResolution.width
+    )
+  ),
+});
 // Approximate height of the header, footer and borders around the game area,
 // used to clamp the restored size before the frame is rendered (the exact
 // size of these elements can only be measured once rendered).
@@ -94,6 +114,13 @@ type GameplayTestFrameLayoutProps = {|
   onToggleMinimized: () => void,
   onStopRequested: () => void,
   /**
+   * The resolution of the game: the game is always displayed at this size
+   * (scaled down to fit the frame), so that it runs exactly like in a normal
+   * preview window - moving or resizing the frame must not change anything
+   * for the game.
+   */
+  gameResolution: Size,
+  /**
    * The game itself (an iframe running the preview). It is always rendered,
    * even when minimized, so that the test keeps running.
    */
@@ -113,6 +140,7 @@ export const GameplayTestFrameLayout = ({
   isMinimized,
   onToggleMinimized,
   onStopRequested,
+  gameResolution,
   children,
 }: GameplayTestFrameLayoutProps): React.Node => {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
@@ -135,7 +163,7 @@ export const GameplayTestFrameLayout = ({
   // now smaller than when the size was saved.
   const [size, setSize] = React.useState<Size>(() => {
     const savedSize = values.gameplayTestFrameSize;
-    if (!savedSize) return defaultGameAreaSize;
+    if (!savedSize) return getDefaultGameAreaSize(gameResolution);
     return {
       width: clamp(
         savedSize.width,
@@ -441,7 +469,25 @@ export const GameplayTestFrameLayout = ({
           isMinimized ? undefined : { width: size.width, height: size.height }
         }
       >
-        {children}
+        {/* The game is kept at the resolution of the project and only scaled
+            down visually: it must never know that the frame is resized (it
+            would change its resolution, unlike in a normal preview window).
+            The scale is not changed when minimized either: the game area
+            simply clips the game, which keeps being rendered (and so the
+            test keeps running). */}
+        <div
+          className={classes.gameScaler}
+          style={{
+            width: gameResolution.width,
+            height: gameResolution.height,
+            transform: `translate(-50%, -50%) scale(${Math.min(
+              size.width / gameResolution.width,
+              size.height / gameResolution.height
+            )})`,
+          }}
+        >
+          {children}
+        </div>
       </div>
       <div className={classes.footer}>
         <GameplayTestStatusChip
@@ -467,11 +513,9 @@ export const GameplayTestFrameLayout = ({
           </Text>
         )}
       </div>
-      {/* Resizing while a test runs would change the game resolution and
-          skew tests based on screen positions: only allow it when no test
-          is in progress. */}
+      {/* Resizing only changes the scale at which the game is displayed:
+          it is safe to do it while a test is running. */}
       {!isMinimized &&
-        !isInProgress &&
         Object.keys(resizeHandleClasses).map(direction => (
           <div
             key={direction}
@@ -491,7 +535,10 @@ export const GameplayTestFrameLayout = ({
 
 let onSetGameplayTestFramePreviewLocation:
   | null
-  | ((previewIndexHtmlLocation: string) => void) = null;
+  | ((
+      previewIndexHtmlLocation: string,
+      gameResolution: Size | null
+    ) => void) = null;
 let onSetGameplayTestFrameRunStatus:
   | null
   | ((runStatus: GameplayTestFrameRunStatus | null) => void) = null;
@@ -503,12 +550,22 @@ let onSetGameplayTestFrameRunStatus:
  */
 export const setGameplayTestFramePreviewLocation = ({
   previewIndexHtmlLocation,
+  gameResolution,
 }: {|
   previewIndexHtmlLocation: string,
+  /**
+   * The resolution of the game being previewed: the game is run at this
+   * resolution, like in a normal preview window, whatever the size of
+   * the frame.
+   */
+  gameResolution: Size,
 |}) => {
   if (!onSetGameplayTestFramePreviewLocation)
     throw new Error('No GameplayTestFrame registered.');
-  onSetGameplayTestFramePreviewLocation(previewIndexHtmlLocation);
+  onSetGameplayTestFramePreviewLocation(
+    previewIndexHtmlLocation,
+    gameResolution
+  );
 };
 
 /**
@@ -516,7 +573,7 @@ export const setGameplayTestFramePreviewLocation = ({
  */
 export const clearGameplayTestFramePreview = () => {
   if (!onSetGameplayTestFramePreviewLocation) return;
-  onSetGameplayTestFramePreviewLocation('');
+  onSetGameplayTestFramePreviewLocation('', null);
 };
 
 /**
@@ -553,12 +610,17 @@ export const GameplayTestFrame = ({
     setRunStatus,
   ] = React.useState<GameplayTestFrameRunStatus | null>(null);
   const [isMinimized, setIsMinimized] = React.useState<boolean>(false);
+  const [gameResolution, setGameResolution] = React.useState<Size>(
+    fallbackGameResolution
+  );
 
   React.useEffect(() => {
     onSetGameplayTestFramePreviewLocation = (
-      newPreviewIndexHtmlLocation: string
+      newPreviewIndexHtmlLocation: string,
+      newGameResolution: Size | null
     ) => {
       setPreviewIndexHtmlLocation(newPreviewIndexHtmlLocation);
+      if (newGameResolution) setGameResolution(newGameResolution);
       setIsMinimized(false);
       // Don't show the status of a previous run when the frame is closed
       // then shown again.
@@ -604,6 +666,7 @@ export const GameplayTestFrame = ({
     <GameplayTestFrameLayout
       runStatus={runStatus}
       isMinimized={isMinimized}
+      gameResolution={gameResolution}
       onToggleMinimized={() => setIsMinimized(!isMinimized)}
       onStopRequested={() => {
         if (isInProgress) {

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -60,9 +60,6 @@ const clampPositionToWindow = (
   };
 };
 
-// Resolution assumed for the game before a preview is launched.
-const fallbackGameResolution = { width: 1280, height: 720 };
-
 // Game area width when the frame is opened: unobtrusive on top of the editor.
 const defaultGameAreaWidth = 320;
 const minGameAreaSize = { width: 240, height: 135 };
@@ -605,9 +602,8 @@ export const GameplayTestFrame = ({
     setRunStatus,
   ] = React.useState<GameplayTestFrameRunStatus | null>(null);
   const [isMinimized, setIsMinimized] = React.useState<boolean>(false);
-  const [gameResolution, setGameResolution] = React.useState<Size>(
-    fallbackGameResolution
-  );
+  // Set together with the preview location, by the launcher starting the game.
+  const [gameResolution, setGameResolution] = React.useState<Size | null>(null);
 
   React.useEffect(() => {
     onSetGameplayTestFramePreviewLocation = (
@@ -651,7 +647,7 @@ export const GameplayTestFrame = ({
     [previewDebuggerServer, previewIndexHtmlLocation]
   );
 
-  if (!previewIndexHtmlLocation) return null;
+  if (!previewIndexHtmlLocation || !gameResolution) return null;
 
   const isInProgress = runStatus
     ? isGameplayTestStatusInProgress(runStatus.status)

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -64,24 +64,44 @@ const clampPositionToWindow = (
 // (only used if the frame is shown without a preview being launched).
 const fallbackGameResolution = { width: 1280, height: 720 };
 
-// The game is displayed scaled down: the frame is a small floating window,
-// while the game itself keeps running at the resolution of the project.
+// Width of the game area when the frame is opened: small enough to stay
+// unobtrusive on top of the editor.
 const defaultGameAreaWidth = 320;
 const minGameAreaSize = { width: 240, height: 135 };
 
 /**
- * The default size of the game area: small enough to stay unobtrusive, with
- * the aspect ratio of the game so that it is displayed without black bars.
+ * The zoom at which the game is displayed in the frame. The frame is a real
+ * preview window, only zoomed out: the game window is always
+ * `game area size / zoom`, so that the game area shows exactly the game
+ * resolution when the frame has its default size.
+ *
+ * This zoom never changes while the frame is shown: resizing the frame
+ * resizes the game window (like resizing a preview window would - a game
+ * adapting to its window size shows it), but the scale at which the game is
+ * displayed stays the same.
  */
-const getDefaultGameAreaSize = (gameResolution: Size): Size => ({
-  width: defaultGameAreaWidth,
-  height: Math.max(
-    minGameAreaSize.height,
-    Math.round(
-      (defaultGameAreaWidth * gameResolution.height) / gameResolution.width
-    )
-  ),
-});
+const getGameZoomFactor = (gameResolution: Size): number =>
+  // Never zoom in on a game with a resolution smaller than the frame: it
+  // would be displayed blurry for no reason.
+  Math.min(1, defaultGameAreaWidth / gameResolution.width);
+
+/**
+ * The default size of the game area: the size at which the game window is
+ * exactly the game resolution, like a preview window when it is opened.
+ */
+const getDefaultGameAreaSize = (gameResolution: Size): Size => {
+  const zoomFactor = getGameZoomFactor(gameResolution);
+  return {
+    width: Math.max(
+      minGameAreaSize.width,
+      Math.round(gameResolution.width * zoomFactor)
+    ),
+    height: Math.max(
+      minGameAreaSize.height,
+      Math.round(gameResolution.height * zoomFactor)
+    ),
+  };
+};
 // Approximate height of the header, footer and borders around the game area,
 // used to clamp the restored size before the frame is rendered (the exact
 // size of these elements can only be measured once rendered).
@@ -114,10 +134,8 @@ type GameplayTestFrameLayoutProps = {|
   onToggleMinimized: () => void,
   onStopRequested: () => void,
   /**
-   * The resolution of the game: the game is always displayed at this size
-   * (scaled down to fit the frame), so that it runs exactly like in a normal
-   * preview window - moving or resizing the frame must not change anything
-   * for the game.
+   * The resolution of the game, used to choose the zoom at which it is
+   * displayed in the frame (see `getGameZoomFactor`).
    */
   gameResolution: Size,
   /**
@@ -150,6 +168,7 @@ export const GameplayTestFrameLayout = ({
     setGameplayTestFramePosition,
     setGameplayTestFrameSize,
   } = React.useContext(PreferencesContext);
+  const zoomFactor = getGameZoomFactor(gameResolution);
   // Restore the last position of the frame (it will be clamped to the window
   // as soon as it is rendered, in case the window is now smaller).
   const [position, setPosition] = React.useState<Position>(
@@ -469,21 +488,18 @@ export const GameplayTestFrameLayout = ({
           isMinimized ? undefined : { width: size.width, height: size.height }
         }
       >
-        {/* The game is kept at the resolution of the project and only scaled
-            down visually: it must never know that the frame is resized (it
-            would change its resolution, unlike in a normal preview window).
-            The scale is not changed when minimized either: the game area
-            simply clips the game, which keeps being rendered (and so the
-            test keeps running). */}
+        {/* The game window is the game area at 1:1 scale, only displayed
+            zoomed out: the game runs like in a preview window of this size,
+            so that a game adapting to its window size shows it. When
+            minimized, the game window is left untouched (the game area
+            simply clips it) so that the game keeps being rendered - and so
+            the test keeps running. */}
         <div
           className={classes.gameScaler}
           style={{
-            width: gameResolution.width,
-            height: gameResolution.height,
-            transform: `translate(-50%, -50%) scale(${Math.min(
-              size.width / gameResolution.width,
-              size.height / gameResolution.height
-            )})`,
+            width: Math.round(size.width / zoomFactor),
+            height: Math.round(size.height / zoomFactor),
+            transform: `translate(-50%, -50%) scale(${zoomFactor})`,
           }}
         >
           {children}
@@ -513,9 +529,12 @@ export const GameplayTestFrameLayout = ({
           </Text>
         )}
       </div>
-      {/* Resizing only changes the scale at which the game is displayed:
-          it is safe to do it while a test is running. */}
+      {/* Resizing resizes the game window, which would skew tests based on
+          screen positions (and, for a game adapting to its window size,
+          change its resolution mid-test): only allow it when no test is in
+          progress. */}
       {!isMinimized &&
+        !isInProgress &&
         Object.keys(resizeHandleClasses).map(direction => (
           <div
             key={direction}
@@ -554,9 +573,9 @@ export const setGameplayTestFramePreviewLocation = ({
 }: {|
   previewIndexHtmlLocation: string,
   /**
-   * The resolution of the game being previewed: the game is run at this
-   * resolution, like in a normal preview window, whatever the size of
-   * the frame.
+   * The resolution of the game being previewed: the frame is sized so that
+   * the game window is exactly this size when it is opened, like a normal
+   * preview window (see `getGameZoomFactor`).
    */
   gameResolution: Size,
 |}) => {

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -65,62 +65,77 @@ const clampPositionToWindow = (
 
 // Game area width when the frame is opened: unobtrusive on top of the editor.
 const defaultGameAreaWidth = 320;
+// Below this, the header and footer of the frame become unusable.
 const minGameAreaSize = { width: 240, height: 135 };
 
-/**
- * The fixed zoom at which the game is displayed: the game window is always
- * `game area size / zoom`. Resizing the frame resizes the game window (like
- * resizing a preview window would), never the scale.
+/*
+ * The game window (the iframe running the preview) is always exactly the
+ * game resolution: the game runs as in a preview window of this size and
+ * can never observe the frame being moved, resized or minimized. The frame
+ * only displays it at a variable zoom - the only thing resizing changes.
+ * The aspect ratio of the game area is thus always the game one.
  */
-const getGameZoomFactor = (gameResolution: Size): number =>
-  // Never zoom in: a small game would only be displayed blurry.
-  Math.min(1, defaultGameAreaWidth / gameResolution.width);
 
-/** Game area size at which the game window is exactly the game resolution. */
-const getDefaultGameAreaSize = (gameResolution: Size): Size => {
-  const zoomFactor = getGameZoomFactor(gameResolution);
-  return {
-    width: Math.max(
-      minGameAreaSize.width,
-      Math.round(gameResolution.width * zoomFactor)
-    ),
-    height: Math.max(
-      minGameAreaSize.height,
-      Math.round(gameResolution.height * zoomFactor)
-    ),
-  };
-};
+/** The smallest zoom keeping the frame usable. */
+const getMinZoomFactor = (gameResolution: Size): number =>
+  Math.max(
+    minGameAreaSize.width / gameResolution.width,
+    minGameAreaSize.height / gameResolution.height
+  );
+
+/**
+ * The largest allowed zoom: 1 (a game displayed larger than its resolution
+ * would only be blurry), unless more is needed to reach the minimum frame
+ * size (for games with a tiny resolution).
+ */
+const getMaxZoomFactor = (gameResolution: Size): number =>
+  Math.max(1, getMinZoomFactor(gameResolution));
+
+/** The zoom used when the frame is opened for the first time. */
+const getDefaultZoomFactor = (gameResolution: Size): number =>
+  clamp(
+    defaultGameAreaWidth / gameResolution.width,
+    getMinZoomFactor(gameResolution),
+    getMaxZoomFactor(gameResolution)
+  );
+
+/** The size of the game area: the game resolution, displayed at this zoom. */
+const getGameAreaSize = (gameResolution: Size, zoomFactor: number): Size => ({
+  width: Math.round(gameResolution.width * zoomFactor),
+  height: Math.round(gameResolution.height * zoomFactor),
+});
+
 // Approximate height of the chrome around the game area, to clamp the
-// restored size before the frame is rendered (and can be measured).
+// restored zoom before the frame is rendered (and can be measured).
 const approximateFrameChromeHeight = 70;
 
 /**
- * Clamp the game area size so the frame fits in the window.
- * `chromeWidth`/`chromeHeight` are the size of the borders, header and
- * footer around the game area.
+ * Clamp the zoom so the frame fits in the window - unless even the minimum
+ * usable size does not (`clampPositionToWindow` then keeps the frame
+ * reachable). `chromeWidth`/`chromeHeight` are the size of the borders,
+ * header and footer around the game area.
  */
-const clampSizeToWindow = (
-  size: Size,
+const clampZoomFactorToWindow = (
+  zoomFactor: number,
+  gameResolution: Size,
   chromeWidth: number,
   chromeHeight: number
-): Size => ({
-  width: clamp(
-    size.width,
-    minGameAreaSize.width,
+): number => {
+  const fittingZoomFactor = Math.min(
+    (window.innerWidth - 2 * windowMargin - chromeWidth) / gameResolution.width,
+    (window.innerHeight - windowMargin - windowTopMargin - chromeHeight) /
+      gameResolution.height
+  );
+  const minZoomFactor = getMinZoomFactor(gameResolution);
+  return clamp(
+    zoomFactor,
+    minZoomFactor,
     Math.max(
-      minGameAreaSize.width,
-      window.innerWidth - 2 * windowMargin - chromeWidth
+      minZoomFactor,
+      Math.min(getMaxZoomFactor(gameResolution), fittingZoomFactor)
     )
-  ),
-  height: clamp(
-    size.height,
-    minGameAreaSize.height,
-    Math.max(
-      minGameAreaSize.height,
-      window.innerHeight - windowMargin - windowTopMargin - chromeHeight
-    )
-  ),
-});
+  );
+};
 
 type ResizeDirection =
   | 'left'
@@ -151,7 +166,10 @@ type GameplayTestFrameLayoutProps = {|
   isMinimized: boolean,
   onToggleMinimized: () => void,
   onStopRequested: () => void,
-  /** The game resolution, giving the display zoom (see `getGameZoomFactor`). */
+  /**
+   * The game resolution: the game window is fixed at exactly this size,
+   * the frame only displays it zoomed.
+   */
   gameResolution: Size,
   /**
    * The game itself (an iframe running the preview). It is always rendered,
@@ -181,9 +199,8 @@ export const GameplayTestFrameLayout = ({
   const {
     values,
     setGameplayTestFramePosition,
-    setGameplayTestFrameSize,
+    setGameplayTestFrameZoomFactor,
   } = React.useContext(PreferencesContext);
-  const zoomFactor = getGameZoomFactor(gameResolution);
   // Restore the last position of the frame (it will be clamped to the window
   // as soon as it is rendered, in case the window is now smaller).
   const [position, setPosition] = React.useState<Position>(
@@ -193,12 +210,17 @@ export const GameplayTestFrameLayout = ({
         bottom: windowMargin,
       }
   );
-  // Restore the last size, clamped in case the window is now smaller.
-  const [size, setSize] = React.useState<Size>(() => {
-    const savedSize = values.gameplayTestFrameSize;
-    if (!savedSize) return getDefaultGameAreaSize(gameResolution);
-    return clampSizeToWindow(savedSize, 0, approximateFrameChromeHeight);
-  });
+  // Restore the last zoom, clamped in case the window is now smaller (or
+  // this project has a larger game resolution).
+  const [zoomFactor, setZoomFactor] = React.useState<number>(() =>
+    clampZoomFactorToWindow(
+      values.gameplayTestFrameZoomFactor ||
+        getDefaultZoomFactor(gameResolution),
+      gameResolution,
+      0,
+      approximateFrameChromeHeight
+    )
+  );
   const [isDragging, setIsDragging] = React.useState<boolean>(false);
   const [isResizing, setIsResizing] = React.useState<boolean>(false);
   const dragOrigin = React.useRef<{|
@@ -212,6 +234,7 @@ export const GameplayTestFrameLayout = ({
     clientX: number,
     clientY: number,
     position: Position,
+    zoomFactor: number,
     size: Size,
     direction: ResizeDirection,
     /** Size of the chrome (borders, header, footer) around the game area. */
@@ -219,10 +242,9 @@ export const GameplayTestFrameLayout = ({
     chromeHeight: number,
   |} | null>(null);
 
-  // Keep the frame inside the window: shrink the game area if the window
-  // got too small for the frame (not when minimized: the game area is then
-  // 1x1 and the chrome around it can't be measured), then clamp the
-  // position.
+  // Keep the frame inside the window: zoom out if the window got too small
+  // for the frame (not when minimized: the game area is then 1x1 and the
+  // chrome around it can't be measured), then clamp the position.
   const keepFrameInsideWindow = React.useCallback(
     () => {
       const container = containerRef.current;
@@ -230,9 +252,10 @@ export const GameplayTestFrameLayout = ({
       if (!isMinimized && container && gameArea) {
         const containerRect = container.getBoundingClientRect();
         const gameAreaRect = gameArea.getBoundingClientRect();
-        setSize(size =>
-          clampSizeToWindow(
-            size,
+        setZoomFactor(zoomFactor =>
+          clampZoomFactorToWindow(
+            zoomFactor,
+            gameResolution,
             containerRect.width - gameAreaRect.width,
             containerRect.height - gameAreaRect.height
           )
@@ -240,7 +263,7 @@ export const GameplayTestFrameLayout = ({
       }
       setPosition(position => clampPositionToWindow(position, container));
     },
-    [isMinimized]
+    [isMinimized, gameResolution]
   );
 
   // Apply it when the window is resized, and when the frame is first
@@ -317,7 +340,8 @@ export const GameplayTestFrameLayout = ({
         clientX: event.clientX,
         clientY: event.clientY,
         position,
-        size,
+        zoomFactor,
+        size: getGameAreaSize(gameResolution, zoomFactor),
         direction,
         chromeWidth: containerRect.width - gameAreaRect.width,
         chromeHeight: containerRect.height - gameAreaRect.height,
@@ -326,69 +350,85 @@ export const GameplayTestFrameLayout = ({
       currentTarget.setPointerCapture(event.pointerId);
       setIsResizing(true);
     },
-    [position, size]
+    [position, zoomFactor, gameResolution]
   );
 
-  const onResizePointerMove = React.useCallback((event: PointerEvent) => {
-    const origin = resizeOrigin.current;
-    if (!origin || origin.pointerId !== event.pointerId) return;
+  const onResizePointerMove = React.useCallback(
+    (event: PointerEvent) => {
+      const origin = resizeOrigin.current;
+      if (!origin || origin.pointerId !== event.pointerId) return;
 
-    const deltaX = event.clientX - origin.clientX;
-    const deltaY = event.clientY - origin.clientY;
-    const newSize = { ...origin.size };
-    const newPosition = { ...origin.position };
+      // The aspect ratio is fixed (it is the game one): resizing only
+      // changes the zoom. Moving the pointer outwards zooms in.
+      const deltaX = event.clientX - origin.clientX;
+      const deltaY = event.clientY - origin.clientY;
+      const widthDelta = origin.direction.includes('left')
+        ? -deltaX
+        : origin.direction.includes('right')
+        ? deltaX
+        : 0;
+      const heightDelta = origin.direction.includes('top')
+        ? -deltaY
+        : origin.direction.includes('bottom')
+        ? deltaY
+        : 0;
+      const zoomFactorFromWidth =
+        origin.zoomFactor + widthDelta / gameResolution.width;
+      const zoomFactorFromHeight =
+        origin.zoomFactor + heightDelta / gameResolution.height;
+      // On corners, follow the axis on which the pointer moved the most.
+      const newZoomFactor =
+        Math.abs(zoomFactorFromWidth - origin.zoomFactor) >=
+        Math.abs(zoomFactorFromHeight - origin.zoomFactor)
+          ? zoomFactorFromWidth
+          : zoomFactorFromHeight;
 
-    if (origin.direction.includes('right')) {
-      // The left border stays in place: only the width changes.
-      const maxWidth =
-        window.innerWidth -
-        windowMargin -
-        origin.position.left -
-        origin.chromeWidth;
-      newSize.width = clamp(
-        origin.size.width + deltaX,
-        minGameAreaSize.width,
-        Math.max(minGameAreaSize.width, maxWidth)
+      // The window space available for the two moving edges to grow into
+      // (the two others are anchored and stay in place).
+      const maxWidth = origin.direction.includes('left')
+        ? origin.size.width + origin.position.left - windowMargin
+        : window.innerWidth -
+          windowMargin -
+          origin.position.left -
+          origin.chromeWidth;
+      const maxHeight = origin.direction.includes('bottom')
+        ? origin.size.height + origin.position.bottom - windowMargin
+        : window.innerHeight -
+          windowTopMargin -
+          origin.position.bottom -
+          origin.chromeHeight;
+      const minZoomFactor = getMinZoomFactor(gameResolution);
+      const clampedZoomFactor = clamp(
+        newZoomFactor,
+        minZoomFactor,
+        Math.max(
+          minZoomFactor,
+          Math.min(
+            getMaxZoomFactor(gameResolution),
+            maxWidth / gameResolution.width,
+            maxHeight / gameResolution.height
+          )
+        )
       );
-    } else if (origin.direction.includes('left')) {
-      // The right border stays in place: the frame moves as it grows.
-      const maxWidth = origin.size.width + origin.position.left - windowMargin;
-      newSize.width = clamp(
-        origin.size.width - deltaX,
-        minGameAreaSize.width,
-        Math.max(minGameAreaSize.width, maxWidth)
-      );
-      newPosition.left =
-        origin.position.left + (origin.size.width - newSize.width);
-    }
-    if (origin.direction.includes('top')) {
-      // Anchored to the window bottom: the frame grows upwards without moving.
-      const maxHeight =
-        window.innerHeight -
-        windowTopMargin -
-        origin.position.bottom -
-        origin.chromeHeight;
-      newSize.height = clamp(
-        origin.size.height - deltaY,
-        minGameAreaSize.height,
-        Math.max(minGameAreaSize.height, maxHeight)
-      );
-    } else if (origin.direction.includes('bottom')) {
-      // The top border stays in place: the frame moves down as it grows.
-      const maxHeight =
-        origin.size.height + origin.position.bottom - windowMargin;
-      newSize.height = clamp(
-        origin.size.height + deltaY,
-        minGameAreaSize.height,
-        Math.max(minGameAreaSize.height, maxHeight)
-      );
-      newPosition.bottom =
-        origin.position.bottom - (newSize.height - origin.size.height);
-    }
 
-    setSize(newSize);
-    setPosition(newPosition);
-  }, []);
+      // Keep the anchored edges in place: growing from the left moves the
+      // frame left, growing from the bottom moves it down.
+      const newSize = getGameAreaSize(gameResolution, clampedZoomFactor);
+      const newPosition = { ...origin.position };
+      if (origin.direction.includes('left')) {
+        newPosition.left =
+          origin.position.left + (origin.size.width - newSize.width);
+      }
+      if (origin.direction.includes('bottom')) {
+        newPosition.bottom =
+          origin.position.bottom - (newSize.height - origin.size.height);
+      }
+
+      setZoomFactor(clampedZoomFactor);
+      setPosition(newPosition);
+    },
+    [gameResolution]
+  );
 
   const onResizePointerUp = React.useCallback(
     (event: PointerEvent) => {
@@ -397,27 +437,23 @@ export const GameplayTestFrameLayout = ({
 
       resizeOrigin.current = null;
       setIsResizing(false);
-      setGameplayTestFrameSize(size);
+      setGameplayTestFrameZoomFactor(zoomFactor);
       // Resizing from the left or bottom edges also moves the frame.
       setGameplayTestFramePosition(position);
     },
-    [size, setGameplayTestFrameSize, position, setGameplayTestFramePosition]
+    [
+      zoomFactor,
+      setGameplayTestFrameZoomFactor,
+      position,
+      setGameplayTestFramePosition,
+    ]
   );
 
   const isInProgress = runStatus
     ? isGameplayTestStatusInProgress(runStatus.status)
     : false;
 
-  // Cancel any resize in progress when a test starts.
-  React.useEffect(
-    () => {
-      if (isInProgress) {
-        resizeOrigin.current = null;
-        setIsResizing(false);
-      }
-    },
-    [isInProgress]
-  );
+  const gameAreaSize = getGameAreaSize(gameResolution, zoomFactor);
 
   return (
     <div
@@ -498,18 +534,23 @@ export const GameplayTestFrameLayout = ({
         })}
         style={
           // When minimized, let the CSS shrink the game area to 1x1 pixel.
-          isMinimized ? undefined : { width: size.width, height: size.height }
+          isMinimized
+            ? undefined
+            : { width: gameAreaSize.width, height: gameAreaSize.height }
         }
       >
-        {/* The game window: the game area at 1:1 scale, displayed zoomed
-            out - the game runs like in a preview window of this size. When
-            minimized it is only clipped, so the game keeps rendering and
-            the test keeps running. */}
+        {/* The game window: always exactly the game resolution, only its
+            displayed zoom changes - the game runs as in a preview window of
+            this size and cannot observe the frame being moved, resized or
+            minimized (minimizing only clips it, so the game keeps rendering
+            and the test keeps running). Only the test itself can change the
+            game resolution (see `setGameResolutionSize` in the harness):
+            the game is then displayed fitted in this same window. */}
         <div
           className={classes.gameScaler}
           style={{
-            width: Math.round(size.width / zoomFactor),
-            height: Math.round(size.height / zoomFactor),
+            width: gameResolution.width,
+            height: gameResolution.height,
             transform: `translate(-50%, -50%) scale(${zoomFactor})`,
           }}
         >
@@ -540,10 +581,10 @@ export const GameplayTestFrameLayout = ({
           </Text>
         )}
       </div>
-      {/* Resizing resizes the game window, which would skew a running
-          test: only allow it when no test is in progress. */}
+      {/* Resizing only changes the zoom at which the game is displayed:
+          the game cannot observe it, so it is harmless even while a test
+          is running. */}
       {!isMinimized &&
-        !isInProgress &&
         resizeHandles.map(({ direction, className }) => (
           <div
             key={direction}
@@ -579,8 +620,8 @@ export const setGameplayTestFramePreviewLocation = ({
 }: {|
   previewIndexHtmlLocation: string,
   /**
-   * The game resolution: the frame opens with the game window at exactly
-   * this size (see `getGameZoomFactor`).
+   * The game resolution: the game window is fixed at exactly this size,
+   * the frame only displays it zoomed.
    */
   gameResolution: Size,
 |}) => {

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -60,35 +60,23 @@ const clampPositionToWindow = (
   };
 };
 
-// The resolution assumed for the game before knowing the one of the project
-// (only used if the frame is shown without a preview being launched).
+// Resolution assumed for the game before a preview is launched.
 const fallbackGameResolution = { width: 1280, height: 720 };
 
-// Width of the game area when the frame is opened: small enough to stay
-// unobtrusive on top of the editor.
+// Game area width when the frame is opened: unobtrusive on top of the editor.
 const defaultGameAreaWidth = 320;
 const minGameAreaSize = { width: 240, height: 135 };
 
 /**
- * The zoom at which the game is displayed in the frame. The frame is a real
- * preview window, only zoomed out: the game window is always
- * `game area size / zoom`, so that the game area shows exactly the game
- * resolution when the frame has its default size.
- *
- * This zoom never changes while the frame is shown: resizing the frame
- * resizes the game window (like resizing a preview window would - a game
- * adapting to its window size shows it), but the scale at which the game is
- * displayed stays the same.
+ * The fixed zoom at which the game is displayed: the game window is always
+ * `game area size / zoom`. Resizing the frame resizes the game window (like
+ * resizing a preview window would), never the scale.
  */
 const getGameZoomFactor = (gameResolution: Size): number =>
-  // Never zoom in on a game with a resolution smaller than the frame: it
-  // would be displayed blurry for no reason.
+  // Never zoom in: a small game would only be displayed blurry.
   Math.min(1, defaultGameAreaWidth / gameResolution.width);
 
-/**
- * The default size of the game area: the size at which the game window is
- * exactly the game resolution, like a preview window when it is opened.
- */
+/** Game area size at which the game window is exactly the game resolution. */
 const getDefaultGameAreaSize = (gameResolution: Size): Size => {
   const zoomFactor = getGameZoomFactor(gameResolution);
   return {
@@ -102,9 +90,8 @@ const getDefaultGameAreaSize = (gameResolution: Size): Size => {
     ),
   };
 };
-// Approximate height of the header, footer and borders around the game area,
-// used to clamp the restored size before the frame is rendered (the exact
-// size of these elements can only be measured once rendered).
+// Approximate height of the chrome around the game area, to clamp the
+// restored size before the frame is rendered (and can be measured).
 const approximateFrameChromeHeight = 70;
 
 type ResizeDirection =
@@ -136,10 +123,7 @@ type GameplayTestFrameLayoutProps = {|
   isMinimized: boolean,
   onToggleMinimized: () => void,
   onStopRequested: () => void,
-  /**
-   * The resolution of the game, used to choose the zoom at which it is
-   * displayed in the frame (see `getGameZoomFactor`).
-   */
+  /** The game resolution, giving the display zoom (see `getGameZoomFactor`). */
   gameResolution: Size,
   /**
    * The game itself (an iframe running the preview). It is always rendered,
@@ -181,8 +165,7 @@ export const GameplayTestFrameLayout = ({
         bottom: windowMargin,
       }
   );
-  // Restore the last size of the game area, clamped in case the window is
-  // now smaller than when the size was saved.
+  // Restore the last size, clamped in case the window is now smaller.
   const [size, setSize] = React.useState<Size>(() => {
     const savedSize = values.gameplayTestFrameSize;
     if (!savedSize) return getDefaultGameAreaSize(gameResolution);
@@ -217,7 +200,7 @@ export const GameplayTestFrameLayout = ({
     position: Position,
     size: Size,
     direction: ResizeDirection,
-    /** Size taken by the borders, header and footer around the game area. */
+    /** Size of the chrome (borders, header, footer) around the game area. */
     chromeWidth: number,
     chromeHeight: number,
   |} | null>(null);
@@ -350,8 +333,7 @@ export const GameplayTestFrameLayout = ({
         origin.position.left + (origin.size.width - newSize.width);
     }
     if (origin.direction.includes('top')) {
-      // The frame is anchored to the bottom of the window: it grows upwards
-      // without moving.
+      // Anchored to the window bottom: the frame grows upwards without moving.
       const maxHeight =
         window.innerHeight -
         windowMargin -
@@ -397,8 +379,7 @@ export const GameplayTestFrameLayout = ({
     ? isGameplayTestStatusInProgress(runStatus.status)
     : false;
 
-  // Cancel any resize in progress when a test starts (the handles are
-  // removed, so the pointer capture is lost anyway).
+  // Cancel any resize in progress when a test starts.
   React.useEffect(
     () => {
       if (isInProgress) {
@@ -491,11 +472,9 @@ export const GameplayTestFrameLayout = ({
           isMinimized ? undefined : { width: size.width, height: size.height }
         }
       >
-        {/* The game window is the game area at 1:1 scale, only displayed
-            zoomed out: the game runs like in a preview window of this size,
-            so that a game adapting to its window size shows it. When
-            minimized, the game window is left untouched (the game area
-            simply clips it) so that the game keeps being rendered - and so
+        {/* The game window: the game area at 1:1 scale, displayed zoomed
+            out - the game runs like in a preview window of this size. When
+            minimized it is only clipped, so the game keeps rendering and
             the test keeps running. */}
         <div
           className={classes.gameScaler}
@@ -532,10 +511,8 @@ export const GameplayTestFrameLayout = ({
           </Text>
         )}
       </div>
-      {/* Resizing resizes the game window, which would skew tests based on
-          screen positions (and, for a game adapting to its window size,
-          change its resolution mid-test): only allow it when no test is in
-          progress. */}
+      {/* Resizing resizes the game window, which would skew a running
+          test: only allow it when no test is in progress. */}
       {!isMinimized &&
         !isInProgress &&
         resizeHandles.map(({ direction, className }) => (
@@ -573,9 +550,8 @@ export const setGameplayTestFramePreviewLocation = ({
 }: {|
   previewIndexHtmlLocation: string,
   /**
-   * The resolution of the game being previewed: the frame is sized so that
-   * the game window is exactly this size when it is opened, like a normal
-   * preview window (see `getGameZoomFactor`).
+   * The game resolution: the frame opens with the game window at exactly
+   * this size (see `getGameZoomFactor`).
    */
   gameResolution: Size,
 |}) => {

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -38,6 +38,7 @@ const clamp = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(max, value));
 
 type Position = {| left: number, bottom: number |};
+type Size = {| width: number, height: number |};
 
 const clampPositionToWindow = (
   position: Position,
@@ -57,6 +58,34 @@ const clampPositionToWindow = (
       Math.max(windowMargin, window.innerHeight - height - windowMargin)
     ),
   };
+};
+
+const defaultGameAreaSize = { width: 320, height: 180 };
+const minGameAreaSize = { width: 240, height: 135 };
+// Approximate height of the header, footer and borders around the game area,
+// used to clamp the restored size before the frame is rendered (the exact
+// size of these elements can only be measured once rendered).
+const approximateFrameChromeHeight = 70;
+
+type ResizeDirection =
+  | 'left'
+  | 'right'
+  | 'top'
+  | 'bottom'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right';
+
+const resizeHandleClasses: { [ResizeDirection]: string } = {
+  left: classes.resizeLeft,
+  right: classes.resizeRight,
+  top: classes.resizeTop,
+  bottom: classes.resizeBottom,
+  'top-left': classes.resizeTopLeft,
+  'top-right': classes.resizeTopRight,
+  'bottom-left': classes.resizeBottomLeft,
+  'bottom-right': classes.resizeBottomRight,
 };
 
 type GameplayTestFrameLayoutProps = {|
@@ -87,9 +116,12 @@ export const GameplayTestFrameLayout = ({
   children,
 }: GameplayTestFrameLayoutProps): React.Node => {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
-  const { values, setGameplayTestFramePosition } = React.useContext(
-    PreferencesContext
-  );
+  const gameAreaRef = React.useRef<HTMLDivElement | null>(null);
+  const {
+    values,
+    setGameplayTestFramePosition,
+    setGameplayTestFrameSize,
+  } = React.useContext(PreferencesContext);
   // Restore the last position of the frame (it will be clamped to the window
   // as soon as it is rendered, in case the window is now smaller).
   const [position, setPosition] = React.useState<Position>(
@@ -99,12 +131,45 @@ export const GameplayTestFrameLayout = ({
         bottom: windowMargin,
       }
   );
+  // Restore the last size of the game area, clamped in case the window is
+  // now smaller than when the size was saved.
+  const [size, setSize] = React.useState<Size>(() => {
+    const savedSize = values.gameplayTestFrameSize;
+    if (!savedSize) return defaultGameAreaSize;
+    return {
+      width: clamp(
+        savedSize.width,
+        minGameAreaSize.width,
+        Math.max(minGameAreaSize.width, window.innerWidth - 2 * windowMargin)
+      ),
+      height: clamp(
+        savedSize.height,
+        minGameAreaSize.height,
+        Math.max(
+          minGameAreaSize.height,
+          window.innerHeight - 2 * windowMargin - approximateFrameChromeHeight
+        )
+      ),
+    };
+  });
   const [isDragging, setIsDragging] = React.useState<boolean>(false);
+  const [isResizing, setIsResizing] = React.useState<boolean>(false);
   const dragOrigin = React.useRef<{|
     pointerId: number,
     clientX: number,
     clientY: number,
     position: Position,
+  |} | null>(null);
+  const resizeOrigin = React.useRef<{|
+    pointerId: number,
+    clientX: number,
+    clientY: number,
+    position: Position,
+    size: Size,
+    direction: ResizeDirection,
+    /** Size taken by the borders, header and footer around the game area. */
+    chromeWidth: number,
+    chromeHeight: number,
   |} | null>(null);
 
   // Keep the frame inside the window when it is resized (or when the frame
@@ -174,9 +239,125 @@ export const GameplayTestFrameLayout = ({
     [position, setGameplayTestFramePosition]
   );
 
+  const onResizePointerDown = React.useCallback(
+    (direction: ResizeDirection, event: PointerEvent) => {
+      if (event.button !== 0) return;
+      const currentTarget = event.currentTarget;
+      if (!(currentTarget instanceof HTMLElement)) return;
+      const container = containerRef.current;
+      const gameArea = gameAreaRef.current;
+      if (!container || !gameArea) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const gameAreaRect = gameArea.getBoundingClientRect();
+      resizeOrigin.current = {
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        position,
+        size,
+        direction,
+        chromeWidth: containerRect.width - gameAreaRect.width,
+        chromeHeight: containerRect.height - gameAreaRect.height,
+      };
+      // $FlowFixMe[incompatible-type] - the Flow definition of `setPointerCapture` wrongly takes a string.
+      currentTarget.setPointerCapture(event.pointerId);
+      setIsResizing(true);
+    },
+    [position, size]
+  );
+
+  const onResizePointerMove = React.useCallback((event: PointerEvent) => {
+    const origin = resizeOrigin.current;
+    if (!origin || origin.pointerId !== event.pointerId) return;
+
+    const deltaX = event.clientX - origin.clientX;
+    const deltaY = event.clientY - origin.clientY;
+    const newSize = { ...origin.size };
+    const newPosition = { ...origin.position };
+
+    if (origin.direction.includes('right')) {
+      // The left border stays in place: only the width changes.
+      const maxWidth =
+        window.innerWidth -
+        windowMargin -
+        origin.position.left -
+        origin.chromeWidth;
+      newSize.width = clamp(
+        origin.size.width + deltaX,
+        minGameAreaSize.width,
+        Math.max(minGameAreaSize.width, maxWidth)
+      );
+    } else if (origin.direction.includes('left')) {
+      // The right border stays in place: the frame moves as it grows.
+      const maxWidth = origin.size.width + origin.position.left - windowMargin;
+      newSize.width = clamp(
+        origin.size.width - deltaX,
+        minGameAreaSize.width,
+        Math.max(minGameAreaSize.width, maxWidth)
+      );
+      newPosition.left =
+        origin.position.left + (origin.size.width - newSize.width);
+    }
+    if (origin.direction.includes('top')) {
+      // The frame is anchored to the bottom of the window: it grows upwards
+      // without moving.
+      const maxHeight =
+        window.innerHeight -
+        windowMargin -
+        origin.position.bottom -
+        origin.chromeHeight;
+      newSize.height = clamp(
+        origin.size.height - deltaY,
+        minGameAreaSize.height,
+        Math.max(minGameAreaSize.height, maxHeight)
+      );
+    } else if (origin.direction.includes('bottom')) {
+      // The top border stays in place: the frame moves down as it grows.
+      const maxHeight =
+        origin.size.height + origin.position.bottom - windowMargin;
+      newSize.height = clamp(
+        origin.size.height + deltaY,
+        minGameAreaSize.height,
+        Math.max(minGameAreaSize.height, maxHeight)
+      );
+      newPosition.bottom =
+        origin.position.bottom - (newSize.height - origin.size.height);
+    }
+
+    setSize(newSize);
+    setPosition(newPosition);
+  }, []);
+
+  const onResizePointerUp = React.useCallback(
+    (event: PointerEvent) => {
+      const origin = resizeOrigin.current;
+      if (!origin || origin.pointerId !== event.pointerId) return;
+
+      resizeOrigin.current = null;
+      setIsResizing(false);
+      setGameplayTestFrameSize(size);
+      // Resizing from the left or bottom edges also moves the frame.
+      setGameplayTestFramePosition(position);
+    },
+    [size, setGameplayTestFrameSize, position, setGameplayTestFramePosition]
+  );
+
   const isInProgress = runStatus
     ? isGameplayTestStatusInProgress(runStatus.status)
     : false;
+
+  // Cancel any resize in progress when a test starts (the handles are
+  // removed, so the pointer capture is lost anyway).
+  React.useEffect(
+    () => {
+      if (isInProgress) {
+        resizeOrigin.current = null;
+        setIsResizing(false);
+      }
+    },
+    [isInProgress]
+  );
 
   return (
     <div
@@ -185,6 +366,7 @@ export const GameplayTestFrameLayout = ({
         [classes.container]: true,
         [classes.minimized]: isMinimized,
         [classes.dragging]: isDragging,
+        [classes.resizing]: isResizing,
       })}
       style={{ left: position.left, bottom: position.bottom }}
     >
@@ -249,10 +431,15 @@ export const GameplayTestFrameLayout = ({
         </div>
       </div>
       <div
+        ref={gameAreaRef}
         className={classNames({
           [classes.gameArea]: true,
           [classes.hiddenGameArea]: isMinimized,
         })}
+        style={
+          // When minimized, let the CSS shrink the game area to 1x1 pixel.
+          isMinimized ? undefined : { width: size.width, height: size.height }
+        }
       >
         {children}
       </div>
@@ -280,6 +467,24 @@ export const GameplayTestFrameLayout = ({
           </Text>
         )}
       </div>
+      {/* Resizing while a test runs would change the game resolution and
+          skew tests based on screen positions: only allow it when no test
+          is in progress. */}
+      {!isMinimized &&
+        !isInProgress &&
+        Object.keys(resizeHandleClasses).map(direction => (
+          <div
+            key={direction}
+            className={classNames(
+              classes.resizeHandle,
+              resizeHandleClasses[direction]
+            )}
+            onPointerDown={event => onResizePointerDown(direction, event)}
+            onPointerMove={onResizePointerMove}
+            onPointerUp={onResizePointerUp}
+            onPointerCancel={onResizePointerUp}
+          />
+        ))}
     </div>
   );
 };

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -117,16 +117,19 @@ type ResizeDirection =
   | 'bottom-left'
   | 'bottom-right';
 
-const resizeHandleClasses: { [ResizeDirection]: string } = {
-  left: classes.resizeLeft,
-  right: classes.resizeRight,
-  top: classes.resizeTop,
-  bottom: classes.resizeBottom,
-  'top-left': classes.resizeTopLeft,
-  'top-right': classes.resizeTopRight,
-  'bottom-left': classes.resizeBottomLeft,
-  'bottom-right': classes.resizeBottomRight,
-};
+const resizeHandles: Array<{|
+  direction: ResizeDirection,
+  className: string,
+|}> = [
+  { direction: 'left', className: classes.resizeLeft },
+  { direction: 'right', className: classes.resizeRight },
+  { direction: 'top', className: classes.resizeTop },
+  { direction: 'bottom', className: classes.resizeBottom },
+  { direction: 'top-left', className: classes.resizeTopLeft },
+  { direction: 'top-right', className: classes.resizeTopRight },
+  { direction: 'bottom-left', className: classes.resizeBottomLeft },
+  { direction: 'bottom-right', className: classes.resizeBottomRight },
+];
 
 type GameplayTestFrameLayoutProps = {|
   runStatus: GameplayTestFrameRunStatus | null,
@@ -535,13 +538,10 @@ export const GameplayTestFrameLayout = ({
           progress. */}
       {!isMinimized &&
         !isInProgress &&
-        Object.keys(resizeHandleClasses).map(direction => (
+        resizeHandles.map(({ direction, className }) => (
           <div
             key={direction}
-            className={classNames(
-              classes.resizeHandle,
-              resizeHandleClasses[direction]
-            )}
+            className={classNames(classes.resizeHandle, className)}
             onPointerDown={event => onResizePointerDown(direction, event)}
             onPointerMove={onResizePointerMove}
             onPointerUp={onResizePointerUp}

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -33,6 +33,9 @@ export type GameplayTestFrameRunStatus = {|
 
 // Distance kept between the frame and the borders of the window.
 const windowMargin = 12;
+// Larger at the top, to keep what is displayed there (like the tabs of the
+// editor) reachable.
+const windowTopMargin = windowMargin * 3;
 
 const clamp = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(max, value));
@@ -55,7 +58,7 @@ const clampPositionToWindow = (
     bottom: clamp(
       position.bottom,
       windowMargin,
-      Math.max(windowMargin, window.innerHeight - height - windowMargin)
+      Math.max(windowMargin, window.innerHeight - height - windowTopMargin)
     ),
   };
 };
@@ -90,6 +93,34 @@ const getDefaultGameAreaSize = (gameResolution: Size): Size => {
 // Approximate height of the chrome around the game area, to clamp the
 // restored size before the frame is rendered (and can be measured).
 const approximateFrameChromeHeight = 70;
+
+/**
+ * Clamp the game area size so the frame fits in the window.
+ * `chromeWidth`/`chromeHeight` are the size of the borders, header and
+ * footer around the game area.
+ */
+const clampSizeToWindow = (
+  size: Size,
+  chromeWidth: number,
+  chromeHeight: number
+): Size => ({
+  width: clamp(
+    size.width,
+    minGameAreaSize.width,
+    Math.max(
+      minGameAreaSize.width,
+      window.innerWidth - 2 * windowMargin - chromeWidth
+    )
+  ),
+  height: clamp(
+    size.height,
+    minGameAreaSize.height,
+    Math.max(
+      minGameAreaSize.height,
+      window.innerHeight - windowMargin - windowTopMargin - chromeHeight
+    )
+  ),
+});
 
 type ResizeDirection =
   | 'left'
@@ -166,21 +197,7 @@ export const GameplayTestFrameLayout = ({
   const [size, setSize] = React.useState<Size>(() => {
     const savedSize = values.gameplayTestFrameSize;
     if (!savedSize) return getDefaultGameAreaSize(gameResolution);
-    return {
-      width: clamp(
-        savedSize.width,
-        minGameAreaSize.width,
-        Math.max(minGameAreaSize.width, window.innerWidth - 2 * windowMargin)
-      ),
-      height: clamp(
-        savedSize.height,
-        minGameAreaSize.height,
-        Math.max(
-          minGameAreaSize.height,
-          window.innerHeight - 2 * windowMargin - approximateFrameChromeHeight
-        )
-      ),
-    };
+    return clampSizeToWindow(savedSize, 0, approximateFrameChromeHeight);
   });
   const [isDragging, setIsDragging] = React.useState<boolean>(false);
   const [isResizing, setIsResizing] = React.useState<boolean>(false);
@@ -202,25 +219,40 @@ export const GameplayTestFrameLayout = ({
     chromeHeight: number,
   |} | null>(null);
 
-  // Keep the frame inside the window when it is resized (or when the frame
-  // grows back after being minimized).
-  React.useEffect(() => {
-    const onWindowResized = () => {
-      setPosition(position =>
-        clampPositionToWindow(position, containerRef.current)
-      );
-    };
-    window.addEventListener('resize', onWindowResized);
-    return () => window.removeEventListener('resize', onWindowResized);
-  }, []);
-  React.useEffect(
+  // Keep the frame inside the window: shrink the game area if the window
+  // got too small for the frame (not when minimized: the game area is then
+  // 1x1 and the chrome around it can't be measured), then clamp the
+  // position.
+  const keepFrameInsideWindow = React.useCallback(
     () => {
-      setPosition(position =>
-        clampPositionToWindow(position, containerRef.current)
-      );
+      const container = containerRef.current;
+      const gameArea = gameAreaRef.current;
+      if (!isMinimized && container && gameArea) {
+        const containerRect = container.getBoundingClientRect();
+        const gameAreaRect = gameArea.getBoundingClientRect();
+        setSize(size =>
+          clampSizeToWindow(
+            size,
+            containerRect.width - gameAreaRect.width,
+            containerRect.height - gameAreaRect.height
+          )
+        );
+      }
+      setPosition(position => clampPositionToWindow(position, container));
     },
     [isMinimized]
   );
+
+  // Apply it when the window is resized, and when the frame is first
+  // rendered or grows back after being minimized.
+  React.useEffect(
+    () => {
+      window.addEventListener('resize', keepFrameInsideWindow);
+      return () => window.removeEventListener('resize', keepFrameInsideWindow);
+    },
+    [keepFrameInsideWindow]
+  );
+  React.useEffect(keepFrameInsideWindow, [keepFrameInsideWindow]);
 
   const onPointerDown = React.useCallback(
     (event: PointerEvent) => {
@@ -333,7 +365,7 @@ export const GameplayTestFrameLayout = ({
       // Anchored to the window bottom: the frame grows upwards without moving.
       const maxHeight =
         window.innerHeight -
-        windowMargin -
+        windowTopMargin -
         origin.position.bottom -
         origin.chromeHeight;
       newSize.height = clamp(

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
@@ -149,16 +149,28 @@
 
 .gameArea {
   position: relative;
-  display: flex;
   width: 320px;
   height: 180px;
+  overflow: hidden;
   background-color: #000;
 }
 
 /*
- * When minimized, the game is kept in a 1x1 pixel visible area: `display: none`
- * (or a zero size) would stop `requestAnimationFrame` in the game - and so the
- * test being run.
+ * Holds the game at its own resolution and only scales it down visually to
+ * fit the game area: the game must never be resized, so that it runs exactly
+ * like in a normal preview window.
+ */
+.gameScaler {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform-origin: center center;
+}
+
+/*
+ * When minimized, the game (still rendered at its own resolution) is clipped
+ * to a 1x1 pixel visible area: `display: none` (or a zero size) would stop
+ * `requestAnimationFrame` in the game - and so the test being run.
  */
 .hiddenGameArea {
   width: 1px;

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
@@ -43,8 +43,80 @@
   cursor: grabbing;
 }
 
-.container.dragging {
+.container.dragging,
+.container.resizing {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+}
+
+/* Invisible handles on the borders and corners of the frame to resize it. */
+.resizeHandle {
+  position: absolute;
+  z-index: 10;
+  touch-action: none;
+}
+
+.resizeLeft,
+.resizeRight {
+  top: 10px;
+  bottom: 10px;
+  width: 5px;
+  cursor: ew-resize;
+}
+
+.resizeLeft {
+  left: 0;
+}
+
+.resizeRight {
+  right: 0;
+}
+
+.resizeTop,
+.resizeBottom {
+  left: 10px;
+  right: 10px;
+  height: 5px;
+  cursor: ns-resize;
+}
+
+.resizeTop {
+  top: 0;
+}
+
+.resizeBottom {
+  bottom: 0;
+}
+
+.resizeTopLeft,
+.resizeTopRight,
+.resizeBottomLeft,
+.resizeBottomRight {
+  width: 10px;
+  height: 10px;
+}
+
+.resizeTopLeft {
+  top: 0;
+  left: 0;
+  cursor: nwse-resize;
+}
+
+.resizeTopRight {
+  top: 0;
+  right: 0;
+  cursor: nesw-resize;
+}
+
+.resizeBottomLeft {
+  bottom: 0;
+  left: 0;
+  cursor: nesw-resize;
+}
+
+.resizeBottomRight {
+  bottom: 0;
+  right: 0;
+  cursor: nwse-resize;
 }
 
 /* Two columns of three dots, hinting that the frame can be moved. */

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
@@ -156,8 +156,8 @@
 }
 
 /*
- * Holds the game window: sized 1:1 and only zoomed out to fit the game area
- * (see `getGameZoomFactor`).
+ * Holds the game window: always sized at exactly the game resolution, and
+ * only scaled to be displayed at the frame zoom.
  */
 .gameScaler {
   position: absolute;

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
@@ -156,9 +156,8 @@
 }
 
 /*
- * Holds the game window, which has the size of the game area at 1:1 scale
- * and is only zoomed out to fit it: the game runs like in a preview window
- * of this size (see `getGameZoomFactor`).
+ * Holds the game window: sized 1:1 and only zoomed out to fit the game area
+ * (see `getGameZoomFactor`).
  */
 .gameScaler {
   position: absolute;
@@ -168,9 +167,9 @@
 }
 
 /*
- * When minimized, the game window is left untouched and only clipped to a
- * 1x1 pixel visible area: `display: none` (or a zero size) would stop
- * `requestAnimationFrame` in the game - and so the test being run.
+ * When minimized, the game window is only clipped to a 1x1 pixel area:
+ * `display: none` (or a zero size) would stop `requestAnimationFrame` in
+ * the game - and so the test being run.
  */
 .hiddenGameArea {
   width: 1px;

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
@@ -156,9 +156,9 @@
 }
 
 /*
- * Holds the game at its own resolution and only scales it down visually to
- * fit the game area: the game must never be resized, so that it runs exactly
- * like in a normal preview window.
+ * Holds the game window, which has the size of the game area at 1:1 scale
+ * and is only zoomed out to fit it: the game runs like in a preview window
+ * of this size (see `getGameZoomFactor`).
  */
 .gameScaler {
   position: absolute;
@@ -168,8 +168,8 @@
 }
 
 /*
- * When minimized, the game (still rendered at its own resolution) is clipped
- * to a 1x1 pixel visible area: `display: none` (or a zero size) would stop
+ * When minimized, the game window is left untouched and only clipped to a
+ * 1x1 pixel visible area: `display: none` (or a zero size) would stop
  * `requestAnimationFrame` in the game - and so the test being run.
  */
 .hiddenGameArea {

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -250,7 +250,7 @@ export type PreferencesValues = {|
   gamesDashboardOrderBy: GamesDashboardOrderBy,
   takeScreenshotOnPreview: boolean,
   gameplayTestFramePosition: {| left: number, bottom: number |} | null,
-  gameplayTestFrameSize: {| width: number, height: number |} | null,
+  gameplayTestFrameZoomFactor: number | null,
   showAiAskButtonInTitleBar: boolean,
   automaticallyUseCreditsForAiRequests: boolean,
   automaticallyApplyAiRequestEditsByProjectId: { [string]: boolean },
@@ -381,10 +381,7 @@ export type Preferences = {|
     left: number,
     bottom: number,
   |}) => void,
-  setGameplayTestFrameSize: (size: {|
-    width: number,
-    height: number,
-  |}) => void,
+  setGameplayTestFrameZoomFactor: (zoomFactor: number) => void,
   setShowAiAskButtonInTitleBar: (enabled: boolean) => void,
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => void,
   setAutomaticallyApplyAiRequestEditsForProjectId: (
@@ -455,7 +452,7 @@ export const initialPreferences = {
     gamesDashboardOrderBy: 'lastModifiedAt',
     takeScreenshotOnPreview: true,
     gameplayTestFramePosition: null,
-    gameplayTestFrameSize: null,
+    gameplayTestFrameZoomFactor: null,
     showAiAskButtonInTitleBar: true,
     automaticallyUseCreditsForAiRequests: false,
     automaticallyApplyAiRequestEditsByProjectId: {},
@@ -549,7 +546,7 @@ export const initialPreferences = {
     left: number,
     bottom: number,
   |}) => {},
-  setGameplayTestFrameSize: (size: {| width: number, height: number |}) => {},
+  setGameplayTestFrameZoomFactor: (zoomFactor: number) => {},
   setShowAiAskButtonInTitleBar: (enabled: boolean) => {},
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => {},
   setAutomaticallyApplyAiRequestEditsForProjectId: (

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -250,6 +250,7 @@ export type PreferencesValues = {|
   gamesDashboardOrderBy: GamesDashboardOrderBy,
   takeScreenshotOnPreview: boolean,
   gameplayTestFramePosition: {| left: number, bottom: number |} | null,
+  gameplayTestFrameSize: {| width: number, height: number |} | null,
   showAiAskButtonInTitleBar: boolean,
   automaticallyUseCreditsForAiRequests: boolean,
   automaticallyApplyAiRequestEditsByProjectId: { [string]: boolean },
@@ -380,6 +381,10 @@ export type Preferences = {|
     left: number,
     bottom: number,
   |}) => void,
+  setGameplayTestFrameSize: (size: {|
+    width: number,
+    height: number,
+  |}) => void,
   setShowAiAskButtonInTitleBar: (enabled: boolean) => void,
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => void,
   setAutomaticallyApplyAiRequestEditsForProjectId: (
@@ -450,6 +455,7 @@ export const initialPreferences = {
     gamesDashboardOrderBy: 'lastModifiedAt',
     takeScreenshotOnPreview: true,
     gameplayTestFramePosition: null,
+    gameplayTestFrameSize: null,
     showAiAskButtonInTitleBar: true,
     automaticallyUseCreditsForAiRequests: false,
     automaticallyApplyAiRequestEditsByProjectId: {},
@@ -543,6 +549,7 @@ export const initialPreferences = {
     left: number,
     bottom: number,
   |}) => {},
+  setGameplayTestFrameSize: (size: {| width: number, height: number |}) => {},
   setShowAiAskButtonInTitleBar: (enabled: boolean) => {},
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => {},
   setAutomaticallyApplyAiRequestEditsForProjectId: (

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -135,6 +135,7 @@ export const getInitialPreferences = (): {
   showInAppTutorialDeveloperMode: boolean,
   takeScreenshotOnPreview: boolean,
   gameplayTestFramePosition: {| left: number, bottom: number |} | null,
+  gameplayTestFrameSize: {| width: number, height: number |} | null,
   themeName: any,
   use3DEditor: any,
   useBackgroundSerializerForSaving: boolean,
@@ -400,6 +401,8 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     setGameplayTestFramePosition: (this._setGameplayTestFramePosition.bind(
       this
     ): any),
+    // $FlowFixMe[method-unbinding]
+    setGameplayTestFrameSize: (this._setGameplayTestFrameSize.bind(this): any),
     // $FlowFixMe[method-unbinding]
     setShowAiAskButtonInTitleBar: (this._setShowAiAskButtonInTitleBar.bind(
       this
@@ -1419,6 +1422,18 @@ export default class PreferencesProvider extends React.Component<Props, State> {
         values: {
           ...state.values,
           gameplayTestFramePosition: newValue,
+        },
+      }),
+      () => this._persistValuesToLocalStorage(this.state)
+    );
+  }
+
+  _setGameplayTestFrameSize(newValue: {| width: number, height: number |}) {
+    this.setState(
+      state => ({
+        values: {
+          ...state.values,
+          gameplayTestFrameSize: newValue,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -135,7 +135,7 @@ export const getInitialPreferences = (): {
   showInAppTutorialDeveloperMode: boolean,
   takeScreenshotOnPreview: boolean,
   gameplayTestFramePosition: {| left: number, bottom: number |} | null,
-  gameplayTestFrameSize: {| width: number, height: number |} | null,
+  gameplayTestFrameZoomFactor: number | null,
   themeName: any,
   use3DEditor: any,
   useBackgroundSerializerForSaving: boolean,
@@ -402,7 +402,9 @@ export default class PreferencesProvider extends React.Component<Props, State> {
       this
     ): any),
     // $FlowFixMe[method-unbinding]
-    setGameplayTestFrameSize: (this._setGameplayTestFrameSize.bind(this): any),
+    setGameplayTestFrameZoomFactor: (this._setGameplayTestFrameZoomFactor.bind(
+      this
+    ): any),
     // $FlowFixMe[method-unbinding]
     setShowAiAskButtonInTitleBar: (this._setShowAiAskButtonInTitleBar.bind(
       this
@@ -1428,12 +1430,12 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     );
   }
 
-  _setGameplayTestFrameSize(newValue: {| width: number, height: number |}) {
+  _setGameplayTestFrameZoomFactor(newValue: number) {
     this.setState(
       state => ({
         values: {
           ...state.values,
-          gameplayTestFrameSize: newValue,
+          gameplayTestFrameZoomFactor: newValue,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
@@ -26,7 +26,8 @@ const styles = {
     alignItems: 'flex-end',
     background: 'linear-gradient(to bottom, #4f28cd, #95c6ff)',
   },
-  // Sized for the fake game resolution below (displayed zoomed out by 4).
+  // Sized for the fake game resolution below (displayed zoomed out by 4
+  // when the frame is at its default size).
   fakeGameGround: {
     width: '100%',
     height: 128,

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
@@ -21,7 +21,8 @@ const styles = {
   storyContainer: { height: 460, position: 'relative' },
   fakeGame: {
     display: 'flex',
-    flex: 1,
+    width: '100%',
+    height: '100%',
     alignItems: 'flex-end',
     background: 'linear-gradient(to bottom, #4f28cd, #95c6ff)',
   },
@@ -87,6 +88,7 @@ const FrameStory = ({
         isMinimized={isMinimized}
         onToggleMinimized={() => setIsMinimized(!isMinimized)}
         onStopRequested={action('stop requested')}
+        gameResolution={{ width: 1280, height: 720 }}
       >
         <FakeGameView />
       </GameplayTestFrameLayout>

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
@@ -26,8 +26,7 @@ const styles = {
     alignItems: 'flex-end',
     background: 'linear-gradient(to bottom, #4f28cd, #95c6ff)',
   },
-  // Sized for the fake game resolution below (the frame displays the game
-  // zoomed out, so these are divided by 4 on screen).
+  // Sized for the fake game resolution below (displayed zoomed out by 4).
   fakeGameGround: {
     width: '100%',
     height: 128,

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
@@ -26,19 +26,21 @@ const styles = {
     alignItems: 'flex-end',
     background: 'linear-gradient(to bottom, #4f28cd, #95c6ff)',
   },
+  // Sized for the fake game resolution below (the frame displays the game
+  // zoomed out, so these are divided by 4 on screen).
   fakeGameGround: {
     width: '100%',
-    height: 32,
+    height: 128,
     backgroundColor: '#16cf89',
     position: 'relative',
   },
   fakeGamePlayer: {
     position: 'absolute',
-    bottom: 32,
-    left: 60,
-    width: 20,
-    height: 28,
-    borderRadius: 3,
+    bottom: 128,
+    left: 240,
+    width: 80,
+    height: 112,
+    borderRadius: 12,
     backgroundColor: '#ffbc57',
   },
 };


### PR DESCRIPTION
This allows resizing the gameplay test mini window, but only when no test is running: resizing during a test triggers a lot of computations and the game feels laggy in the preview.

I tested resizing during a test, and the anchors on objects were not following properly.
I also tried advancing the preview by one frame on each resize, but it was still not smooth enough for the anchors while a test was running.
So I decided to lock resizing while a test is running.

When the test is finished (the game is left paused, showing the last frame), resizing the frame advances the game by a single frame, so anchored objects and cameras adapt the displayed frame to the new size. This does not affect the test results, which were already reported.

The size of the frame is remembered in the preferences, like its position.


https://github.com/user-attachments/assets/00c0aa70-fecf-4e76-9f07-ceb1097d9060



Max size of the window inside the editor.
<img width="1922" height="925" alt="image" src="https://github.com/user-attachments/assets/3a4fe09d-d1b7-46c6-8843-8a00e4216d8e" />


