### PR TITLE
In the object group from the panel: Move the select list of object on top to get a static position for picking.

### DIFF
--- a/newIDE/app/src/ObjectGroupEditor/CompactObjectGroupEditor.js
+++ b/newIDE/app/src/ObjectGroupEditor/CompactObjectGroupEditor.js
@@ -95,6 +95,20 @@ const CompactObjectGroupEditor = ({
               }
             />
           ) : null}
+          <CompactObjectSelector
+            id="add-object-to-group"
+            label=""
+            project={project}
+            projectScopedContainersAccessor={projectScopedContainersAccessor}
+            value={objectName}
+            excludedObjectOrGroupNames={groupObjectNames}
+            onChange={setObjectName}
+            onChoose={addObject}
+            noGroups
+            hintText={t`Choose an object to add to the group`}
+            fullWidth
+            disabled={isObjectListLocked}
+          />
           <List>
             {groupObjectNames.map(objectName => {
               let object = getObjectByName(
@@ -129,20 +143,6 @@ const CompactObjectGroupEditor = ({
               );
             })}
           </List>
-          <CompactObjectSelector
-            id="add-object-to-group"
-            label=""
-            project={project}
-            projectScopedContainersAccessor={projectScopedContainersAccessor}
-            value={objectName}
-            excludedObjectOrGroupNames={groupObjectNames}
-            onChange={setObjectName}
-            onChoose={addObject}
-            noGroups
-            hintText={t`Choose an object to add to the group`}
-            fullWidth
-            disabled={isObjectListLocked}
-          />
         </ColumnStackLayout>
       )}
     </I18n>

--- a/newIDE/app/src/ObjectGroupEditor/index.js
+++ b/newIDE/app/src/ObjectGroupEditor/index.js
@@ -99,6 +99,23 @@ const ObjectGroupEditor = ({
   return (
     <ColumnStackLayout noMargin>
       {renderExplanation()}
+      <Paper style={styles.objectSelector} background="medium">
+        <Column noMargin>
+          <ObjectSelector
+            project={project}
+            projectScopedContainersAccessor={projectScopedContainersAccessor}
+            value={objectName}
+            excludedObjectOrGroupNames={groupObjectNames}
+            onChange={setObjectName}
+            onChoose={addObject}
+            openOnFocus
+            noGroups
+            hintText={t`Choose an object to add to the group`}
+            fullWidth
+            disabled={isObjectListLocked}
+          />
+        </Column>
+      </Paper>
       <List>
         {groupObjectNames.map(objectName => {
           let object = getObjectByName(
@@ -133,23 +150,6 @@ const ObjectGroupEditor = ({
           );
         })}
       </List>
-      <Paper style={styles.objectSelector} background="medium">
-        <Column noMargin>
-          <ObjectSelector
-            project={project}
-            projectScopedContainersAccessor={projectScopedContainersAccessor}
-            value={objectName}
-            excludedObjectOrGroupNames={groupObjectNames}
-            onChange={setObjectName}
-            onChoose={addObject}
-            openOnFocus
-            noGroups
-            hintText={t`Choose an object to add to the group`}
-            fullWidth
-            disabled={isObjectListLocked}
-          />
-        </Column>
-      </Paper>
     </ColumnStackLayout>
   );
 };


### PR DESCRIPTION
Why:
Picking an object make the select list moving with the new object added to the list, the layout shifting is anoying.

This PR:
<img width="385" height="452" alt="image" src="https://github.com/user-attachments/assets/aaa70f71-f73b-4b7b-9ee1-e5e3d092f71b" />

On the modal, the select list also moved on top.
<img width="1267" height="544" alt="image" src="https://github.com/user-attachments/assets/4394fbb9-35c3-400c-b190-120577a21387" />



Before:
<img width="387" height="274" alt="image" src="https://github.com/user-attachments/assets/68f8f81d-e8b3-461b-8fe4-b5ac77bd8ecc" />

