### PR TITLE
Ensure variables created are immediately visible in autocompletes

### DIFF
--- a/newIDE/app/src/ObjectGroupEditor/EditedObjectGroupEditorDialog.js
+++ b/newIDE/app/src/ObjectGroupEditor/EditedObjectGroupEditorDialog.js
@@ -98,10 +98,10 @@ const EditedObjectGroupEditorDialog = ({
   );
 
   const apply = async () => {
-    onApply();
     if (!initialInstances) {
       // This can only happens for legacy function object groups.
       // In this case, we don't do any refactoring.
+      onApply();
       return;
     }
 
@@ -131,6 +131,8 @@ const EditedObjectGroupEditorDialog = ({
         );
       }
     }
+    // Notify only once the variables are copied to the objects of the group.
+    onApply();
   };
 
   const removeObject = React.useCallback(

--- a/newIDE/app/src/VariablesList/ObjectGroupVariablesDialog.js
+++ b/newIDE/app/src/VariablesList/ObjectGroupVariablesDialog.js
@@ -92,16 +92,16 @@ const ObjectGroupVariablesDialog = ({
   );
 
   const apply = async () => {
-    onApply(
+    const selectedVariableName =
       lastSelectedVariableNodeId.current &&
-        getVariablePathFromNodeId(
-          lastSelectedVariableNodeId.current,
-          groupVariablesContainer
-        )
-    );
+      getVariablePathFromNodeId(
+        lastSelectedVariableNodeId.current,
+        groupVariablesContainer
+      );
     if (!initialInstances) {
       // This can only happens for legacy function object groups.
       // In this case, we don't do any refactoring.
+      onApply(selectedVariableName);
       return;
     }
 
@@ -131,6 +131,9 @@ const ObjectGroupVariablesDialog = ({
         );
       }
     }
+    // Notify only once the variables are copied to the objects of the group,
+    // so that the caller can read them (for example to refresh autocompletions).
+    onApply(selectedVariableName);
   };
 
   const lastSelectedVariableNodeId = React.useRef<string | null>(null);


### PR DESCRIPTION
Fix https://forum.gdevelop.io/t/object-vars-do-not-show-up-in-autocomplete-when-just-created-from-existing-variable/77857

Autocomplete was not refreshed at the right time