### PR TITLE
Never let resizing the gameplay test frame affect the game

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -1356,6 +1356,12 @@ namespace gdjs {
        * this size. Useful to test layouts made for other screen sizes,
        * before asserting positions or taking a screenshot.
        *
+       * This is the ONLY way the game resolution changes during a test:
+       * a gameplay test always runs in a game window of the project's game
+       * resolution, and moving, resizing or minimizing the gameplay test
+       * frame in the editor is never visible to the game (the frame is
+       * only a zoomed view of that fixed window).
+       *
        * The engine sees a game window of this size until the end of the
        * test: a game adapting its resolution to the game window size would
        * otherwise recompute it from the real window, ignoring the size

--- a/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/BrowserExporters/BrowserSWPreviewLauncher/index.js
@@ -312,8 +312,8 @@ export default class BrowserSWPreviewLauncher extends React.Component<
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation:
             outputDir + '/index.html?previewId=' + previewId,
-          // The frame opens with a game window of the project resolution,
-          // displayed zoomed out.
+          // The game window of the frame is fixed at the project
+          // resolution: the frame only zooms its display.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
+++ b/newIDE/app/src/ExportAndShare/LocalExporters/LocalPreviewLauncher/index.js
@@ -461,8 +461,8 @@ export default class LocalPreviewLauncher extends React.Component<
         // reload the game when the same preview is re-exported.
         setGameplayTestFramePreviewLocation({
           previewIndexHtmlLocation: `file://${outputDir}/index.html?previewId=${previewId}`,
-          // The frame opens with a game window of the project resolution,
-          // displayed zoomed out.
+          // The game window of the frame is fixed at the project
+          // resolution: the frame only zooms its display.
           gameResolution: {
             width: project.getGameResolutionWidth(),
             height: project.getGameResolutionHeight(),

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -65,62 +65,77 @@ const clampPositionToWindow = (
 
 // Game area width when the frame is opened: unobtrusive on top of the editor.
 const defaultGameAreaWidth = 320;
+// Below this, the header and footer of the frame become unusable.
 const minGameAreaSize = { width: 240, height: 135 };
 
-/**
- * The fixed zoom at which the game is displayed: the game window is always
- * `game area size / zoom`. Resizing the frame resizes the game window (like
- * resizing a preview window would), never the scale.
+/*
+ * The game window (the iframe running the preview) is always exactly the
+ * game resolution: the game runs as in a preview window of this size and
+ * can never observe the frame being moved, resized or minimized. The frame
+ * only displays it at a variable zoom - the only thing resizing changes.
+ * The aspect ratio of the game area is thus always the game one.
  */
-const getGameZoomFactor = (gameResolution: Size): number =>
-  // Never zoom in: a small game would only be displayed blurry.
-  Math.min(1, defaultGameAreaWidth / gameResolution.width);
 
-/** Game area size at which the game window is exactly the game resolution. */
-const getDefaultGameAreaSize = (gameResolution: Size): Size => {
-  const zoomFactor = getGameZoomFactor(gameResolution);
-  return {
-    width: Math.max(
-      minGameAreaSize.width,
-      Math.round(gameResolution.width * zoomFactor)
-    ),
-    height: Math.max(
-      minGameAreaSize.height,
-      Math.round(gameResolution.height * zoomFactor)
-    ),
-  };
-};
+/** The smallest zoom keeping the frame usable. */
+const getMinZoomFactor = (gameResolution: Size): number =>
+  Math.max(
+    minGameAreaSize.width / gameResolution.width,
+    minGameAreaSize.height / gameResolution.height
+  );
+
+/**
+ * The largest allowed zoom: 1 (a game displayed larger than its resolution
+ * would only be blurry), unless more is needed to reach the minimum frame
+ * size (for games with a tiny resolution).
+ */
+const getMaxZoomFactor = (gameResolution: Size): number =>
+  Math.max(1, getMinZoomFactor(gameResolution));
+
+/** The zoom used when the frame is opened for the first time. */
+const getDefaultZoomFactor = (gameResolution: Size): number =>
+  clamp(
+    defaultGameAreaWidth / gameResolution.width,
+    getMinZoomFactor(gameResolution),
+    getMaxZoomFactor(gameResolution)
+  );
+
+/** The size of the game area: the game resolution, displayed at this zoom. */
+const getGameAreaSize = (gameResolution: Size, zoomFactor: number): Size => ({
+  width: Math.round(gameResolution.width * zoomFactor),
+  height: Math.round(gameResolution.height * zoomFactor),
+});
+
 // Approximate height of the chrome around the game area, to clamp the
-// restored size before the frame is rendered (and can be measured).
+// restored zoom before the frame is rendered (and can be measured).
 const approximateFrameChromeHeight = 70;
 
 /**
- * Clamp the game area size so the frame fits in the window.
- * `chromeWidth`/`chromeHeight` are the size of the borders, header and
- * footer around the game area.
+ * Clamp the zoom so the frame fits in the window - unless even the minimum
+ * usable size does not (`clampPositionToWindow` then keeps the frame
+ * reachable). `chromeWidth`/`chromeHeight` are the size of the borders,
+ * header and footer around the game area.
  */
-const clampSizeToWindow = (
-  size: Size,
+const clampZoomFactorToWindow = (
+  zoomFactor: number,
+  gameResolution: Size,
   chromeWidth: number,
   chromeHeight: number
-): Size => ({
-  width: clamp(
-    size.width,
-    minGameAreaSize.width,
+): number => {
+  const fittingZoomFactor = Math.min(
+    (window.innerWidth - 2 * windowMargin - chromeWidth) / gameResolution.width,
+    (window.innerHeight - windowMargin - windowTopMargin - chromeHeight) /
+      gameResolution.height
+  );
+  const minZoomFactor = getMinZoomFactor(gameResolution);
+  return clamp(
+    zoomFactor,
+    minZoomFactor,
     Math.max(
-      minGameAreaSize.width,
-      window.innerWidth - 2 * windowMargin - chromeWidth
+      minZoomFactor,
+      Math.min(getMaxZoomFactor(gameResolution), fittingZoomFactor)
     )
-  ),
-  height: clamp(
-    size.height,
-    minGameAreaSize.height,
-    Math.max(
-      minGameAreaSize.height,
-      window.innerHeight - windowMargin - windowTopMargin - chromeHeight
-    )
-  ),
-});
+  );
+};
 
 type ResizeDirection =
   | 'left'
@@ -151,7 +166,10 @@ type GameplayTestFrameLayoutProps = {|
   isMinimized: boolean,
   onToggleMinimized: () => void,
   onStopRequested: () => void,
-  /** The game resolution, giving the display zoom (see `getGameZoomFactor`). */
+  /**
+   * The game resolution: the game window is fixed at exactly this size,
+   * the frame only displays it zoomed.
+   */
   gameResolution: Size,
   /**
    * The game itself (an iframe running the preview). It is always rendered,
@@ -181,9 +199,8 @@ export const GameplayTestFrameLayout = ({
   const {
     values,
     setGameplayTestFramePosition,
-    setGameplayTestFrameSize,
+    setGameplayTestFrameZoomFactor,
   } = React.useContext(PreferencesContext);
-  const zoomFactor = getGameZoomFactor(gameResolution);
   // Restore the last position of the frame (it will be clamped to the window
   // as soon as it is rendered, in case the window is now smaller).
   const [position, setPosition] = React.useState<Position>(
@@ -193,12 +210,17 @@ export const GameplayTestFrameLayout = ({
         bottom: windowMargin,
       }
   );
-  // Restore the last size, clamped in case the window is now smaller.
-  const [size, setSize] = React.useState<Size>(() => {
-    const savedSize = values.gameplayTestFrameSize;
-    if (!savedSize) return getDefaultGameAreaSize(gameResolution);
-    return clampSizeToWindow(savedSize, 0, approximateFrameChromeHeight);
-  });
+  // Restore the last zoom, clamped in case the window is now smaller (or
+  // this project has a larger game resolution).
+  const [zoomFactor, setZoomFactor] = React.useState<number>(() =>
+    clampZoomFactorToWindow(
+      values.gameplayTestFrameZoomFactor ||
+        getDefaultZoomFactor(gameResolution),
+      gameResolution,
+      0,
+      approximateFrameChromeHeight
+    )
+  );
   const [isDragging, setIsDragging] = React.useState<boolean>(false);
   const [isResizing, setIsResizing] = React.useState<boolean>(false);
   const dragOrigin = React.useRef<{|
@@ -212,6 +234,7 @@ export const GameplayTestFrameLayout = ({
     clientX: number,
     clientY: number,
     position: Position,
+    zoomFactor: number,
     size: Size,
     direction: ResizeDirection,
     /** Size of the chrome (borders, header, footer) around the game area. */
@@ -219,10 +242,9 @@ export const GameplayTestFrameLayout = ({
     chromeHeight: number,
   |} | null>(null);
 
-  // Keep the frame inside the window: shrink the game area if the window
-  // got too small for the frame (not when minimized: the game area is then
-  // 1x1 and the chrome around it can't be measured), then clamp the
-  // position.
+  // Keep the frame inside the window: zoom out if the window got too small
+  // for the frame (not when minimized: the game area is then 1x1 and the
+  // chrome around it can't be measured), then clamp the position.
   const keepFrameInsideWindow = React.useCallback(
     () => {
       const container = containerRef.current;
@@ -230,9 +252,10 @@ export const GameplayTestFrameLayout = ({
       if (!isMinimized && container && gameArea) {
         const containerRect = container.getBoundingClientRect();
         const gameAreaRect = gameArea.getBoundingClientRect();
-        setSize(size =>
-          clampSizeToWindow(
-            size,
+        setZoomFactor(zoomFactor =>
+          clampZoomFactorToWindow(
+            zoomFactor,
+            gameResolution,
             containerRect.width - gameAreaRect.width,
             containerRect.height - gameAreaRect.height
           )
@@ -240,7 +263,7 @@ export const GameplayTestFrameLayout = ({
       }
       setPosition(position => clampPositionToWindow(position, container));
     },
-    [isMinimized]
+    [isMinimized, gameResolution]
   );
 
   // Apply it when the window is resized, and when the frame is first
@@ -317,7 +340,8 @@ export const GameplayTestFrameLayout = ({
         clientX: event.clientX,
         clientY: event.clientY,
         position,
-        size,
+        zoomFactor,
+        size: getGameAreaSize(gameResolution, zoomFactor),
         direction,
         chromeWidth: containerRect.width - gameAreaRect.width,
         chromeHeight: containerRect.height - gameAreaRect.height,
@@ -326,69 +350,85 @@ export const GameplayTestFrameLayout = ({
       currentTarget.setPointerCapture(event.pointerId);
       setIsResizing(true);
     },
-    [position, size]
+    [position, zoomFactor, gameResolution]
   );
 
-  const onResizePointerMove = React.useCallback((event: PointerEvent) => {
-    const origin = resizeOrigin.current;
-    if (!origin || origin.pointerId !== event.pointerId) return;
+  const onResizePointerMove = React.useCallback(
+    (event: PointerEvent) => {
+      const origin = resizeOrigin.current;
+      if (!origin || origin.pointerId !== event.pointerId) return;
 
-    const deltaX = event.clientX - origin.clientX;
-    const deltaY = event.clientY - origin.clientY;
-    const newSize = { ...origin.size };
-    const newPosition = { ...origin.position };
+      // The aspect ratio is fixed (it is the game one): resizing only
+      // changes the zoom. Moving the pointer outwards zooms in.
+      const deltaX = event.clientX - origin.clientX;
+      const deltaY = event.clientY - origin.clientY;
+      const widthDelta = origin.direction.includes('left')
+        ? -deltaX
+        : origin.direction.includes('right')
+        ? deltaX
+        : 0;
+      const heightDelta = origin.direction.includes('top')
+        ? -deltaY
+        : origin.direction.includes('bottom')
+        ? deltaY
+        : 0;
+      const zoomFactorFromWidth =
+        origin.zoomFactor + widthDelta / gameResolution.width;
+      const zoomFactorFromHeight =
+        origin.zoomFactor + heightDelta / gameResolution.height;
+      // On corners, follow the axis on which the pointer moved the most.
+      const newZoomFactor =
+        Math.abs(zoomFactorFromWidth - origin.zoomFactor) >=
+        Math.abs(zoomFactorFromHeight - origin.zoomFactor)
+          ? zoomFactorFromWidth
+          : zoomFactorFromHeight;
 
-    if (origin.direction.includes('right')) {
-      // The left border stays in place: only the width changes.
-      const maxWidth =
-        window.innerWidth -
-        windowMargin -
-        origin.position.left -
-        origin.chromeWidth;
-      newSize.width = clamp(
-        origin.size.width + deltaX,
-        minGameAreaSize.width,
-        Math.max(minGameAreaSize.width, maxWidth)
+      // The window space available for the two moving edges to grow into
+      // (the two others are anchored and stay in place).
+      const maxWidth = origin.direction.includes('left')
+        ? origin.size.width + origin.position.left - windowMargin
+        : window.innerWidth -
+          windowMargin -
+          origin.position.left -
+          origin.chromeWidth;
+      const maxHeight = origin.direction.includes('bottom')
+        ? origin.size.height + origin.position.bottom - windowMargin
+        : window.innerHeight -
+          windowTopMargin -
+          origin.position.bottom -
+          origin.chromeHeight;
+      const minZoomFactor = getMinZoomFactor(gameResolution);
+      const clampedZoomFactor = clamp(
+        newZoomFactor,
+        minZoomFactor,
+        Math.max(
+          minZoomFactor,
+          Math.min(
+            getMaxZoomFactor(gameResolution),
+            maxWidth / gameResolution.width,
+            maxHeight / gameResolution.height
+          )
+        )
       );
-    } else if (origin.direction.includes('left')) {
-      // The right border stays in place: the frame moves as it grows.
-      const maxWidth = origin.size.width + origin.position.left - windowMargin;
-      newSize.width = clamp(
-        origin.size.width - deltaX,
-        minGameAreaSize.width,
-        Math.max(minGameAreaSize.width, maxWidth)
-      );
-      newPosition.left =
-        origin.position.left + (origin.size.width - newSize.width);
-    }
-    if (origin.direction.includes('top')) {
-      // Anchored to the window bottom: the frame grows upwards without moving.
-      const maxHeight =
-        window.innerHeight -
-        windowTopMargin -
-        origin.position.bottom -
-        origin.chromeHeight;
-      newSize.height = clamp(
-        origin.size.height - deltaY,
-        minGameAreaSize.height,
-        Math.max(minGameAreaSize.height, maxHeight)
-      );
-    } else if (origin.direction.includes('bottom')) {
-      // The top border stays in place: the frame moves down as it grows.
-      const maxHeight =
-        origin.size.height + origin.position.bottom - windowMargin;
-      newSize.height = clamp(
-        origin.size.height + deltaY,
-        minGameAreaSize.height,
-        Math.max(minGameAreaSize.height, maxHeight)
-      );
-      newPosition.bottom =
-        origin.position.bottom - (newSize.height - origin.size.height);
-    }
 
-    setSize(newSize);
-    setPosition(newPosition);
-  }, []);
+      // Keep the anchored edges in place: growing from the left moves the
+      // frame left, growing from the bottom moves it down.
+      const newSize = getGameAreaSize(gameResolution, clampedZoomFactor);
+      const newPosition = { ...origin.position };
+      if (origin.direction.includes('left')) {
+        newPosition.left =
+          origin.position.left + (origin.size.width - newSize.width);
+      }
+      if (origin.direction.includes('bottom')) {
+        newPosition.bottom =
+          origin.position.bottom - (newSize.height - origin.size.height);
+      }
+
+      setZoomFactor(clampedZoomFactor);
+      setPosition(newPosition);
+    },
+    [gameResolution]
+  );
 
   const onResizePointerUp = React.useCallback(
     (event: PointerEvent) => {
@@ -397,27 +437,23 @@ export const GameplayTestFrameLayout = ({
 
       resizeOrigin.current = null;
       setIsResizing(false);
-      setGameplayTestFrameSize(size);
+      setGameplayTestFrameZoomFactor(zoomFactor);
       // Resizing from the left or bottom edges also moves the frame.
       setGameplayTestFramePosition(position);
     },
-    [size, setGameplayTestFrameSize, position, setGameplayTestFramePosition]
+    [
+      zoomFactor,
+      setGameplayTestFrameZoomFactor,
+      position,
+      setGameplayTestFramePosition,
+    ]
   );
 
   const isInProgress = runStatus
     ? isGameplayTestStatusInProgress(runStatus.status)
     : false;
 
-  // Cancel any resize in progress when a test starts.
-  React.useEffect(
-    () => {
-      if (isInProgress) {
-        resizeOrigin.current = null;
-        setIsResizing(false);
-      }
-    },
-    [isInProgress]
-  );
+  const gameAreaSize = getGameAreaSize(gameResolution, zoomFactor);
 
   return (
     <div
@@ -498,18 +534,23 @@ export const GameplayTestFrameLayout = ({
         })}
         style={
           // When minimized, let the CSS shrink the game area to 1x1 pixel.
-          isMinimized ? undefined : { width: size.width, height: size.height }
+          isMinimized
+            ? undefined
+            : { width: gameAreaSize.width, height: gameAreaSize.height }
         }
       >
-        {/* The game window: the game area at 1:1 scale, displayed zoomed
-            out - the game runs like in a preview window of this size. When
-            minimized it is only clipped, so the game keeps rendering and
-            the test keeps running. */}
+        {/* The game window: always exactly the game resolution, only its
+            displayed zoom changes - the game runs as in a preview window of
+            this size and cannot observe the frame being moved, resized or
+            minimized (minimizing only clips it, so the game keeps rendering
+            and the test keeps running). Only the test itself can change the
+            game resolution (see `setGameResolutionSize` in the harness):
+            the game is then displayed fitted in this same window. */}
         <div
           className={classes.gameScaler}
           style={{
-            width: Math.round(size.width / zoomFactor),
-            height: Math.round(size.height / zoomFactor),
+            width: gameResolution.width,
+            height: gameResolution.height,
             transform: `translate(-50%, -50%) scale(${zoomFactor})`,
           }}
         >
@@ -540,10 +581,10 @@ export const GameplayTestFrameLayout = ({
           </Text>
         )}
       </div>
-      {/* Resizing resizes the game window, which would skew a running
-          test: only allow it when no test is in progress. */}
+      {/* Resizing only changes the zoom at which the game is displayed:
+          the game cannot observe it, so it is harmless even while a test
+          is running. */}
       {!isMinimized &&
-        !isInProgress &&
         resizeHandles.map(({ direction, className }) => (
           <div
             key={direction}
@@ -579,8 +620,8 @@ export const setGameplayTestFramePreviewLocation = ({
 }: {|
   previewIndexHtmlLocation: string,
   /**
-   * The game resolution: the frame opens with the game window at exactly
-   * this size (see `getGameZoomFactor`).
+   * The game resolution: the game window is fixed at exactly this size,
+   * the frame only displays it zoomed.
    */
   gameResolution: Size,
 |}) => {

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
@@ -156,8 +156,8 @@
 }
 
 /*
- * Holds the game window: sized 1:1 and only zoomed out to fit the game area
- * (see `getGameZoomFactor`).
+ * Holds the game window: always sized at exactly the game resolution, and
+ * only scaled to be displayed at the frame zoom.
  */
 .gameScaler {
   position: absolute;

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesContext.js
@@ -250,7 +250,7 @@ export type PreferencesValues = {|
   gamesDashboardOrderBy: GamesDashboardOrderBy,
   takeScreenshotOnPreview: boolean,
   gameplayTestFramePosition: {| left: number, bottom: number |} | null,
-  gameplayTestFrameSize: {| width: number, height: number |} | null,
+  gameplayTestFrameZoomFactor: number | null,
   showAiAskButtonInTitleBar: boolean,
   automaticallyUseCreditsForAiRequests: boolean,
   automaticallyApplyAiRequestEditsByProjectId: { [string]: boolean },
@@ -381,10 +381,7 @@ export type Preferences = {|
     left: number,
     bottom: number,
   |}) => void,
-  setGameplayTestFrameSize: (size: {|
-    width: number,
-    height: number,
-  |}) => void,
+  setGameplayTestFrameZoomFactor: (zoomFactor: number) => void,
   setShowAiAskButtonInTitleBar: (enabled: boolean) => void,
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => void,
   setAutomaticallyApplyAiRequestEditsForProjectId: (
@@ -455,7 +452,7 @@ export const initialPreferences = {
     gamesDashboardOrderBy: 'lastModifiedAt',
     takeScreenshotOnPreview: true,
     gameplayTestFramePosition: null,
-    gameplayTestFrameSize: null,
+    gameplayTestFrameZoomFactor: null,
     showAiAskButtonInTitleBar: true,
     automaticallyUseCreditsForAiRequests: false,
     automaticallyApplyAiRequestEditsByProjectId: {},
@@ -549,7 +546,7 @@ export const initialPreferences = {
     left: number,
     bottom: number,
   |}) => {},
-  setGameplayTestFrameSize: (size: {| width: number, height: number |}) => {},
+  setGameplayTestFrameZoomFactor: (zoomFactor: number) => {},
   setShowAiAskButtonInTitleBar: (enabled: boolean) => {},
   setAutomaticallyUseCreditsForAiRequests: (enabled: boolean) => {},
   setAutomaticallyApplyAiRequestEditsForProjectId: (

--- a/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
+++ b/newIDE/app/src/MainFrame/Preferences/PreferencesProvider.js
@@ -135,7 +135,7 @@ export const getInitialPreferences = (): {
   showInAppTutorialDeveloperMode: boolean,
   takeScreenshotOnPreview: boolean,
   gameplayTestFramePosition: {| left: number, bottom: number |} | null,
-  gameplayTestFrameSize: {| width: number, height: number |} | null,
+  gameplayTestFrameZoomFactor: number | null,
   themeName: any,
   use3DEditor: any,
   useBackgroundSerializerForSaving: boolean,
@@ -402,7 +402,9 @@ export default class PreferencesProvider extends React.Component<Props, State> {
       this
     ): any),
     // $FlowFixMe[method-unbinding]
-    setGameplayTestFrameSize: (this._setGameplayTestFrameSize.bind(this): any),
+    setGameplayTestFrameZoomFactor: (this._setGameplayTestFrameZoomFactor.bind(
+      this
+    ): any),
     // $FlowFixMe[method-unbinding]
     setShowAiAskButtonInTitleBar: (this._setShowAiAskButtonInTitleBar.bind(
       this
@@ -1428,12 +1430,12 @@ export default class PreferencesProvider extends React.Component<Props, State> {
     );
   }
 
-  _setGameplayTestFrameSize(newValue: {| width: number, height: number |}) {
+  _setGameplayTestFrameZoomFactor(newValue: number) {
     this.setState(
       state => ({
         values: {
           ...state.values,
-          gameplayTestFrameSize: newValue,
+          gameplayTestFrameZoomFactor: newValue,
         },
       }),
       () => this._persistValuesToLocalStorage(this.state)

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
@@ -26,7 +26,8 @@ const styles = {
     alignItems: 'flex-end',
     background: 'linear-gradient(to bottom, #4f28cd, #95c6ff)',
   },
-  // Sized for the fake game resolution below (displayed zoomed out by 4).
+  // Sized for the fake game resolution below (displayed zoomed out by 4
+  // when the frame is at its default size).
   fakeGameGround: {
     width: '100%',
     height: 128,


### PR DESCRIPTION
The game window (the iframe running the preview) is now always exactly the game resolution: the game runs as in a preview window of the project resolution and cannot observe the frame being moved, resized or minimized. Resizing the frame only changes the zoom at which this fixed window is displayed (keeping the game aspect ratio), so it is now also allowed while a test is running. The zoom is remembered in the preferences instead of the frame size.

The only way the game resolution changes during a test is the test itself deliberately calling setGameResolutionSize on the harness (the game is then displayed fitted in the same window).


Claude-Session: https://claude.ai/code/session_01FtXm4V5RxmvRaA6gtK4Y7q