### PR TITLE
Keep the editor working when it is not looked at (agent, gameplay tests)

### DIFF
--- a/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
+++ b/GDJS/Runtime/gameplay-tests/gameplay-test-runner.ts
@@ -312,6 +312,12 @@ namespace gdjs {
        * (`durationMs - loadingMs` close to it means the test is at risk of
        * timing out on a slower machine). */
       timeoutMs: number;
+      /** Time during which the game was frozen by the browser because the
+       * page was hidden (tab in the background, window minimized or covered
+       * by another one): animation frames stop, so the game stops stepping.
+       * Excluded from the `timeoutMs` budget - being looked away from is
+       * not a reason for a test to fail. */
+      hiddenStallMs: number;
       gameTimeMs: number;
       assertions: Array<GameplayTestAssertion>;
       errors: Array<string>;
@@ -541,6 +547,17 @@ namespace gdjs {
       /** Time spent waiting for loading (game boot, scene assets) so far:
        * excluded from the `_timeoutMs` budget, reported as `loadingMs`. */
       _loadingTimeMs: number = 0;
+      /** Time already spent frozen by the browser because the page was
+       * hidden, excluded from the `_timeoutMs` budget (see
+       * `_installPageVisibilityTracking`). */
+      _hiddenStallTimeMs: number = 0;
+      /** When the page became hidden, while it still is, or null. */
+      _hiddenSinceMs: number | null = null;
+      /** When the last game frame was stepped: tells apart a page that is
+       * hidden AND frozen from one that is only hidden (in the desktop app,
+       * background throttling is disabled and the game keeps running). */
+      _lastFrameStepTimeMs: number = 0;
+      _uninstallPageVisibilityTracking: () => void = () => {};
       _maxFrames: integer;
       /** Last time the stepping loop yielded to the browser (see
        * `_maybeYield`). */
@@ -650,6 +667,60 @@ namespace gdjs {
         }
       }
 
+      /**
+       * Track the time during which the game is frozen because the page is
+       * hidden, so that it can be excluded from the `_timeoutMs` budget.
+       *
+       * Browsers stop `requestAnimationFrame` in a hidden page (a tab in
+       * the background, a minimized window, or - with Chrome's occlusion
+       * detection - a window entirely covered by another one). The test
+       * loop steps frames from animation frames, so the game simply stops:
+       * without this, a test would be reported as timing out just because
+       * the user looked at something else while it ran.
+       *
+       * Being hidden is not enough to conclude the game was frozen: the
+       * desktop app disables background throttling, and the game then keeps
+       * running while hidden. So only the time after the last stepped frame
+       * is counted as a stall.
+       */
+      _installPageVisibilityTracking(): void {
+        if (typeof document === 'undefined') return;
+
+        const onVisibilityChanged = () => {
+          if (document.visibilityState === 'hidden') {
+            this._hiddenSinceMs = Date.now();
+          } else {
+            this._hiddenStallTimeMs += this._getOngoingHiddenStallMs();
+            this._hiddenSinceMs = null;
+          }
+        };
+        if (document.visibilityState === 'hidden') {
+          this._hiddenSinceMs = Date.now();
+        }
+        document.addEventListener('visibilitychange', onVisibilityChanged);
+        this._uninstallPageVisibilityTracking = () => {
+          document.removeEventListener('visibilitychange', onVisibilityChanged);
+          this._uninstallPageVisibilityTracking = () => {};
+        };
+      }
+
+      /** The stall of the hidden period currently in progress, if any. */
+      private _getOngoingHiddenStallMs(): number {
+        if (this._hiddenSinceMs === null) return 0;
+        // Frames stepped while hidden are frames the game was not frozen
+        // for: the stall only starts after the last of them.
+        const stallStartTimeMs = Math.max(
+          this._hiddenSinceMs,
+          this._lastFrameStepTimeMs
+        );
+        return Math.max(0, Date.now() - stallStartTimeMs);
+      }
+
+      /** Total time the game was frozen because the page was hidden. */
+      _getHiddenStallTimeMs(): number {
+        return this._hiddenStallTimeMs + this._getOngoingHiddenStallMs();
+      }
+
       private _checkGuards(): void {
         if (this._stopped) {
           throw new GameplayTestStoppedError('The test was stopped.');
@@ -660,12 +731,15 @@ namespace gdjs {
           );
         }
         if (
-          Date.now() - this._startTimeMs - this._loadingTimeMs >
+          Date.now() -
+            this._startTimeMs -
+            this._loadingTimeMs -
+            this._getHiddenStallTimeMs() >
           this._timeoutMs
         ) {
           throw new GameplayTestTimeoutError(
             `The test timed out after ${this._timeoutMs}ms ` +
-              '(wall-clock, loading time excluded).'
+              '(wall-clock, loading and time spent hidden excluded).'
           );
         }
       }
@@ -856,6 +930,7 @@ namespace gdjs {
         this._framesExecuted++;
         this._gameTimeMs += dtMs;
         const stepTimeMs = Date.now() - stepStartTimeMs;
+        this._lastFrameStepTimeMs = stepStartTimeMs + stepTimeMs;
         this._totalStepTimeMs += stepTimeMs;
         if (stepTimeMs > this._worstStepTimeMs) {
           this._worstStepTimeMs = stepTimeMs;
@@ -2896,6 +2971,7 @@ namespace gdjs {
           durationMs: this._startTimeMs ? Date.now() - this._startTimeMs : 0,
           loadingMs: Math.round(this._loadingTimeMs),
           timeoutMs: this._timeoutMs,
+          hiddenStallMs: Math.round(this._getHiddenStallTimeMs()),
           gameTimeMs: Math.round(this._gameTimeMs),
           assertions: this._assertions,
           errors: errors.slice(0, MAX_ERRORS),
@@ -3056,6 +3132,10 @@ namespace gdjs {
 
       harness._installPointerLockShim();
       harness._installSoundLog();
+      // Only from now on: the boot wait above is already excluded from the
+      // `timeoutMs` budget, as loading time.
+      harness._lastFrameStepTimeMs = Date.now();
+      harness._installPageVisibilityTracking();
 
       // Capture the logs of the game itself (in addition to the `console`
       // passed to the script).
@@ -3192,6 +3272,7 @@ namespace gdjs {
           // Ignore errors during cleanup.
         }
         inputManager.onFrameEnded = originalOnFrameEnded;
+        harness._uninstallPageVisibilityTracking();
         harness._uninstallPointerLockShim();
         harness._uninstallSoundLog();
         harness._uninstallGameWindowSizeOverride();

--- a/newIDE/app/src/AiGeneration/AiRequestContext.js
+++ b/newIDE/app/src/AiGeneration/AiRequestContext.js
@@ -18,6 +18,8 @@ import { useAsyncLazyMemo } from '../Utils/UseLazyMemo';
 import { retryIfFailed } from '../Utils/RetryIfFailed';
 import { useInterval } from '../Utils/UseInterval';
 import { useAdaptivePollingInterval } from '../Utils/UseAdaptivePollingInterval';
+import { usePageBecameVisible } from '../Utils/PageVisibility';
+import { useKeepPageActive } from '../Utils/UseKeepPageActive';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import {
   aiRequestShouldBeWatched,
@@ -942,14 +944,34 @@ export const AiRequestProvider = ({
     reportWatchPollingTick(sawChangeThisTick);
   };
 
+  // Kept in a ref so the visibility effect below can run the latest watch
+  // loop without re-registering a listener on every render.
+  const onWatchRef = React.useRef(onWatch);
+  onWatchRef.current = onWatch;
+
+  const isWatching =
+    (shouldWatchRequest || hasActiveSubAgents) && !pendingEditApproval;
+
   useInterval(
     () => {
       onWatch();
     },
-    (shouldWatchRequest || hasActiveSubAgents) && !pendingEditApproval
-      ? currentWatchPollingIntervalInMs
-      : null
+    isWatching ? currentWatchPollingIntervalInMs : null
   );
+
+  // Catch up immediately when the user comes back to the editor. While the
+  // page is hidden, the browser throttles the watch loop (down to one wake
+  // up per minute after a few minutes in the background), and the adaptive
+  // interval has had every reason to back off to its maximum: without this,
+  // returning to the editor would show a stale conversation for seconds.
+  usePageBecameVisible(() => {
+    if (!isWatching) return;
+    resetWatchPollingInterval();
+    // Force the next tick to be a full fetch, so the messages produced
+    // while the editor was in the background are all picked up at once.
+    lastFullFetchTimeRef.current = 0;
+    onWatchRef.current();
+  });
 
   // Clear sub-agents when the parent request is suspended.
   React.useEffect(
@@ -1037,6 +1059,13 @@ export const AiRequestProvider = ({
     },
     [selectedAiRequest, getEditorFunctionCallResults]
   );
+
+  // Keep the app running at full speed while the AI is working, even if the
+  // user goes to another tab or covers the window: the whole agent loop
+  // (polling for the next turn, running the editor functions, sending their
+  // results back) lives in this page, so a throttled or frozen page means a
+  // paused AI request.
+  useKeepPageActive(!!getWorkingAiRequest());
 
   const suspendAiRequest = React.useCallback(
     async (aiRequestId: string): Promise<void> => {

--- a/newIDE/app/src/EditorFunctions/GameplayTestTools.js
+++ b/newIDE/app/src/EditorFunctions/GameplayTestTools.js
@@ -50,6 +50,26 @@ const makeGameplayTestOutput = (
   didModifyProject: boolean,
   executedSource: string | null
 ): EditorFunctionGenericOutput => {
+  // The run never finished because the editor was left in the background,
+  // where the browser stops running games. Nothing was learned about the
+  // game: say so as explicitly as possible, so that this is never read as a
+  // failing test and "fixed" by changing a game that is fine.
+  if (result.status === 'paused') {
+    return {
+      success: false,
+      ...makeGameplayTestResultReadableOutput(result),
+      message:
+        'The test was PAUSED, not failed: it could not run to the end ' +
+        'because the GDevelop window was in the background (browsers stop ' +
+        'running games in a hidden tab or a covered window). This result ' +
+        'says nothing about the game. Do NOT change the game, the test or ' +
+        'anything else because of it, and do not report it as a problem: ' +
+        'run the test again, and tell the user to keep the GDevelop window ' +
+        'visible while gameplay tests run.',
+      meta: didModifyProject ? { didModifyProject: true } : undefined,
+    };
+  }
+
   return {
     success: result.status === 'passed',
     ...makeGameplayTestResultReadableOutput(result),

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.js
@@ -10,6 +10,7 @@ import MinimizeIcon from '../UI/CustomSvgIcons/Minimize';
 import MaximizeIcon from '../UI/CustomSvgIcons/Maximize';
 import StopIcon from '../UI/CustomSvgIcons/Stop';
 import CrossIcon from '../UI/CustomSvgIcons/Cross';
+import PauseIcon from '../UI/CustomSvgIcons/Pause';
 import {
   formatRunDuration,
   GameplayTestStatusChip,
@@ -18,6 +19,116 @@ import {
 } from './GameplayTestStatusIndicator';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
 import classes from './GameplayTestFrame.module.css';
+
+/**
+ * Why and for how long a run was frozen because the editor was in the
+ * background (see the banner below).
+ */
+export type GameplayTestFrameHiddenPause = {|
+  /** How long the game was frozen, in total. */
+  pausedMs: number,
+  /**
+   * Whether the run was given up on (it stayed frozen for too long) rather
+   * than resumed when the editor came back.
+   */
+  isRunInterrupted: boolean,
+|};
+
+// How long the "the test resumed by itself" banner stays before dismissing
+// itself. Long enough to be read after coming back to the editor.
+const RESUMED_BANNER_DURATION_MS = 12000;
+
+/**
+ * How long the run was paused, written for someone reading a message rather
+ * than for a report: "paused for 40 seconds", "paused for 3 minutes".
+ */
+const renderPausedDurationTitle = (pausedMs: number): React.Node => {
+  const seconds = Math.round(pausedMs / 1000);
+  if (seconds < 90) return <Trans>Test paused for {seconds} seconds</Trans>;
+
+  const minutes = Math.round(seconds / 60);
+  return <Trans>Test paused for {minutes} minutes</Trans>;
+};
+
+type HiddenPauseBannerProps = {|
+  hiddenPause: GameplayTestFrameHiddenPause,
+  onDismiss: () => void,
+|};
+
+/**
+ * Shown when a run was frozen because GDevelop was in the background: games
+ * are not run by the browser in a hidden tab or a covered window, so the
+ * test simply stopped progressing.
+ *
+ * This is the one thing that keeps a paused run from looking like a broken
+ * game: the user (or the AI) must understand that nothing failed, that the
+ * pause was not counted against the test, and what to do about it.
+ */
+export const GameplayTestHiddenPauseBanner = ({
+  hiddenPause,
+  onDismiss,
+}: HiddenPauseBannerProps): React.Node => {
+  const { pausedMs, isRunInterrupted } = hiddenPause;
+
+  // A run that resumed on its own needs no action: say what happened, then
+  // get out of the way. An interrupted one has to be run again, so it stays
+  // until it is dismissed.
+  React.useEffect(
+    () => {
+      if (isRunInterrupted) return;
+      const timeoutId = setTimeout(onDismiss, RESUMED_BANNER_DURATION_MS);
+      return () => clearTimeout(timeoutId);
+    },
+    [isRunInterrupted, onDismiss]
+  );
+
+  return (
+    <div
+      className={classNames({
+        [classes.hiddenPauseBanner]: true,
+        [classes.interrupted]: isRunInterrupted,
+      })}
+      role="status"
+    >
+      <span className={classes.hiddenPauseIcon}>
+        <PauseIcon />
+      </span>
+      <div className={classes.hiddenPauseText}>
+        <Text noMargin size="body-small" color="inherit">
+          {isRunInterrupted ? (
+            <Trans>Test paused - and not run to the end</Trans>
+          ) : (
+            renderPausedDurationTitle(pausedMs)
+          )}
+        </Text>
+        <Text noMargin size="body-small" color="secondary">
+          {isRunInterrupted ? (
+            <Trans>
+              GDevelop stayed in the background, where the browser stops running
+              games. This is not a test failure - run it again with this window
+              visible.
+            </Trans>
+          ) : (
+            <Trans>
+              GDevelop was in the background, where the browser stops running
+              games. The test picked up where it left off, and the pause is not
+              counted against it.
+            </Trans>
+          )}
+        </Text>
+      </div>
+      <IconButton size="small" tooltip={t`Dismiss`} onClick={onDismiss}>
+        <CrossIcon className={classes.headerIcon} />
+      </IconButton>
+      {!isRunInterrupted && (
+        <span
+          className={classes.hiddenPauseCountdown}
+          style={{ animationDuration: `${RESUMED_BANNER_DURATION_MS}ms` }}
+        />
+      )}
+    </div>
+  );
+};
 
 /** The status of the run displayed on the gameplay test frame. */
 export type GameplayTestFrameRunStatus = {|
@@ -163,6 +274,9 @@ const resizeHandles: Array<{|
 
 type GameplayTestFrameLayoutProps = {|
   runStatus: GameplayTestFrameRunStatus | null,
+  /** Set when the run was frozen because the editor was in the background. */
+  hiddenPause: GameplayTestFrameHiddenPause | null,
+  onDismissHiddenPause: () => void,
   isMinimized: boolean,
   onToggleMinimized: () => void,
   onStopRequested: () => void,
@@ -188,6 +302,8 @@ type GameplayTestFrameLayoutProps = {|
  */
 export const GameplayTestFrameLayout = ({
   runStatus,
+  hiddenPause,
+  onDismissHiddenPause,
   isMinimized,
   onToggleMinimized,
   onStopRequested,
@@ -526,6 +642,12 @@ export const GameplayTestFrameLayout = ({
           </IconButton>
         </div>
       </div>
+      {hiddenPause && (
+        <GameplayTestHiddenPauseBanner
+          hiddenPause={hiddenPause}
+          onDismiss={onDismissHiddenPause}
+        />
+      )}
       <div
         ref={gameAreaRef}
         className={classNames({
@@ -608,6 +730,9 @@ let onSetGameplayTestFramePreviewLocation:
 let onSetGameplayTestFrameRunStatus:
   | null
   | ((runStatus: GameplayTestFrameRunStatus | null) => void) = null;
+let onSetGameplayTestFrameHiddenPause:
+  | null
+  | ((hiddenPause: GameplayTestFrameHiddenPause | null) => void) = null;
 
 /**
  * Point the gameplay test frame to a preview (and show it).
@@ -651,6 +776,17 @@ export const setGameplayTestFrameRunStatus = (
   onSetGameplayTestFrameRunStatus(runStatus);
 };
 
+/**
+ * Show (or hide, with null) the banner telling that the run was frozen
+ * because GDevelop was in the background.
+ */
+export const setGameplayTestFrameHiddenPause = (
+  hiddenPause: GameplayTestFrameHiddenPause | null
+) => {
+  if (!onSetGameplayTestFrameHiddenPause) return;
+  onSetGameplayTestFrameHiddenPause(hiddenPause);
+};
+
 type Props = {|
   previewDebuggerServer: ?PreviewDebuggerServer,
   onStopRequested: () => void,
@@ -675,6 +811,10 @@ export const GameplayTestFrame = ({
     setRunStatus,
   ] = React.useState<GameplayTestFrameRunStatus | null>(null);
   const [isMinimized, setIsMinimized] = React.useState<boolean>(false);
+  const [
+    hiddenPause,
+    setHiddenPause,
+  ] = React.useState<GameplayTestFrameHiddenPause | null>(null);
   // Set together with the preview location, by the launcher starting the game.
   const [gameResolution, setGameResolution] = React.useState<Size | null>(null);
 
@@ -688,12 +828,17 @@ export const GameplayTestFrame = ({
       setIsMinimized(false);
       // Don't show the status of a previous run when the frame is closed
       // then shown again.
-      if (!newPreviewIndexHtmlLocation) setRunStatus(null);
+      if (!newPreviewIndexHtmlLocation) {
+        setRunStatus(null);
+        setHiddenPause(null);
+      }
     };
     onSetGameplayTestFrameRunStatus = setRunStatus;
+    onSetGameplayTestFrameHiddenPause = setHiddenPause;
     return () => {
       onSetGameplayTestFramePreviewLocation = null;
       onSetGameplayTestFrameRunStatus = null;
+      onSetGameplayTestFrameHiddenPause = null;
     };
   }, []);
 
@@ -729,6 +874,8 @@ export const GameplayTestFrame = ({
   return (
     <GameplayTestFrameLayout
       runStatus={runStatus}
+      hiddenPause={hiddenPause}
+      onDismissHiddenPause={() => setHiddenPause(null)}
       isMinimized={isMinimized}
       gameResolution={gameResolution}
       onToggleMinimized={() => setIsMinimized(!isMinimized)}
@@ -742,6 +889,7 @@ export const GameplayTestFrame = ({
           // the game running in it.
           setPreviewIndexHtmlLocation('');
           setRunStatus(null);
+          setHiddenPause(null);
         }
       }}
     >

--- a/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
+++ b/newIDE/app/src/GameplayTests/GameplayTestFrame.module.css
@@ -198,3 +198,139 @@
   background-color: var(--theme-surface-canvas-background-color);
   border-top: 1px solid var(--theme-dialog-separator-color);
 }
+
+/*
+ * The banner shown when the run was frozen because the editor was in the
+ * background: it is the only sign the user gets that nothing was wrong with
+ * their game, so it must be noticed - and read - as soon as they come back.
+ *
+ * `width: 0` with `min-width: 100%` keeps it from widening the frame: the
+ * frame is sized by the game area (`width: max-content` on the container),
+ * and a banner longer than the game would otherwise stretch it.
+ */
+.hiddenPauseBanner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 0;
+  min-width: 100%;
+  padding: 8px 4px 8px 10px;
+  overflow: hidden;
+  /* The tone color, used by the accent, the icon and the tint below. */
+  color: var(--theme-info-color);
+  background-color: color-mix(
+    in srgb,
+    currentColor 10%,
+    var(--theme-surface-alternate-canvas-background-color)
+  );
+  border-bottom: 1px solid
+    color-mix(in srgb, currentColor 35%, var(--theme-dialog-separator-color));
+  animation: gameplay-test-hidden-pause-in 260ms
+    cubic-bezier(0.16, 0.84, 0.44, 1);
+}
+
+.hiddenPauseBanner.interrupted {
+  color: var(--theme-warning-color);
+}
+
+/* A gradient bar on the left edge, tying the banner to its tone. */
+.hiddenPauseBanner::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: linear-gradient(
+    to bottom,
+    currentColor,
+    color-mix(in srgb, currentColor 25%, transparent)
+  );
+}
+
+@keyframes gameplay-test-hidden-pause-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hiddenPauseIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background-color: color-mix(in srgb, currentColor 18%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 30%, transparent);
+}
+
+.hiddenPauseIcon svg {
+  font-size: 14px;
+}
+
+/* A slow breathing halo, to catch the eye of someone coming back to the
+   editor without ever becoming distracting. */
+.hiddenPauseBanner:not(.interrupted) .hiddenPauseIcon {
+  animation: gameplay-test-hidden-pause-breathe 2.4s ease-in-out infinite;
+}
+
+@keyframes gameplay-test-hidden-pause-breathe {
+  0%,
+  100% {
+    box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 30%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 12%, transparent);
+  }
+}
+
+.hiddenPauseText {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+  /* Let the explanation wrap on as many lines as it needs. */
+  overflow-wrap: anywhere;
+  padding-top: 2px;
+}
+
+/* The countdown of the banner dismissing itself, so its disappearance is
+   never a surprise. */
+.hiddenPauseCountdown {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  width: 100%;
+  transform-origin: left center;
+  background-color: color-mix(in srgb, currentColor 45%, transparent);
+  animation: gameplay-test-hidden-pause-countdown linear forwards;
+}
+
+@keyframes gameplay-test-hidden-pause-countdown {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hiddenPauseBanner,
+  .hiddenPauseBanner:not(.interrupted) .hiddenPauseIcon,
+  .hiddenPauseCountdown {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+  }
+}

--- a/newIDE/app/src/GameplayTests/GameplayTestRunner.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestRunner.js
@@ -11,8 +11,13 @@ import {
 import {
   clearGameplayTestFramePreview,
   setGameplayTestFrameRunStatus,
+  setGameplayTestFrameHiddenPause,
   type GameplayTestFrameRunStatus,
 } from './GameplayTestFrame';
+import {
+  getIsPageHidden,
+  addPageVisibilityListener,
+} from '../Utils/PageVisibility';
 
 export type GameplayTestScope =
   | {| type: 'project' |}
@@ -37,7 +42,10 @@ export type GameplayTestAssertion = {|
 
 export type GameplayTestResult = {
   testName: string,
-  status: 'passed' | 'failed' | 'error' | 'stopped' | 'timeout',
+  // 'paused': the run was interrupted because the editor stayed in the
+  // background, where the browser stops running the game. Not a failure of
+  // the test: it must simply be run again.
+  status: 'passed' | 'failed' | 'error' | 'stopped' | 'timeout' | 'paused',
   framesExecuted: number,
   durationMs: number,
   // Time spent waiting for the game to boot and for scene assets to load,
@@ -47,6 +55,10 @@ export type GameplayTestResult = {
   // (`durationMs - loadingMs` close to it means the test is at risk of
   // timing out on a slower machine).
   timeoutMs: number,
+  // Time during which the game was frozen because the editor was in the
+  // background (browsers stop animation frames in a hidden page, so the
+  // game stops stepping). Excluded from the `timeoutMs` budget.
+  hiddenStallMs: number,
   gameTimeMs: number,
   assertions: Array<GameplayTestAssertion>,
   errors: Array<string>,
@@ -100,6 +112,15 @@ const GAMEPLAY_TEST_FRAME_DEBUGGER_ID = 'gameplay-test-frame';
 const GAME_READY_TIMEOUT_MS = 60 * 1000;
 const GAME_READY_POLL_INTERVAL_MS = 300;
 const RESULT_EXTRA_TIMEOUT_MS = 10 * 1000;
+// A silence shorter than this while the editor is in the background is not
+// considered a stall: the game sends progress every 500ms, so a quick tab
+// switch can pass unnoticed by the game.
+const HIDDEN_STALL_THRESHOLD_MS = 1500;
+// How long a run is allowed to stay frozen because the editor is in the
+// background before it is given up on (as 'paused', not as a failure).
+// Generous: the run resumes by itself as soon as the editor is looked at
+// again, and giving up means the test has to be run from the start.
+const MAX_HIDDEN_STALL_MS = 5 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 30 * 1000;
 // Paced runs are slow by design (a human is watching): give them room.
 // They can always be stopped with the stop button.
@@ -151,7 +172,7 @@ export const useIsGameplayTestRunInProgress = (): boolean => {
 
 const makeResultWithoutRun = (
   testName: string,
-  status: 'error' | 'stopped',
+  status: 'error' | 'stopped' | 'paused',
   errorMessage: string
 ): GameplayTestResult => ({
   testName,
@@ -160,6 +181,7 @@ const makeResultWithoutRun = (
   durationMs: 0,
   loadingMs: 0,
   timeoutMs: 0,
+  hiddenStallMs: 0,
   gameTimeMs: 0,
   assertions: [],
   errors: [errorMessage],
@@ -189,6 +211,7 @@ export const makeGameplayTestResultReadableOutput = (
   durationMs: result.durationMs,
   loadingMs: result.loadingMs,
   timeoutMs: result.timeoutMs,
+  hiddenStallMs: result.hiddenStallMs,
   gameTimeMs: result.gameTimeMs,
   assertions: result.assertions,
   errors: result.errors,
@@ -206,6 +229,27 @@ const makeStoppedResult = (testName: string): GameplayTestResult =>
     'stopped',
     'The test was not run because the run was stopped.'
   );
+
+/**
+ * The run was interrupted because the editor was left in the background:
+ * browsers stop animation frames in a hidden page, so the game stopped
+ * stepping and never finished. This says nothing about the game: the test
+ * has to be run again, with the editor visible.
+ */
+const makePausedResult = (
+  testName: string,
+  hiddenStallMs: number
+): GameplayTestResult => ({
+  ...makeResultWithoutRun(
+    testName,
+    'paused',
+    'The test did not finish: it was paused because GDevelop was left in ' +
+      'the background, where the browser stops running games. This is not a ' +
+      'test failure and says nothing about the game - run the test again ' +
+      'with the GDevelop window visible.'
+  ),
+  hiddenStallMs,
+});
 
 /**
  * Get the tests container for a scope ('project' or an extension name),
@@ -308,6 +352,71 @@ const waitForGameToBeReady = async (
   });
 };
 
+export type HiddenStallTracker = {|
+  /** Call on every sign of life from the game (a progress message). */
+  reportProgress: () => void,
+  /** Call when the editor goes to the background. */
+  reportHidden: () => void,
+  /**
+   * Call when the editor comes back. Returns how long the game was actually
+   * frozen during the period that just ended (0 when it kept running, or
+   * when the editor was only away for an instant).
+   */
+  reportVisible: () => number,
+  /** The total stall so far, hidden period in progress included. */
+  getTotalStallMs: () => number,
+|};
+
+/**
+ * Measures how long a run is frozen because the editor is in the
+ * background. Browsers stop animation frames in a hidden page, so the game
+ * stops stepping - but being hidden is not enough to conclude it was
+ * frozen: the desktop app disables background throttling, and the game then
+ * keeps running. Only the silence *after the last sign of life* counts.
+ */
+export const createHiddenStallTracker = ({
+  isHiddenAtStart,
+  getNowMs = () => Date.now(),
+}: {|
+  isHiddenAtStart: boolean,
+  getNowMs?: () => number,
+|}): HiddenStallTracker => {
+  let hiddenSinceMs: number | null = isHiddenAtStart ? getNowMs() : null;
+  let lastProgressAtMs = getNowMs();
+  let totalStallMs = 0;
+
+  /** The stall of the hidden period in progress, if any. */
+  const getOngoingStallMs = (): number => {
+    const startedBeingHiddenAtMs = hiddenSinceMs;
+    if (startedBeingHiddenAtMs === null) return 0;
+    return Math.max(
+      0,
+      getNowMs() - Math.max(startedBeingHiddenAtMs, lastProgressAtMs)
+    );
+  };
+
+  return {
+    reportProgress: () => {
+      lastProgressAtMs = getNowMs();
+    },
+    reportHidden: () => {
+      hiddenSinceMs = getNowMs();
+    },
+    reportVisible: () => {
+      if (hiddenSinceMs === null) return 0;
+      const stalledMs = getOngoingStallMs();
+      hiddenSinceMs = null;
+      // A short gap is not a stall: the game only heartbeats every 500ms,
+      // so a quick look at another tab can pass completely unnoticed.
+      if (stalledMs <= HIDDEN_STALL_THRESHOLD_MS) return 0;
+
+      totalStallMs += stalledMs;
+      return stalledMs;
+    },
+    getTotalStallMs: () => totalStallMs + getOngoingStallMs(),
+  };
+};
+
 const runSingleTest = async ({
   previewDebuggerServer,
   test,
@@ -331,6 +440,9 @@ const runSingleTest = async ({
 
   return new Promise(resolve => {
     let watchdogTimeoutId: ?TimeoutID = null;
+    const hiddenStallTracker = createHiddenStallTracker({
+      isHiddenAtStart: getIsPageHidden(),
+    });
     const unregisterCallbacks: () => void = previewDebuggerServer.registerCallbacks(
       {
         onErrorReceived: () => {},
@@ -354,6 +466,7 @@ const runSingleTest = async ({
             // The game is alive (stepping frames, or heartbeating while it
             // loads assets - loading is not counted against the test
             // timeout): give it a full budget again.
+            hiddenStallTracker.reportProgress();
             armWatchdog();
             if (onProgress && parsedMessage.payload) {
               onProgress(test, parsedMessage.payload.frame || 0);
@@ -371,8 +484,18 @@ const runSingleTest = async ({
 
     const finish = (result: GameplayTestResult) => {
       if (watchdogTimeoutId !== null) clearTimeout(watchdogTimeoutId);
+      unregisterVisibilityListener();
       unregisterCallbacks();
-      resolve(result);
+      resolve({
+        ...result,
+        // The game measures the same thing on its side; keep the longest,
+        // as each can miss a stall the other saw (the game is frozen while
+        // hidden, the editor only learns about it when it comes back).
+        hiddenStallMs: Math.max(
+          result.hiddenStallMs || 0,
+          hiddenStallTracker.getTotalStallMs()
+        ),
+      });
     };
 
     // An editor-side watchdog, in case the game dies without sending its
@@ -380,18 +503,64 @@ const runSingleTest = async ({
     // spends long over its own timeout while loading assets (loading is
     // excluded from the test budget), but it heartbeats while doing so - a
     // full silence is what means it crashed.
+    //
+    // Unless the editor is in the background: browsers then stop animation
+    // frames, so the game stops stepping and goes silent for a reason that
+    // has nothing to do with the game. The watchdog then waits much longer
+    // and gives up on the run as 'paused' rather than blaming the game.
     const armWatchdog = () => {
       if (watchdogTimeoutId !== null) clearTimeout(watchdogTimeoutId);
-      watchdogTimeoutId = setTimeout(() => {
-        finish(
-          makeErrorResult(
-            test.testName,
-            `No result nor progress received from the game after ${timeoutMs +
-              RESULT_EXTRA_TIMEOUT_MS}ms - the game may have crashed or been closed.`
-          )
-        );
-      }, timeoutMs + RESULT_EXTRA_TIMEOUT_MS);
+      const wasHidden = getIsPageHidden();
+      watchdogTimeoutId = setTimeout(
+        () => {
+          // Visibility changed while waiting (the timer itself is throttled
+          // in a hidden page, so it can fire long after it was armed): the
+          // budget that just elapsed was not the right one.
+          if (getIsPageHidden() !== wasHidden) {
+            armWatchdog();
+            return;
+          }
+          if (wasHidden) {
+            const totalHiddenStallMs = hiddenStallTracker.getTotalStallMs();
+            setGameplayTestFrameHiddenPause({
+              pausedMs: totalHiddenStallMs,
+              isRunInterrupted: true,
+            });
+            finish(makePausedResult(test.testName, totalHiddenStallMs));
+            return;
+          }
+          finish(
+            makeErrorResult(
+              test.testName,
+              `No result nor progress received from the game after ${timeoutMs +
+                RESULT_EXTRA_TIMEOUT_MS}ms - the game may have crashed or been closed.`
+            )
+          );
+        },
+        wasHidden ? MAX_HIDDEN_STALL_MS : timeoutMs + RESULT_EXTRA_TIMEOUT_MS
+      );
     };
+
+    // Follow the editor being hidden and shown again, to tell a frozen run
+    // apart from a crashed one and to nudge the user about it (see the
+    // banner on the gameplay test frame).
+    const unregisterVisibilityListener = addPageVisibilityListener(isHidden => {
+      if (isHidden) {
+        hiddenStallTracker.reportHidden();
+      } else if (hiddenStallTracker.reportVisible() > 0) {
+        // The game really was frozen while the editor was away: nudge the
+        // user about it, so a run that took much longer than it should - or
+        // a game that looks stuck on an old frame - is never a mystery.
+        setGameplayTestFrameHiddenPause({
+          pausedMs: hiddenStallTracker.getTotalStallMs(),
+          isRunInterrupted: false,
+        });
+      }
+      // The run only resumes when the editor is looked at again: give it a
+      // full budget from now on, not from when it was frozen.
+      armWatchdog();
+    });
+
     armWatchdog();
 
     const payload: Object = {
@@ -457,6 +626,7 @@ export const runGameplayTests = async ({
       // always loads in a fresh frame (and a stale game can never answer
       // in place of the new one).
       clearGameplayTestFramePreview();
+      setGameplayTestFrameHiddenPause(null);
 
       // Readable state for object/behavior snapshots, derived once per batch
       // from the extensions metadata.
@@ -599,6 +769,20 @@ export const runGameplayTests = async ({
             durationMs: result.durationMs,
           });
           results.push(result);
+
+          if (result.status === 'paused') {
+            // The editor is (still) in the background, so the game is not
+            // running: the remaining tests would all be paused the same
+            // way. Report them as such rather than pretending to run them.
+            for (const { test: remainingTest } of testsWithSources.slice(
+              testIndex + 1
+            )) {
+              results.push(
+                makePausedResult(remainingTest.testName, result.hiddenStallMs)
+              );
+            }
+            break;
+          }
         }
       } catch (error) {
         if (error.isStopRequested) {

--- a/newIDE/app/src/GameplayTests/GameplayTestRunner.spec.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestRunner.spec.js
@@ -1,0 +1,144 @@
+// @flow
+import { createHiddenStallTracker } from './GameplayTestRunner';
+
+describe('createHiddenStallTracker', () => {
+  /** A clock that can be moved forward by the test. */
+  const makeFakeClock = (startMs: number = 1000) => {
+    let nowMs = startMs;
+    return {
+      getNowMs: () => nowMs,
+      advanceBy: (durationMs: number) => {
+        nowMs += durationMs;
+      },
+    };
+  };
+
+  it('reports no stall when the editor is never hidden', () => {
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: false,
+      getNowMs: clock.getNowMs,
+    });
+
+    clock.advanceBy(5000);
+    tracker.reportProgress();
+
+    expect(tracker.getTotalStallMs()).toBe(0);
+  });
+
+  it('counts the time the game was frozen while the editor was hidden', () => {
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: false,
+      getNowMs: clock.getNowMs,
+    });
+
+    tracker.reportProgress();
+    tracker.reportHidden();
+    clock.advanceBy(30000);
+
+    expect(tracker.reportVisible()).toBe(30000);
+    expect(tracker.getTotalStallMs()).toBe(30000);
+  });
+
+  it('adds up several hidden periods', () => {
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: false,
+      getNowMs: clock.getNowMs,
+    });
+
+    tracker.reportHidden();
+    clock.advanceBy(10000);
+    tracker.reportVisible();
+
+    tracker.reportProgress();
+    clock.advanceBy(2000);
+    tracker.reportHidden();
+    clock.advanceBy(5000);
+    tracker.reportVisible();
+
+    expect(tracker.getTotalStallMs()).toBe(15000);
+  });
+
+  it('ignores a hidden period too short to have frozen anything', () => {
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: false,
+      getNowMs: clock.getNowMs,
+    });
+
+    tracker.reportProgress();
+    tracker.reportHidden();
+    clock.advanceBy(400);
+
+    expect(tracker.reportVisible()).toBe(0);
+    expect(tracker.getTotalStallMs()).toBe(0);
+  });
+
+  it('does not count a hidden period during which the game kept running', () => {
+    // What happens in the desktop app, where background throttling is
+    // disabled: the window is hidden, but the game keeps stepping and
+    // sending progress.
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: false,
+      getNowMs: clock.getNowMs,
+    });
+
+    tracker.reportHidden();
+    for (let i = 0; i < 20; i++) {
+      clock.advanceBy(500);
+      tracker.reportProgress();
+    }
+
+    expect(tracker.reportVisible()).toBe(0);
+    expect(tracker.getTotalStallMs()).toBe(0);
+  });
+
+  it('only counts the silence following the last sign of life', () => {
+    // The game stepped a few more frames after the editor was hidden,
+    // then froze: only the freeze is a stall.
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: false,
+      getNowMs: clock.getNowMs,
+    });
+
+    tracker.reportHidden();
+    clock.advanceBy(600);
+    tracker.reportProgress();
+    clock.advanceBy(20000);
+
+    expect(tracker.reportVisible()).toBe(20000);
+  });
+
+  it('counts a run started while the editor was already hidden', () => {
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: true,
+      getNowMs: clock.getNowMs,
+    });
+
+    clock.advanceBy(45000);
+
+    // The stall is readable before the editor comes back: this is what the
+    // watchdog uses to give up on a run as 'paused'.
+    expect(tracker.getTotalStallMs()).toBe(45000);
+    expect(tracker.reportVisible()).toBe(45000);
+    expect(tracker.getTotalStallMs()).toBe(45000);
+  });
+
+  it('reports nothing when the editor comes back without having been hidden', () => {
+    const clock = makeFakeClock();
+    const tracker = createHiddenStallTracker({
+      isHiddenAtStart: false,
+      getNowMs: clock.getNowMs,
+    });
+
+    clock.advanceBy(30000);
+
+    expect(tracker.reportVisible()).toBe(0);
+    expect(tracker.getTotalStallMs()).toBe(0);
+  });
+});

--- a/newIDE/app/src/GameplayTests/GameplayTestStatusIndicator.js
+++ b/newIDE/app/src/GameplayTests/GameplayTestStatusIndicator.js
@@ -12,6 +12,7 @@ import ErrorFilled from '../UI/CustomSvgIcons/ErrorFilled';
 import WarningRound from '../UI/CustomSvgIcons/WarningRound';
 import History from '../UI/CustomSvgIcons/History';
 import Stop from '../UI/CustomSvgIcons/Stop';
+import Pause from '../UI/CustomSvgIcons/Pause';
 
 /**
  * The status of a test as displayed in the editor: the statuses reported by
@@ -26,7 +27,11 @@ export type GameplayTestDisplayStatus =
   | 'failed'
   | 'error'
   | 'stopped'
-  | 'timeout';
+  | 'timeout'
+  // The run was frozen because GDevelop was left in the background (the
+  // browser stops running games in a hidden page) and did not finish. Says
+  // nothing about the game: not a failure.
+  | 'paused';
 
 export const getDisplayStatusFromTest = (
   test: gdTest
@@ -37,7 +42,8 @@ export const getDisplayStatusFromTest = (
     lastRunStatus === 'failed' ||
     lastRunStatus === 'error' ||
     lastRunStatus === 'stopped' ||
-    lastRunStatus === 'timeout'
+    lastRunStatus === 'timeout' ||
+    lastRunStatus === 'paused'
   ) {
     return lastRunStatus;
   }
@@ -64,6 +70,7 @@ const statusTones: { [GameplayTestDisplayStatus]: StatusChipTone } = {
   error: 'warning',
   stopped: 'neutral',
   timeout: 'warning',
+  paused: 'info',
 };
 
 export const getGameplayTestStatusLabel = (
@@ -80,6 +87,8 @@ export const getGameplayTestStatusLabel = (
       return <Trans>Stopped</Trans>;
     case 'timeout':
       return <Trans>Timed out</Trans>;
+    case 'paused':
+      return <Trans>Paused</Trans>;
     case 'launching':
       return <Trans>Starting the game...</Trans>;
     case 'running':
@@ -102,6 +111,8 @@ const renderStatusIcon = (status: GameplayTestDisplayStatus) => {
       return <History />;
     case 'stopped':
       return <Stop />;
+    case 'paused':
+      return <Pause />;
     case 'launching':
     case 'running':
       // The chip shows its own spinner for a status in progress.

--- a/newIDE/app/src/Utils/PageVisibility.js
+++ b/newIDE/app/src/Utils/PageVisibility.js
@@ -1,0 +1,68 @@
+// @flow
+import * as React from 'react';
+
+/**
+ * Whether the page is currently hidden: the browser tab is in the
+ * background, the window is minimized, or (on Chrome/Windows/macOS, thanks
+ * to native occlusion detection) the window is entirely covered by another
+ * one.
+ *
+ * This matters much more than it looks: while a page is hidden, browsers
+ * stop `requestAnimationFrame` entirely and throttle `setTimeout`/
+ * `setInterval` - down to a single wake up per minute once the page has
+ * been hidden for a few minutes ("intensive throttling"). Anything driven
+ * by a timer (like the AI agent watching loop) slows to a crawl, and
+ * anything driven by animation frames (like a game running in a gameplay
+ * test) stops altogether.
+ *
+ * In the desktop app, `backgroundThrottling` is disabled on the main window
+ * (see `newIDE/electron-app/app/main.js`), so timers and animation frames
+ * keep running even when this returns true.
+ */
+export const getIsPageHidden = (): boolean =>
+  typeof document !== 'undefined' && document.visibilityState === 'hidden';
+
+/**
+ * Listen to the page being hidden or shown. Returns the function to
+ * unregister the listener.
+ */
+export const addPageVisibilityListener = (
+  onVisibilityChanged: (isHidden: boolean) => void
+): (() => void) => {
+  if (typeof document === 'undefined') return () => {};
+
+  const listener = () => onVisibilityChanged(getIsPageHidden());
+  document.addEventListener('visibilitychange', listener);
+  return () => document.removeEventListener('visibilitychange', listener);
+};
+
+/**
+ * Call `onPageBecameVisible` every time the page becomes visible again
+ * (never on mount, even if the page is visible).
+ */
+export const usePageBecameVisible = (onPageBecameVisible: () => void) => {
+  // Kept in a ref so that a caller passing a new function on every render
+  // does not re-register the listener.
+  const callbackRef = React.useRef(onPageBecameVisible);
+  callbackRef.current = onPageBecameVisible;
+
+  React.useEffect(() => {
+    return addPageVisibilityListener(isHidden => {
+      if (!isHidden) callbackRef.current();
+    });
+  }, []);
+};
+
+/** Whether the page is hidden, as a piece of React state. */
+export const useIsPageHidden = (): boolean => {
+  const [isHidden, setIsHidden] = React.useState<boolean>(getIsPageHidden);
+
+  React.useEffect(() => {
+    // The page may have changed visibility between the first render and
+    // this effect.
+    setIsHidden(getIsPageHidden());
+    return addPageVisibilityListener(setIsHidden);
+  }, []);
+
+  return isHidden;
+};

--- a/newIDE/app/src/Utils/UseKeepPageActive.js
+++ b/newIDE/app/src/Utils/UseKeepPageActive.js
@@ -1,0 +1,124 @@
+// @flow
+import * as React from 'react';
+import optionalRequire from './OptionalRequire';
+
+const electron = optionalRequire('electron');
+
+/**
+ * Browsers stop `requestAnimationFrame` and throttle timers in a hidden
+ * page - down to one wake up per minute once it has been hidden for a few
+ * minutes - and can even freeze it entirely to save memory or battery.
+ * A page that is playing audio is exempted from all of this.
+ *
+ * So, to keep long running work (the AI agent) going while the user looks
+ * at something else, we play a tone that is inaudible in practice but not
+ * digitally silent: Chromium decides that a page is audible by measuring
+ * the power of what it outputs (anything under about -72 dBFS counts as
+ * silence), so a perfectly silent - or muted - source would be ignored.
+ *
+ * -60 dBFS at 40Hz: two orders of magnitude below the quietest sound of a
+ * game, at the very bottom of the audible spectrum. It cannot be heard, but
+ * it is loud enough for the browser to consider the page active.
+ */
+const KEEP_PAGE_ACTIVE_GAIN = 0.001;
+const KEEP_PAGE_ACTIVE_FREQUENCY = 40;
+
+// A single audio context is used for the whole app: creating one is costly,
+// and browsers limit how many can exist at the same time.
+let audioContext: ?AudioContext = null;
+let oscillator: ?OscillatorNode = null;
+let hasLoggedFailure = false;
+
+const getAudioContext = (): ?AudioContext => {
+  if (audioContext) return audioContext;
+
+  const AudioContextConstructor =
+    typeof window !== 'undefined'
+      ? window.AudioContext || window.webkitAudioContext
+      : null;
+  if (!AudioContextConstructor) return null;
+
+  try {
+    audioContext = new AudioContextConstructor();
+    return audioContext;
+  } catch (error) {
+    console.warn('Could not create an audio context to keep the page active.');
+    return null;
+  }
+};
+
+const startKeepingPageActive = () => {
+  if (oscillator) return;
+
+  const context = getAudioContext();
+  if (!context) return;
+
+  try {
+    const newOscillator = context.createOscillator();
+    const gainNode = context.createGain();
+    gainNode.gain.value = KEEP_PAGE_ACTIVE_GAIN;
+    newOscillator.frequency.value = KEEP_PAGE_ACTIVE_FREQUENCY;
+    newOscillator.connect(gainNode);
+    gainNode.connect(context.destination);
+    newOscillator.start();
+    oscillator = newOscillator;
+
+    // Autoplay policies start an audio context suspended until the page
+    // has been interacted with. In practice there always was an
+    // interaction (the user sent a request to the AI), but if the context
+    // stays suspended, nothing is played and the page will be throttled as
+    // usual: degraded, not broken.
+    if (context.state === 'suspended') {
+      context.resume().catch(() => {
+        if (hasLoggedFailure) return;
+        hasLoggedFailure = true;
+        console.info(
+          'Could not resume the audio context keeping the page active: the app will be throttled by the browser if left in the background.'
+        );
+      });
+    }
+  } catch (error) {
+    if (hasLoggedFailure) return;
+    hasLoggedFailure = true;
+    console.warn('Could not keep the page active:', error);
+  }
+};
+
+const stopKeepingPageActive = () => {
+  const startedOscillator = oscillator;
+  if (!startedOscillator) return;
+
+  oscillator = null;
+  try {
+    startedOscillator.stop();
+    startedOscillator.disconnect();
+  } catch (error) {
+    // The oscillator was already stopped: nothing to do.
+  }
+};
+
+/**
+ * While `shouldKeepPageActive` is true, prevent the browser from throttling
+ * or freezing the app when it is not looked at (tab in the background,
+ * window minimized or covered by another one).
+ *
+ * Use it only for work that must keep going while the user is away (an AI
+ * request being processed): it makes the tab show the "playing audio"
+ * indicator, and keeping a page fully awake in the background costs
+ * battery.
+ *
+ * Does nothing in the desktop app, where the main window is already created
+ * with `backgroundThrottling` disabled.
+ */
+export const useKeepPageActive = (shouldKeepPageActive: boolean) => {
+  React.useEffect(
+    () => {
+      if (electron) return;
+      if (!shouldKeepPageActive) return;
+
+      startKeepingPageActive();
+      return () => stopKeepingPageActive();
+    },
+    [shouldKeepPageActive]
+  );
+};

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestFrame.stories.js
@@ -5,6 +5,7 @@ import { action } from '@storybook/addon-actions';
 import {
   GameplayTestFrameLayout,
   type GameplayTestFrameRunStatus,
+  type GameplayTestFrameHiddenPause,
 } from '../../../GameplayTests/GameplayTestFrame';
 import Text from '../../../UI/Text';
 import { Column } from '../../../UI/Grid';
@@ -69,12 +70,20 @@ const makeRunStatus = (
 const FrameStory = ({
   runStatus,
   initiallyMinimized,
+  initialHiddenPause,
 }: {|
   runStatus: GameplayTestFrameRunStatus | null,
   initiallyMinimized?: boolean,
+  initialHiddenPause?: GameplayTestFrameHiddenPause,
 |}) => {
   const [isMinimized, setIsMinimized] = React.useState<boolean>(
     !!initiallyMinimized
+  );
+  const [
+    hiddenPause,
+    setHiddenPause,
+  ] = React.useState<GameplayTestFrameHiddenPause | null>(
+    initialHiddenPause || null
   );
   return (
     <div style={styles.storyContainer}>
@@ -87,6 +96,11 @@ const FrameStory = ({
       </Column>
       <GameplayTestFrameLayout
         runStatus={runStatus}
+        hiddenPause={hiddenPause}
+        onDismissHiddenPause={() => {
+          action('hidden pause dismissed')();
+          setHiddenPause(null);
+        }}
         isMinimized={isMinimized}
         onToggleMinimized={() => setIsMinimized(!isMinimized)}
         onStopRequested={action('stop requested')}
@@ -139,4 +153,30 @@ export const Failed = (): React.Node => (
 
 export const Minimized = (): React.Node => (
   <FrameStory runStatus={makeRunStatus({})} initiallyMinimized />
+);
+
+export const PausedWhileInTheBackgroundThenResumed = (): React.Node => (
+  <FrameStory
+    runStatus={makeRunStatus({ frame: 512 })}
+    initialHiddenPause={{ pausedMs: 47000, isRunInterrupted: false }}
+  />
+);
+
+export const InterruptedAfterTooLongInTheBackground = (): React.Node => (
+  <FrameStory
+    runStatus={makeRunStatus({
+      status: 'paused',
+      frame: 512,
+      durationMs: 312000,
+    })}
+    initialHiddenPause={{ pausedMs: 300000, isRunInterrupted: true }}
+  />
+);
+
+export const PausedWhileMinimized = (): React.Node => (
+  <FrameStory
+    runStatus={makeRunStatus({ frame: 512 })}
+    initialHiddenPause={{ pausedMs: 8000, isRunInterrupted: false }}
+    initiallyMinimized
+  />
 );

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestProperties.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestProperties.stories.js
@@ -75,6 +75,7 @@ const makeResult = (
   durationMs: 0,
   loadingMs: 0,
   timeoutMs: 0,
+  hiddenStallMs: 0,
   gameTimeMs: 0,
   assertions: [],
   errors: [],

--- a/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestStatusIndicator.stories.js
+++ b/newIDE/app/src/stories/componentStories/GameplayTests/GameplayTestStatusIndicator.stories.js
@@ -24,6 +24,7 @@ const allStatuses: Array<GameplayTestDisplayStatus> = [
   'failed',
   'error',
   'timeout',
+  'paused',
   'stopped',
 ];
 

--- a/newIDE/electron-app/app/main.js
+++ b/newIDE/electron-app/app/main.js
@@ -177,6 +177,13 @@ function createNewWindow(windowArgs = args) {
       // as we've not removed dependency on it and on "@electron/remote".
       nodeIntegration: true,
       contextIsolation: false,
+      // Keep timers and `requestAnimationFrame` running at full speed when
+      // the window is minimized or covered by another window (Chromium
+      // otherwise throttles timers to once a minute and stops animation
+      // frames entirely). The editor keeps working in the background: the
+      // AI agent keeps running its turns, and gameplay tests - which need
+      // animation frames to step the game - keep progressing.
+      backgroundThrottling: false,
     },
     enableLargerThanScreen: true,
     backgroundColor: '#000',


### PR DESCRIPTION
Browsers stop `requestAnimationFrame` and throttle timers in a hidden page (a tab in the background, a minimized window, or - with Chrome's occlusion detection - a window entirely covered by another one): after a few minutes in the background, timers wake up only once a minute, and the page can even be frozen. So leaving GDevelop in the background paused the agent, and a gameplay test (whose game is stepped from animation frames) simply stopped.

- Desktop app: create the main window with `backgroundThrottling: false`, so timers and animation frames keep running when it is minimized or covered.
- Web app: while an AI request is working, keep the page active by playing an inaudible tone (-60 dBFS at 40Hz - a digitally silent or muted source is ignored by the browser's audibility measurement). Scoped to work in progress, and skipped in the desktop app.
- Catch up immediately when the editor becomes visible again: reset the adaptive polling interval and force a full fetch, instead of waiting for a throttled tick that had backed off to its maximum.
- Gameplay tests are no longer reported as failing when the editor is in the background. The game and the editor both measure how long the game was really frozen (a hidden page during which no frame was stepped, so the desktop app - which keeps running - is not affected) and exclude it from the test timeout budget. The editor watchdog no longer blames the game for a silence it did not cause.
- Show a banner on the gameplay test frame when a run was frozen this way, so a run that resumed on its own (dismissing itself after a few seconds) or one that was interrupted is never mistaken for a broken game.