### PR TITLE
List the chats of the opened project first in the history

### DIFF
--- a/newIDE/app/src/AiGeneration/AiRequestContext.js
+++ b/newIDE/app/src/AiGeneration/AiRequestContext.js
@@ -131,6 +131,11 @@ type AiRequestStorage = {|
   // known are kept, the history only shows the ones matching the filter.
   aiRequestSummariesFilter: AiRequestSummariesFilter,
   setAiRequestSummariesFilter: (filter: AiRequestSummariesFilter) => void,
+  // The opened game, whose chats are fetched too, to be shown first.
+  aiRequestSummariesGameId: ?string,
+  setAiRequestSummariesGameId: (gameId: ?string) => void,
+  onLoadMoreGameAiRequestSummaries: () => Promise<void>,
+  canLoadMoreGameAiRequestSummaries: boolean,
   // The chat history: the user's top-level AI requests, newest first.
   aiRequestSummaries: { [aiRequestId: string]: AiRequestSummary },
   // The AI requests loaded with their conversation: the ones opened, created
@@ -178,13 +183,18 @@ type AiRequestSendState = {|
 
 type AiRequestsState = {|
   aiRequestSummaries: { [aiRequestId: string]: AiRequestSummary },
+  // The next page of the recent chats, and of the chats of the opened game.
   nextPageUri: ?string,
+  gameId: ?string,
+  gameNextPageUri: ?string,
   aiRequests: { [aiRequestId: string]: AiRequest },
 |};
 
 const emptyAiRequestsState: AiRequestsState = {
   aiRequestSummaries: {},
   nextPageUri: null,
+  gameId: null,
+  gameNextPageUri: null,
   aiRequests: {},
 };
 
@@ -222,25 +232,62 @@ export const useAiRequestsStorage = (): AiRequestStorage => {
     messageId: string,
   |}>(null);
 
-  const fetchAiRequestSummariesWithFilter = React.useCallback(
-    async (filter: AiRequestSummariesFilter) => {
+  /**
+   * Fetch the first pages of the recent chats and of the chats of the game (if
+   * one is given), or the next page of one of them (`forceUri`).
+   */
+  const fetchAiRequestSummariesPages = React.useCallback(
+    async ({
+      filter,
+      gameId,
+      forceUri,
+    }: {|
+      filter: AiRequestSummariesFilter,
+      gameId: ?string,
+      forceUri?: {| list: 'recents' | 'game', uri: string |},
+    |}) => {
       if (!profile) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const history = await getAiRequestSummaries(getAuthorizationHeader, {
-          userId: profile.id,
-          forceUri: null, // Fetch the first page.
-          filter,
-        });
+        const [recentsPage, gamePage] = await Promise.all([
+          forceUri && forceUri.list === 'game'
+            ? null
+            : getAiRequestSummaries(getAuthorizationHeader, {
+                userId: profile.id,
+                forceUri: forceUri ? forceUri.uri : null,
+                filter,
+              }),
+          gameId && (!forceUri || forceUri.list === 'game')
+            ? getAiRequestSummaries(getAuthorizationHeader, {
+                userId: profile.id,
+                forceUri: forceUri ? forceUri.uri : null,
+                filter,
+                gameId,
+              })
+            : null,
+        ]);
+        const fetchedSummaries = [
+          ...(recentsPage ? recentsPage.aiRequestSummaries : []),
+          ...(gamePage ? gamePage.aiRequestSummaries : []),
+        ];
         setState(previousState => ({
           ...previousState,
-          aiRequestSummaries: toAiRequestSummariesById(
-            history.aiRequestSummaries
-          ),
-          nextPageUri: history.nextPageUri,
+          aiRequestSummaries: forceUri
+            ? {
+                // The summaries already known are the most up to date.
+                ...toAiRequestSummariesById(fetchedSummaries),
+                ...previousState.aiRequestSummaries,
+              }
+            : toAiRequestSummariesById(fetchedSummaries),
+          nextPageUri: recentsPage
+            ? recentsPage.nextPageUri
+            : previousState.nextPageUri,
+          gameNextPageUri: gamePage
+            ? gamePage.nextPageUri
+            : previousState.gameNextPageUri,
         }));
       } catch (err) {
         setError(err);
@@ -252,51 +299,69 @@ export const useAiRequestsStorage = (): AiRequestStorage => {
     [profile, getAuthorizationHeader]
   );
   const fetchAiRequestSummaries = React.useCallback(
-    () => fetchAiRequestSummariesWithFilter(aiRequestSummariesFilter),
-    [fetchAiRequestSummariesWithFilter, aiRequestSummariesFilter]
+    () =>
+      fetchAiRequestSummariesPages({
+        filter: aiRequestSummariesFilter,
+        gameId: state.gameId,
+      }),
+    [fetchAiRequestSummariesPages, aiRequestSummariesFilter, state.gameId]
   );
   const setAiRequestSummariesFilter = React.useCallback(
     (filter: AiRequestSummariesFilter) => {
       setAiRequestSummariesFilterState(filter);
-      fetchAiRequestSummariesWithFilter(filter);
+      fetchAiRequestSummariesPages({ filter, gameId: state.gameId });
     },
-    [fetchAiRequestSummariesWithFilter]
+    [fetchAiRequestSummariesPages, state.gameId]
+  );
+  const setAiRequestSummariesGameId = React.useCallback(
+    (gameId: ?string) => {
+      if (gameId === state.gameId) return;
+      setState(previousState => ({
+        ...previousState,
+        gameId,
+        gameNextPageUri: null,
+      }));
+      if (gameId) {
+        fetchAiRequestSummariesPages({
+          filter: aiRequestSummariesFilter,
+          gameId,
+          forceUri: { list: 'game', uri: '/ai-request-summary' },
+        });
+      }
+    },
+    [fetchAiRequestSummariesPages, aiRequestSummariesFilter, state.gameId]
   );
 
   const onLoadMoreAiRequestSummaries = React.useCallback(
     async () => {
-      if (!profile) return;
-
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const history = await getAiRequestSummaries(getAuthorizationHeader, {
-          userId: profile.id,
-          forceUri: state.nextPageUri,
-          filter: aiRequestSummariesFilter,
-        });
-        setState(previousState => ({
-          ...previousState,
-          aiRequestSummaries: {
-            // The summaries already known are the most up to date.
-            ...toAiRequestSummariesById(history.aiRequestSummaries),
-            ...previousState.aiRequestSummaries,
-          },
-          nextPageUri: history.nextPageUri,
-        }));
-      } catch (err) {
-        setError(err);
-        console.error('Error fetching AI request summaries:', err);
-      } finally {
-        setIsLoading(false);
-      }
+      if (!state.nextPageUri) return;
+      await fetchAiRequestSummariesPages({
+        filter: aiRequestSummariesFilter,
+        gameId: state.gameId,
+        forceUri: { list: 'recents', uri: state.nextPageUri },
+      });
     },
     [
-      profile,
-      getAuthorizationHeader,
-      state.nextPageUri,
+      fetchAiRequestSummariesPages,
       aiRequestSummariesFilter,
+      state.gameId,
+      state.nextPageUri,
+    ]
+  );
+  const onLoadMoreGameAiRequestSummaries = React.useCallback(
+    async () => {
+      if (!state.gameNextPageUri) return;
+      await fetchAiRequestSummariesPages({
+        filter: aiRequestSummariesFilter,
+        gameId: state.gameId,
+        forceUri: { list: 'game', uri: state.gameNextPageUri },
+      });
+    },
+    [
+      fetchAiRequestSummariesPages,
+      aiRequestSummariesFilter,
+      state.gameId,
+      state.gameNextPageUri,
     ]
   );
 
@@ -538,15 +603,10 @@ export const useAiRequestsStorage = (): AiRequestStorage => {
           'Error while deleting the AI request - refreshing the history:',
           error
         );
-        fetchAiRequestSummariesWithFilter(aiRequestSummariesFilter);
+        fetchAiRequestSummaries();
       }
     },
-    [
-      getAuthorizationHeader,
-      profile,
-      fetchAiRequestSummariesWithFilter,
-      aiRequestSummariesFilter,
-    ]
+    [getAuthorizationHeader, profile, fetchAiRequestSummaries]
   );
 
   React.useEffect(
@@ -621,6 +681,10 @@ export const useAiRequestsStorage = (): AiRequestStorage => {
     isLoading,
     aiRequestSummariesFilter,
     setAiRequestSummariesFilter,
+    aiRequestSummariesGameId: state.gameId,
+    setAiRequestSummariesGameId,
+    onLoadMoreGameAiRequestSummaries,
+    canLoadMoreGameAiRequestSummaries: !!state.gameNextPageUri,
     aiRequestSummaries: state.aiRequestSummaries,
     aiRequests: state.aiRequests,
     aiRequestLoadingStates,
@@ -771,6 +835,10 @@ export const initialAiRequestContextState: AiRequestContextState = {
     isLoading: false,
     aiRequestSummariesFilter: 'active',
     setAiRequestSummariesFilter: () => {},
+    aiRequestSummariesGameId: null,
+    setAiRequestSummariesGameId: () => {},
+    onLoadMoreGameAiRequestSummaries: async () => {},
+    canLoadMoreGameAiRequestSummaries: false,
     aiRequestSummaries: {},
     aiRequests: {},
     aiRequestLoadingStates: {},

--- a/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
+++ b/newIDE/app/src/AiGeneration/AskAiEditorContainer.js
@@ -347,6 +347,7 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
       const {
         aiRequestStorage: {
           fetchAiRequestSummaries,
+          setAiRequestSummariesGameId,
           aiRequests,
           aiRequestSummaries,
           aiRequestLoadingStates,
@@ -445,6 +446,15 @@ export const AskAiEditor: React.ComponentType<Props> = React.memo<Props>(
         // retried once it becomes available.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [isActive, fetchAiRequestSummaries]
+      );
+
+      // The chats of the opened project are listed first in the history.
+      const projectGameId = project ? project.getProjectUuid() : null;
+      React.useEffect(
+        () => {
+          setAiRequestSummariesGameId(projectGameId);
+        },
+        [projectGameId, setAiRequestSummariesGameId]
       );
 
       const canStartNewChat = !!selectedAiRequestId;

--- a/newIDE/app/src/AiGeneration/AskAiHistory.js
+++ b/newIDE/app/src/AiGeneration/AskAiHistory.js
@@ -269,6 +269,9 @@ export const AskAiHistoryContent = ({
     deleteAiRequest,
     aiRequestSummariesFilter,
     setAiRequestSummariesFilter,
+    aiRequestSummariesGameId,
+    onLoadMoreGameAiRequestSummaries,
+    canLoadMoreGameAiRequestSummaries,
   } = React.useContext(AiRequestContext).aiRequestStorage;
   const { isMobile } = useResponsiveWindowSize();
   const { showConfirmation } = useAlertDialog();
@@ -346,7 +349,83 @@ export const AskAiHistoryContent = ({
         ),
     [aiRequestSummaries, aiRequestSummariesFilter]
   );
+  // The chats of the opened project come first, the others after.
+  const gameAiRequestSummaries = aiRequestSummariesGameId
+    ? sortedAiRequestSummaries.filter(
+        aiRequestSummary => aiRequestSummary.gameId === aiRequestSummariesGameId
+      )
+    : [];
+  const recentAiRequestSummaries = aiRequestSummariesGameId
+    ? sortedAiRequestSummaries.filter(
+        aiRequestSummary => aiRequestSummary.gameId !== aiRequestSummariesGameId
+      )
+    : sortedAiRequestSummaries;
+  const hasGameSection =
+    gameAiRequestSummaries.length > 0 || canLoadMoreGameAiRequestSummaries;
   const hasChats = sortedAiRequestSummaries.length > 0;
+
+  const renderChatItems = (summaries: Array<AiRequestSummary>) =>
+    summaries.map(aiRequestSummary => {
+      const isSelected = selectedAiRequestId === aiRequestSummary.id;
+      return (
+        <ChatItem
+          key={aiRequestSummary.id}
+          aiRequestSummary={aiRequestSummary}
+          isSelected={isSelected}
+          isWaitingForUser={isSelected && !!pendingEditApproval}
+          isRenaming={renamedAiRequestId === aiRequestSummary.id}
+          // On touch screens, a long press opens the menu.
+          showMenuButton={!isMobile}
+          onOpen={() => onOpenAiRequest(aiRequestSummary.id)}
+          onOpenContextMenu={(x, y) => {
+            if (contextMenuRef.current)
+              contextMenuRef.current.open(x, y, {
+                aiRequestId: aiRequestSummary.id,
+                isArchived: !!aiRequestSummary.archivedAt,
+              });
+          }}
+          onEndRenaming={newTitle => {
+            setRenamedAiRequestId(null);
+            renameAiRequest(aiRequestSummary.id, newTitle);
+          }}
+        />
+      );
+    });
+  const renderLoadMore = (onLoadMore: () => Promise<void>) => (
+    <div className={classes.footer}>
+      <TextButton
+        label={isLoading ? <Trans>Loading...</Trans> : <Trans>Load more</Trans>}
+        onClick={onLoadMore}
+        disabled={isLoading}
+      />
+    </div>
+  );
+  const headerButtons = (
+    <span className={classes.sectionTitleButtons}>
+      <IconButton
+        size="small"
+        color="inherit"
+        tooltip={t`Refresh the chats`}
+        onClick={fetchAiRequestSummaries}
+        disabled={isLoading}
+      >
+        <Refresh fontSize="small" />
+      </IconButton>
+      <ElementWithMenu
+        element={
+          <IconButton
+            size="small"
+            color="inherit"
+            tooltip={t`Choose which chats to show`}
+            selected={aiRequestSummariesFilter !== 'active'}
+          >
+            <Tune fontSize="small" />
+          </IconButton>
+        }
+        buildMenuTemplate={buildFilterMenuTemplate}
+      />
+    </span>
+  );
 
   return (
     <div className={classNames(classes.panel, className)}>
@@ -362,31 +441,12 @@ export const AskAiHistoryContent = ({
         />
       </div>
       <div className={classes.sectionTitle}>
-        {sectionTitles[aiRequestSummariesFilter]}
-        <span className={classes.sectionTitleButtons}>
-          <IconButton
-            size="small"
-            color="inherit"
-            tooltip={t`Refresh the chats`}
-            onClick={fetchAiRequestSummaries}
-            disabled={isLoading}
-          >
-            <Refresh fontSize="small" />
-          </IconButton>
-          <ElementWithMenu
-            element={
-              <IconButton
-                size="small"
-                color="inherit"
-                tooltip={t`Choose which chats to show`}
-                selected={aiRequestSummariesFilter !== 'active'}
-              >
-                <Tune fontSize="small" />
-              </IconButton>
-            }
-            buildMenuTemplate={buildFilterMenuTemplate}
-          />
-        </span>
+        {hasGameSection ? (
+          <Trans>This project</Trans>
+        ) : (
+          sectionTitles[aiRequestSummariesFilter]
+        )}
+        {headerButtons}
       </div>
       {error && !hasChats ? (
         <PlaceholderError onRetry={fetchAiRequestSummaries}>
@@ -400,53 +460,26 @@ export const AskAiHistoryContent = ({
         </div>
       ) : (
         <ScrollView>
+          {hasGameSection && (
+            <>
+              <div className={classes.list}>
+                {renderChatItems(gameAiRequestSummaries)}
+              </div>
+              {canLoadMoreGameAiRequestSummaries &&
+                renderLoadMore(onLoadMoreGameAiRequestSummaries)}
+              <div className={classes.sectionTitle}>
+                {sectionTitles[aiRequestSummariesFilter]}
+              </div>
+            </>
+          )}
           <div className={classes.list}>
-            {sortedAiRequestSummaries.map(aiRequestSummary => {
-              const isSelected = selectedAiRequestId === aiRequestSummary.id;
-              return (
-                <ChatItem
-                  key={aiRequestSummary.id}
-                  aiRequestSummary={aiRequestSummary}
-                  isSelected={isSelected}
-                  isWaitingForUser={isSelected && !!pendingEditApproval}
-                  isRenaming={renamedAiRequestId === aiRequestSummary.id}
-                  // On touch screens, a long press opens the menu.
-                  showMenuButton={!isMobile}
-                  onOpen={() => onOpenAiRequest(aiRequestSummary.id)}
-                  onOpenContextMenu={(x, y) => {
-                    if (contextMenuRef.current)
-                      contextMenuRef.current.open(x, y, {
-                        aiRequestId: aiRequestSummary.id,
-                        isArchived: !!aiRequestSummary.archivedAt,
-                      });
-                  }}
-                  onEndRenaming={newTitle => {
-                    setRenamedAiRequestId(null);
-                    renameAiRequest(aiRequestSummary.id, newTitle);
-                  }}
-                />
-              );
-            })}
+            {renderChatItems(recentAiRequestSummaries)}
           </div>
           <ContextMenu
             ref={contextMenuRef}
             buildMenuTemplate={buildMenuTemplate}
           />
-          {canLoadMore && (
-            <div className={classes.footer}>
-              <TextButton
-                label={
-                  isLoading ? (
-                    <Trans>Loading...</Trans>
-                  ) : (
-                    <Trans>Load more</Trans>
-                  )
-                }
-                onClick={onLoadMoreAiRequestSummaries}
-                disabled={isLoading}
-              />
-            </div>
-          )}
+          {canLoadMore && renderLoadMore(onLoadMoreAiRequestSummaries)}
         </ScrollView>
       )}
     </div>

--- a/newIDE/app/src/Utils/GDevelopServices/Generation.js
+++ b/newIDE/app/src/Utils/GDevelopServices/Generation.js
@@ -395,6 +395,7 @@ export type AiRequestSummary = {
   id: string,
   title: string | null,
   archivedAt: string | null,
+  gameId: string | null,
   createdAt: string,
   updatedAt: string,
   userId: string,
@@ -417,6 +418,7 @@ export const getAiRequestSummary = (aiRequest: AiRequest): AiRequestSummary => {
     id: aiRequest.id,
     title: aiRequest.title || null,
     archivedAt: aiRequest.archivedAt || null,
+    gameId: aiRequest.gameId || null,
     createdAt: aiRequest.createdAt,
     updatedAt: aiRequest.updatedAt,
     userId: aiRequest.userId,
@@ -459,12 +461,15 @@ export const getAiRequestSummaries = async (
     userId,
     forceUri,
     filter,
+    gameId,
   }: {|
     userId: string,
-    // The URI of the page to fetch, which carries the filter (or null for the
-    // first page).
+    // The URI of the page to fetch, which carries the filter and the game (or
+    // null for the first page).
     forceUri: ?string,
     filter: AiRequestSummariesFilter,
+    // Only the chats made on this game.
+    gameId?: ?string,
   |}
 ): Promise<{
   aiRequestSummaries: Array<AiRequestSummary>,
@@ -480,7 +485,12 @@ export const getAiRequestSummaries = async (
     },
     params: forceUri
       ? { userId }
-      : { userId, perPage: 10, archived: archivedParameterByFilter[filter] },
+      : {
+          userId,
+          perPage: 10,
+          archived: archivedParameterByFilter[filter],
+          gameId: gameId || undefined,
+        },
   });
   const nextPageUri = response.headers.link
     ? extractNextPageUriFromLinkHeader(response.headers.link)

--- a/newIDE/app/src/stories/componentStories/AiGeneration/AskAiHistory.stories.js
+++ b/newIDE/app/src/stories/componentStories/AiGeneration/AskAiHistory.stories.js
@@ -25,6 +25,7 @@ const createFakeAiRequestSummary = ({
   text,
   title = null,
   archivedAt = null,
+  gameId = null,
   status = 'ready',
   createdAt = '2024-01-01T12:00:00Z',
 }: {|
@@ -32,6 +33,7 @@ const createFakeAiRequestSummary = ({
   text: string | null,
   title?: string | null,
   archivedAt?: string | null,
+  gameId?: string | null,
   status?: GenerationStatus,
   createdAt?: string,
 |}): AiRequestSummary => {
@@ -39,6 +41,7 @@ const createFakeAiRequestSummary = ({
     id,
     title,
     archivedAt,
+    gameId,
     status,
     createdAt,
     updatedAt: createdAt,
@@ -76,6 +79,7 @@ const fakeAiRequestSummaries = toAiRequestSummariesById([
     id: 'request-1',
     text: 'Add a leaderboard with the player best score',
     status: 'working',
+    gameId: 'opened-game',
     createdAt: '2024-03-15T10:30:00Z',
   }),
   createFakeAiRequestSummary({
@@ -83,6 +87,7 @@ const fakeAiRequestSummaries = toAiRequestSummariesById([
     text: 'Create a GTA-style game with cars, pedestrians and a city',
     // A chat renamed by the user.
     title: 'City game',
+    gameId: 'opened-game',
     status: 'ready',
     createdAt: '2024-03-14T16:20:00Z',
   }),
@@ -141,6 +146,7 @@ const AskAiHistoryStoryTemplate = ({
   selectedAiRequestId = 'request-2',
   isWaitingForUser = false,
   filter = 'active',
+  gameId = null,
   width = 1000,
   height = 600,
   initiallyOpen = true,
@@ -153,6 +159,7 @@ const AskAiHistoryStoryTemplate = ({
   selectedAiRequestId?: string | null,
   isWaitingForUser?: boolean,
   filter?: AiRequestSummariesFilter,
+  gameId?: ?string,
   width?: number,
   height?: number,
   initiallyOpen?: boolean,
@@ -184,6 +191,10 @@ const AskAiHistoryStoryTemplate = ({
               setAiRequestSummariesFilter: action(
                 'setAiRequestSummariesFilter'
               ),
+              aiRequestSummariesGameId: gameId,
+              onLoadMoreGameAiRequestSummaries: async () =>
+                action('onLoadMoreGameAiRequestSummaries')(),
+              canLoadMoreGameAiRequestSummaries: false,
             },
             selectedAiRequestId,
             pendingEditApproval: isWaitingForUser
@@ -230,6 +241,23 @@ const AskAiHistoryStoryTemplate = ({
 
 export const SidePanel = (): React.Node => (
   <AskAiHistoryStoryTemplate layout="side-panel" />
+);
+
+export const SidePanelWithOpenedProject = (): React.Node => (
+  <AskAiHistoryStoryTemplate layout="side-panel" gameId="opened-game" />
+);
+
+export const SidePanelWithOpenedProjectWithoutChats = (): React.Node => (
+  <AskAiHistoryStoryTemplate layout="side-panel" gameId="another-game" />
+);
+
+export const RightDrawerWithOpenedProject = (): React.Node => (
+  <AskAiHistoryStoryTemplate
+    layout="right-drawer"
+    gameId="opened-game"
+    width={450}
+    height={600}
+  />
 );
 
 export const SidePanelArchivedChats = (): React.Node => (


### PR DESCRIPTION
When a project is opened, its chats are fetched from the API (by game id) and shown in a "This project" section above the recent chats, which then skip them. The archived filter applies to both, and each list has its own "Load more".