### PR TITLE
Redesign the AI chat edit approval and error rows

### DIFF
--- a/newIDE/app/src/AiGeneration/AiRequestChat/AiRequestErrorRow.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/AiRequestErrorRow.js
@@ -1,0 +1,120 @@
+// @flow
+import * as React from 'react';
+import { Trans } from '@lingui/macro';
+import Text from '../../UI/Text';
+import ErrorFilled from '../../UI/CustomSvgIcons/ErrorFilled';
+import Refresh from '../../UI/CustomSvgIcons/Refresh';
+import ChatBubbles from '../../UI/CustomSvgIcons/ChatBubbles';
+import { ChatActionButton } from './ChatActionButton';
+import classes from './AiRequestErrorRow.module.css';
+
+type Props = {|
+  /** The error reported by the API, shown as a discreet technical detail. */
+  error?: ?{ code: string, message: string },
+  /** Continues the request where it stopped. Absent when it can't be resumed. */
+  onRetry?: ?() => void | Promise<void>,
+  onStartNewChat?: ?() => void,
+|};
+
+const styles = {
+  title: {
+    fontWeight: 'bold',
+  },
+  errorCode: {
+    fontFamily: '"Lucida Console", Monaco, monospace',
+    opacity: 0.75,
+  },
+};
+
+/**
+ * Shown at the end of the chat when the AI request stopped on an error: what
+ * happened, what it means for the user, and how to get going again.
+ */
+export const AiRequestErrorRow = ({
+  error,
+  onRetry,
+  onStartNewChat,
+}: Props): React.Node => {
+  const [isRetrying, setIsRetrying] = React.useState(false);
+
+  const retry = React.useCallback(
+    async () => {
+      if (!onRetry) return;
+      setIsRetrying(true);
+      try {
+        await onRetry();
+      } finally {
+        setIsRetrying(false);
+      }
+    },
+    [onRetry]
+  );
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.header}>
+        <span className={classes.icon}>
+          <ErrorFilled fontSize="inherit" />
+        </span>
+        <span className={classes.title}>
+          <Text
+            noMargin
+            size="body-small"
+            // $FlowFixMe[incompatible-type]
+            style={styles.title}
+          >
+            <Trans>The AI ran into an error</Trans>
+          </Text>
+        </span>
+        {error && (
+          <span className={classes.errorCode}>
+            <Text
+              noMargin
+              size="body-small"
+              color="secondary"
+              tooltip={error.message}
+              // $FlowFixMe[incompatible-type]
+              style={styles.errorCode}
+            >
+              {error.code}
+            </Text>
+          </span>
+        )}
+      </div>
+      <Text noMargin size="body-small" color="secondary">
+        {onRetry ? (
+          <Trans>
+            This request was not counted in your AI usage. The work done so far
+            is kept: try again to continue where it stopped.
+          </Trans>
+        ) : (
+          <Trans>
+            This request was not counted in your AI usage. The work done so far
+            is kept.
+          </Trans>
+        )}
+      </Text>
+      <div className={classes.actions}>
+        {onRetry && (
+          <ChatActionButton
+            emphasis="primary"
+            icon={<Refresh fontSize="inherit" />}
+            label={
+              isRetrying ? <Trans>Retrying...</Trans> : <Trans>Retry</Trans>
+            }
+            disabled={isRetrying}
+            onClick={retry}
+          />
+        )}
+        {onStartNewChat && (
+          <ChatActionButton
+            emphasis="quiet"
+            icon={<ChatBubbles fontSize="inherit" />}
+            label={<Trans>Start a new chat</Trans>}
+            onClick={onStartNewChat}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/newIDE/app/src/AiGeneration/AiRequestChat/AiRequestErrorRow.module.css
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/AiRequestErrorRow.module.css
@@ -14,6 +14,24 @@
     transparent 100%
   );
   min-width: 0;
+  animation: aiRequestErrorAppear 180ms ease-out;
+}
+
+@keyframes aiRequestErrorAppear {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .container {
+    animation: none;
+  }
 }
 
 .header {

--- a/newIDE/app/src/AiGeneration/AiRequestChat/AiRequestErrorRow.module.css
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/AiRequestErrorRow.module.css
@@ -1,0 +1,58 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid
+    color-mix(in srgb, var(--theme-message-error-color) 35%, transparent);
+  /* A red tint that stays discreet on both light and dark themes. */
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--theme-message-error-color) 12%, transparent) 0%,
+    color-mix(in srgb, var(--theme-message-error-color) 4%, transparent) 55%,
+    transparent 100%
+  );
+  min-width: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  font-size: 18px;
+  color: var(--theme-message-error-color);
+}
+
+.title {
+  flex-shrink: 0;
+}
+
+/* The error code sits at the end of the header line, out of the way of the
+   explanation but available when reporting the issue. */
+.errorCode {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  margin-left: auto;
+}
+
+/* Anywhere so a long code wraps instead of making the whole chat wider. */
+.errorCode > * {
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}

--- a/newIDE/app/src/AiGeneration/AiRequestChat/ChatActionButton.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/ChatActionButton.js
@@ -1,0 +1,59 @@
+// @flow
+import * as React from 'react';
+import ButtonBase from '@material-ui/core/ButtonBase';
+import Tooltip from '@material-ui/core/Tooltip';
+import classNames from 'classnames';
+import classes from './ChatActionButton.module.css';
+
+type Props = {|
+  label: React.Node,
+  onClick: () => void | Promise<void>,
+  icon?: React.Node,
+  /**
+   * `primary` for the action the user is expected to take, `quiet` for the one
+   * that dismisses the row.
+   */
+  emphasis?: 'primary' | 'default' | 'quiet',
+  disabled?: boolean,
+  tooltip?: React.Node,
+|};
+
+/**
+ * A compact button for the actions offered by a row of the AI chat (approving
+ * an edit, retrying a failed request...). Kept lighter than the buttons of the
+ * rest of the editor so a row stays at the scale of the conversation.
+ */
+export const ChatActionButton = ({
+  label,
+  onClick,
+  icon,
+  emphasis = 'default',
+  disabled,
+  tooltip,
+}: Props): React.Node => {
+  const button = (
+    <ButtonBase
+      className={classNames({
+        [classes.button]: true,
+        [classes.buttonPrimary]: emphasis === 'primary',
+        [classes.buttonQuiet]: emphasis === 'quiet',
+      })}
+      onClick={onClick}
+      disabled={disabled}
+      disableRipple
+      focusVisibleClassName={classes.buttonFocusVisible}
+    >
+      {icon && <span className={classes.icon}>{icon}</span>}
+      {label}
+    </ButtonBase>
+  );
+
+  if (!tooltip) return button;
+
+  return (
+    <Tooltip title={tooltip} placement="top" enterDelay={400}>
+      {/* A span is needed so the tooltip still shows on a disabled button. */}
+      <span className={classes.tooltipWrapper}>{button}</span>
+    </Tooltip>
+  );
+};

--- a/newIDE/app/src/AiGeneration/AiRequestChat/ChatActionButton.module.css
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/ChatActionButton.module.css
@@ -1,0 +1,68 @@
+/* All the rules are scoped to the `button` element: Material UI resets the
+   background and the border of its ButtonBase in a stylesheet injected at
+   runtime, which would otherwise win over the class alone. */
+
+button.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 13px;
+  border: 1px solid var(--theme-list-item-separator-color);
+  background-color: var(--theme-surface-canvas-background-color);
+  color: var(--theme-text-default-color);
+  font-family: var(--gdevelop-modern-font-family);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  transition: background-color 150ms ease, border-color 150ms ease,
+    color 150ms ease;
+}
+
+button.button:hover {
+  background-color: var(--theme-list-item-hover-background-color);
+  border-color: var(--theme-text-secondary-color);
+}
+
+button.buttonFocusVisible {
+  outline: 2px solid var(--theme-text-field-active-border-color);
+  outline-offset: 2px;
+}
+
+button.button:disabled {
+  opacity: 0.5;
+}
+
+button.buttonPrimary {
+  border-color: transparent;
+  background-color: var(--theme-primary-light);
+  color: var(--theme-primary-text-contrast-color);
+}
+
+button.buttonPrimary:hover {
+  border-color: transparent;
+  background-color: var(--theme-primary-color);
+}
+
+button.buttonQuiet {
+  border-color: transparent;
+  background-color: transparent;
+  color: var(--theme-text-secondary-color);
+}
+
+button.buttonQuiet:hover {
+  border-color: transparent;
+  background-color: var(--theme-list-item-hover-background-color);
+  color: var(--theme-text-default-color);
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  font-size: 15px;
+}
+
+.tooltipWrapper {
+  display: inline-flex;
+}

--- a/newIDE/app/src/AiGeneration/AiRequestChat/ChatMessages.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/ChatMessages.js
@@ -29,8 +29,8 @@ import {
 } from '../../EditorFunctions';
 import classes from './ChatMessages.module.css';
 import { DislikeFeedbackDialog } from './DislikeFeedbackDialog';
+import { AiRequestErrorRow } from './AiRequestErrorRow';
 import Text from '../../UI/Text';
-import AlertMessage from '../../UI/AlertMessage';
 import { ColumnStackLayout, LineStackLayout } from '../../UI/Layout';
 import FlatButton from '../../UI/FlatButton';
 import Paper from '../../UI/Paper';
@@ -119,6 +119,9 @@ type Props = {|
   onSwitchedToGDevelopCredits: () => void,
 
   onStartOrOpenChat: (options: ?{| aiRequestId: string | null |}) => void,
+  // Continues a request that stopped on an error, from where it stopped.
+  // Absent when the chat has no way to resume it (e.g. the standalone form).
+  onRetryAfterError?: ?() => Promise<void>,
   isSending?: boolean,
   // True while the request is paused waiting for the user to answer the inline
   // "Apply this edit?" prompt. Replaces the working/thinking indicators.
@@ -203,6 +206,7 @@ export const ChatMessages: React.ComponentType<Props> = React.memo<Props>(
     hasStartedRequestButCannotContinue,
     onSwitchedToGDevelopCredits,
     onStartOrOpenChat,
+    onRetryAfterError,
     isSending,
     isWaitingForEditApproval,
     savingProjectForMessageId,
@@ -1255,12 +1259,11 @@ export const ChatMessages: React.ComponentType<Props> = React.memo<Props>(
 
         {aiRequest.status === 'error' ? (
           <Line justifyContent="flex-start">
-            <AlertMessage kind="error">
-              <Trans>
-                The AI encountered an error while handling your request - this
-                request was not counted in your AI usage. Try again later.
-              </Trans>
-            </AlertMessage>
+            <AiRequestErrorRow
+              error={aiRequest.error}
+              onRetry={onRetryAfterError}
+              onStartNewChat={() => onStartOrOpenChat({ aiRequestId: null })}
+            />
           </Line>
         ) : isWaitingForEditApproval ? null : aiRequest.status === // EditApprovalRow): suppress the working/thinking indicators. // Paused on the inline "Apply this edit?" prompt (rendered below by
             'suspended' && !shouldBeWorkingIfNotPaused ? (

--- a/newIDE/app/src/AiGeneration/AiRequestChat/EditApprovalRow.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/EditApprovalRow.js
@@ -2,11 +2,13 @@
 import * as React from 'react';
 import { Trans } from '@lingui/macro';
 import Text from '../../UI/Text';
-import RaisedButton from '../../UI/RaisedButton';
-import FlatButton from '../../UI/FlatButton';
-import { ColumnStackLayout, LineStackLayout } from '../../UI/Layout';
-import HelpQuestion from '../../UI/CustomSvgIcons/HelpQuestion';
+import Check from '../../UI/CustomSvgIcons/Check';
+import Cross from '../../UI/CustomSvgIcons/Cross';
+import Edit from '../../UI/CustomSvgIcons/Edit';
+import Sparkle from '../../UI/CustomSvgIcons/Sparkle';
+import { ChatActionButton } from './ChatActionButton';
 import { type EditApprovalRequest } from '../Utils';
+import classes from './EditApprovalRow.module.css';
 
 type Props = {|
   pendingEditApproval: EditApprovalRequest,
@@ -15,10 +17,10 @@ type Props = {|
 |};
 
 const styles = {
-  icon: {
-    fontSize: 14,
-    flexShrink: 0,
-    marginTop: 1,
+  label: {
+    // Anywhere because the label can contain long object or scene names.
+    overflowWrap: 'anywhere',
+    fontWeight: 'bold',
   },
 };
 
@@ -31,27 +33,47 @@ export const EditApprovalRow = ({
   onResolveEditApproval,
   onAcceptAndEnableAutoEdit,
 }: Props): React.Node => (
-  <ColumnStackLayout noMargin>
-    <LineStackLayout noMargin alignItems="flex-start">
-      <HelpQuestion style={styles.icon} />
+  <div className={classes.container}>
+    <div className={classes.header}>
+      <span className={classes.iconBadge}>
+        <Edit fontSize="inherit" />
+      </span>
       <Text noMargin size="body-small" color="secondary">
-        <Trans>Apply this change:</Trans> {pendingEditApproval.label}
+        <Trans>The AI wants to edit your project</Trans>
       </Text>
-    </LineStackLayout>
-    <ColumnStackLayout noMargin alignItems="flex-start">
-      <RaisedButton
-        primary
-        label={<Trans>Yes, just this change</Trans>}
+    </div>
+    <Text
+      noMargin
+      size="body-small"
+      // $FlowFixMe[incompatible-type]
+      style={styles.label}
+    >
+      {pendingEditApproval.label}
+    </Text>
+    <div className={classes.actions}>
+      <ChatActionButton
+        emphasis="primary"
+        icon={<Check fontSize="inherit" />}
+        label={<Trans>Apply</Trans>}
         onClick={() => onResolveEditApproval(true)}
       />
-      <FlatButton
-        label={<Trans>Yes, and enable auto-edit</Trans>}
+      <ChatActionButton
+        icon={<Sparkle fontSize="inherit" />}
+        label={<Trans>Always apply</Trans>}
+        tooltip={
+          <Trans>
+            Apply this change and turn on auto edit, so the next changes are
+            applied without asking.
+          </Trans>
+        }
         onClick={onAcceptAndEnableAutoEdit}
       />
-      <FlatButton
-        label={<Trans>No</Trans>}
+      <ChatActionButton
+        emphasis="quiet"
+        icon={<Cross fontSize="inherit" />}
+        label={<Trans>Don't apply</Trans>}
         onClick={() => onResolveEditApproval(false)}
       />
-    </ColumnStackLayout>
-  </ColumnStackLayout>
+    </div>
+  </div>
 );

--- a/newIDE/app/src/AiGeneration/AiRequestChat/EditApprovalRow.module.css
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/EditApprovalRow.module.css
@@ -1,0 +1,66 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--theme-primary-light) 40%, transparent);
+  /* A purple tint, matching the AI accent of the chat, kept discreet enough to
+     stay readable on both light and dark themes. */
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--theme-primary-light) 14%, transparent) 0%,
+    color-mix(in srgb, var(--theme-primary-light) 4%, transparent) 55%,
+    transparent 100%
+  );
+  min-width: 0;
+  animation: editApprovalAppear 180ms ease-out;
+}
+
+@keyframes editApprovalAppear {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .container {
+    animation: none;
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.iconBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  flex-shrink: 0;
+  font-size: 15px;
+  background-color: color-mix(
+    in srgb,
+    var(--theme-primary-light) 25%,
+    transparent
+  );
+  color: var(--theme-text-default-color);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}

--- a/newIDE/app/src/AiGeneration/AiRequestChat/index.js
+++ b/newIDE/app/src/AiGeneration/AiRequestChat/index.js
@@ -354,6 +354,9 @@ type Props = {|
   ) => Promise<void>,
   editorFunctionCallResults: Array<EditorFunctionCallResult> | null,
   editorCallbacks: EditorCallbacks,
+  // Continues a request that stopped on an error, from where it stopped.
+  // Absent in contexts that can't resume a request (e.g. the standalone form).
+  onRetryAfterError?: ?() => Promise<void>,
   // Error that occurred while sending the last request.
   lastSendError: ?Error,
 
@@ -421,6 +424,7 @@ export const AiRequestChat: React.ComponentType<{
       onIsAutoEditEnabledChange,
       pendingEditApproval,
       onResolveEditApproval,
+      onRetryAfterError,
     }: Props,
     ref
   ) => {
@@ -571,6 +575,15 @@ export const AiRequestChat: React.ComponentType<{
         if (pendingEditApproval) scrollToBottom();
       },
       [pendingEditApproval, scrollToBottom]
+    );
+
+    const retryAfterErrorAndScroll = React.useCallback(
+      async () => {
+        if (!onRetryAfterError) return;
+        scrollToBottom();
+        await onRetryAfterError();
+      },
+      [onRetryAfterError, scrollToBottom]
     );
 
     const onScroll = React.useCallback(
@@ -1165,6 +1178,9 @@ export const AiRequestChat: React.ComponentType<{
               setHasSwitchedToGDevelopCreditsMidChat(true)
             }
             onStartOrOpenChat={onStartOrOpenChat}
+            onRetryAfterError={
+              onRetryAfterError ? retryAfterErrorAndScroll : null
+            }
             isSending={isSendingUserMessage}
             isWaitingForEditApproval={!!pendingEditApproval}
             savingProjectForMessageId={savingProjectForMessageId}

--- a/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
+++ b/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
@@ -880,6 +880,7 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           triggerUnsavedChanges,
         ]
       );
+
       // Ask the AI to continue a request that stopped on an error: nothing new
       // is sent, so it picks up from the last message it managed to write.
       const onRetryAfterError = React.useCallback(

--- a/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
+++ b/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
@@ -659,12 +659,16 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           createdSceneNames,
           createdProject,
           editorFunctionCallResults,
+          forceSend,
         }: {|
           aiRequestId: string,
           userMessage: string,
           createdSceneNames?: Array<string>,
           createdProject?: ?gdProject,
           editorFunctionCallResults: Array<EditorFunctionCallResult>,
+          // Sends even when there is nothing new to send: used to ask the AI to
+          // continue a request that stopped on an error.
+          forceSend?: boolean,
         |}) => {
           if (!profile) return;
 
@@ -709,7 +713,8 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           }
 
           // If nothing to send, stop there.
-          if (functionCallOutputs.length === 0 && !userMessage) return;
+          if (functionCallOutputs.length === 0 && !userMessage && !forceSend)
+            return;
 
           // Paying with credits is only when a user message is sent (and quota is exhausted).
           let payWithCredits = false;
@@ -875,6 +880,22 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
           triggerUnsavedChanges,
         ]
       );
+      // Ask the AI to continue a request that stopped on an error: nothing new
+      // is sent, so it picks up from the last message it managed to write.
+      const onRetryAfterError = React.useCallback(
+        async () => {
+          if (!selectedAiRequestId) return;
+          await onSendMessage({
+            aiRequestId: selectedAiRequestId,
+            userMessage: '',
+            editorFunctionCallResults:
+              getEditorFunctionCallResults(selectedAiRequestId) || [],
+            forceSend: true,
+          });
+        },
+        [selectedAiRequestId, onSendMessage, getEditorFunctionCallResults]
+      );
+
       useActivatePendingSubAgents({ selectedAiRequest });
       useLoadSubAgentRequests({ selectedAiRequest });
 
@@ -1545,6 +1566,7 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
                       : [],
                   });
                 }}
+                onRetryAfterError={onRetryAfterError}
                 onIsAutoEditEnabledChange={enabled => {
                   isAutoEditEnabledRef.current = enabled;
                   // Toggling auto-edit revokes any blanket approvals already

--- a/newIDE/app/src/stories/componentStories/AiGeneration/AiRequestChat/ChatRows.stories.js
+++ b/newIDE/app/src/stories/componentStories/AiGeneration/AiRequestChat/ChatRows.stories.js
@@ -1,0 +1,99 @@
+// @flow
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+import paperDecorator from '../../../PaperDecorator';
+import FixedWidthFlexContainer from '../../../FixedWidthFlexContainer';
+import { ColumnStackLayout } from '../../../../UI/Layout';
+import Text from '../../../../UI/Text';
+import { EditApprovalRow } from '../../../../AiGeneration/AiRequestChat/EditApprovalRow';
+import { AiRequestErrorRow } from '../../../../AiGeneration/AiRequestChat/AiRequestErrorRow';
+import { type EditApprovalRequest } from '../../../../AiGeneration/Utils';
+
+// The rows shown in the AI chat outside of a message: they ask the user
+// something (approving an edit) or tell them what happened to their request
+// (an error), so they are checked here on their own, at the widths the chat
+// panel can have.
+export default {
+  title: 'EventsFunctionsExtensionEditor/AiRequestChat/ChatRows',
+  component: EditApprovalRow,
+  decorators: [paperDecorator],
+};
+
+const pendingEditApproval: EditApprovalRequest = {
+  aiRequestId: 'fake-ai-request-id',
+  callIds: ['fake_modifying_call_1'],
+  label: 'Add a score display and update it on coin pickup',
+};
+
+export const EditApproval = (): React.Node => (
+  <FixedWidthFlexContainer width={600}>
+    <EditApprovalRow
+      pendingEditApproval={pendingEditApproval}
+      onResolveEditApproval={action('onResolveEditApproval')}
+      onAcceptAndEnableAutoEdit={action('onAcceptAndEnableAutoEdit')}
+    />
+  </FixedWidthFlexContainer>
+);
+
+export const EditApprovalWithLongLabel = (): React.Node => (
+  <FixedWidthFlexContainer width={600}>
+    <EditApprovalRow
+      pendingEditApproval={{
+        ...pendingEditApproval,
+        label:
+          'Add a score display in the top left corner of the scene, update it every time a coin is picked up and save the best score in a storage variable',
+      }}
+      onResolveEditApproval={action('onResolveEditApproval')}
+      onAcceptAndEnableAutoEdit={action('onAcceptAndEnableAutoEdit')}
+    />
+  </FixedWidthFlexContainer>
+);
+
+export const AiRequestError = (): React.Node => (
+  <FixedWidthFlexContainer width={600}>
+    <AiRequestErrorRow
+      error={{
+        code: 'ai-request/internal-error',
+        message: 'The AI request failed to complete.',
+      }}
+      onRetry={async () => action('onRetry')()}
+      onStartNewChat={action('onStartNewChat')}
+    />
+  </FixedWidthFlexContainer>
+);
+
+// A request that can't be continued (no retry offered): only starting a new
+// chat is left to the user.
+export const AiRequestErrorWithoutRetry = (): React.Node => (
+  <FixedWidthFlexContainer width={600}>
+    <AiRequestErrorRow onStartNewChat={action('onStartNewChat')} />
+  </FixedWidthFlexContainer>
+);
+
+// The chat panel can be docked and narrow: the actions must then wrap instead
+// of overflowing.
+export const RowsInANarrowPanel = (): React.Node => (
+  <FixedWidthFlexContainer width={280}>
+    <ColumnStackLayout noMargin expand>
+      <Text noMargin size="body-small" color="secondary">
+        Edit approval
+      </Text>
+      <EditApprovalRow
+        pendingEditApproval={pendingEditApproval}
+        onResolveEditApproval={action('onResolveEditApproval')}
+        onAcceptAndEnableAutoEdit={action('onAcceptAndEnableAutoEdit')}
+      />
+      <Text noMargin size="body-small" color="secondary">
+        Request error
+      </Text>
+      <AiRequestErrorRow
+        error={{
+          code: 'ai-request/internal-error',
+          message: 'The AI request failed to complete.',
+        }}
+        onRetry={async () => action('onRetry')()}
+        onStartNewChat={action('onStartNewChat')}
+      />
+    </ColumnStackLayout>
+  </FixedWidthFlexContainer>
+);

--- a/newIDE/app/src/stories/componentStories/AiGeneration/AiRequestChat/Orchestrator.stories.js
+++ b/newIDE/app/src/stories/componentStories/AiGeneration/AiRequestChat/Orchestrator.stories.js
@@ -719,6 +719,28 @@ export const ErrorLaunchingFollowupAiRequest = (): React.Node => (
   />
 );
 
+// The request itself stopped on an error: the chat offers to continue it where
+// it stopped, or to start over in a new chat.
+export const AiRequestStoppedOnError = (): React.Node => (
+  <WrappedChatComponent
+    aiRequest={{
+      ...aiRequestWithAiResponses,
+      status: 'error',
+      error: {
+        code: 'ai-request/internal-error',
+        message: 'The AI request failed to complete.',
+      },
+    }}
+    onRetryAfterError={async () => action('onRetryAfterError')()}
+  />
+);
+
+export const AiRequestStoppedOnErrorWithoutRetry = (): React.Node => (
+  <WrappedChatComponent
+    aiRequest={{ ...aiRequestWithAiResponses, status: 'error' }}
+  />
+);
+
 // Quota limits
 // ------------
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The inline "Apply this change?" prompt (`EditApprovalRow`) and the request error shown at the end of the chat were built out of the editor's standard raised/flat buttons and `AlertMessage`. They looked heavy next to the rest of the AI chat, whose rows are compact and typographic.

Both now share the visual language of the other chat rows (the script row and its error block): a tinted card with an accent border, a short title, and a row of compact pill actions.

- `EditApprovalRow`: purple (AI accent) card, the change to apply in bold, and three pill actions — `Apply`, `Always apply` (with a tooltip explaining it turns on auto edit) and `Don't apply`.
- `AiRequestErrorRow` (new component, replacing the inline `AlertMessage` in `ChatMessages`): red-tinted card, the error code reported by the API shown discreetly in monospace, and two actions — `Retry` (continues the request where it stopped) and `Start a new chat`.
- `ChatActionButton` (new): the compact pill button shared by both rows, built on Material UI's `ButtonBase`.
- Retry plumbing: `AskAiEditorContainer` gets an `onRetryAfterError` callback that re-sends the request without any new content (`forceSend`), so the AI picks up from the last message it managed to write.

[Edit approval row inside the chat, dark theme](https://cursor.com/agents/bc-c360692f-ac07-4afe-8b4b-941436428e14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_approval_row_in_chat_dark.png)

[AI request error row inside the chat, dark theme](https://cursor.com/agents/bc-c360692f-ac07-4afe-8b4b-941436428e14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_request_error_row_in_chat_dark.png)

Both rows in a narrow (280px) docked panel, where the actions wrap:

[Both rows in a narrow panel, light theme](https://cursor.com/agents/bc-c360692f-ac07-4afe-8b4b-941436428e14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fboth_rows_narrow_panel_light.png)

## Stories

- New `EventsFunctionsExtensionEditor/AiRequestChat/ChatRows` stories render both rows on their own, with a long label, without a retry, and inside a 280px-wide panel.
- New `AiRequestStoppedOnError` and `AiRequestStoppedOnErrorWithoutRetry` stories in `Orchestrator` show the error row in a full chat.

## Testing

`flow check` (0 errors), `eslint` and `prettier` pass, and the AI/editor function test suites pass (582 tests). The rows were checked in Storybook in the light, dark, Nord and One Dark themes, at chat width and in a narrow docked panel, with hover states.

[ai_chat_edit_approval_and_error_rows_storybook_walkthrough.mp4](https://cursor.com/agents/bc-c360692f-ac07-4afe-8b4b-941436428e14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_chat_edit_approval_and_error_rows_storybook_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c360692f-ac07-4afe-8b4b-941436428e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c360692f-ac07-4afe-8b4b-941436428e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

