### PR TITLE
Fix children custom object types and behavior shared resource properties

### DIFF
--- a/Core/GDCore/IDE/EventsBasedObjectVariantHelper.cpp
+++ b/Core/GDCore/IDE/EventsBasedObjectVariantHelper.cpp
@@ -166,12 +166,17 @@ void EventsBasedObjectVariantHelper::FindAllChildrenCustomObjectType(
   const auto &objects = eventsBasedObject.GetObjects();
 
   for (size_t i = 0; i < objects.GetObjectsCount(); i++) {
-    const auto &object = objects.GetObject(i);
-    if (std::find(objectTypes.begin(), objectTypes.end(), object.GetType()) ==
+    const auto &objectType = objects.GetObject(i).GetType();
+    if (std::find(objectTypes.begin(), objectTypes.end(), objectType) ==
             objectTypes.end() &&
-        project.HasEventsBasedObject(object.GetType())) {
-      objectTypes.push_back(object.GetType());
-      FindAllChildrenCustomObjectType(project, eventsBasedObject, objectTypes);
+        project.HasEventsBasedObject(objectType)) {
+      objectTypes.push_back(objectType);
+      // Recurse on the child events-based object to also find the custom object
+      // types used deeper in the hierarchy.
+      // Types that were already found are skipped, which also avoids infinite
+      // loops in case events-based objects have (invalid) cyclic dependencies.
+      FindAllChildrenCustomObjectType(
+          project, project.GetEventsBasedObject(objectType), objectTypes);
     }
   }
 }

--- a/Core/GDCore/IDE/EventsFunctionTools.cpp
+++ b/Core/GDCore/IDE/EventsFunctionTools.cpp
@@ -220,14 +220,28 @@ void EventsFunctionTools::ParametersToResourcesContainer(
 void EventsFunctionTools::PropertiesToResourcesContainer(
     const PropertiesContainer &properties,
     gd::ResourcesContainer &outputResourcesContainer) {
+  outputResourcesContainer.Clear();
+  AddPropertiesToResourcesContainer(properties, outputResourcesContainer);
+}
+
+void EventsFunctionTools::PropertiesToResourcesContainer(
+    const PropertiesContainer &properties,
+    const PropertiesContainer &sharedProperties,
+    gd::ResourcesContainer &outputResourcesContainer) {
+  outputResourcesContainer.Clear();
+  AddPropertiesToResourcesContainer(properties, outputResourcesContainer);
+  AddPropertiesToResourcesContainer(sharedProperties, outputResourcesContainer);
+}
+
+void EventsFunctionTools::AddPropertiesToResourcesContainer(
+    const PropertiesContainer &properties,
+    gd::ResourcesContainer &outputResourcesContainer) {
   if (outputResourcesContainer.GetSourceType() !=
       gd::ResourcesContainer::SourceType::Properties) {
     throw std::logic_error("Tried to generate a resources container from "
                            "properties with the wrong source type.");
   }
-  outputResourcesContainer.Clear();
 
-  gd::String lastObjectName;
   for (std::size_t i = 0; i < properties.GetCount(); ++i) {
     const auto &property = properties.Get(i);
     if (property.GetName().empty()) {

--- a/Core/GDCore/IDE/EventsFunctionTools.h
+++ b/Core/GDCore/IDE/EventsFunctionTools.h
@@ -94,9 +94,18 @@ class GD_CORE_API EventsFunctionTools {
       const PropertiesContainer &properties,
       gd::ResourcesContainer &outputResourcesContainer);
 
+  static void PropertiesToResourcesContainer(
+      const PropertiesContainer &properties,
+      const PropertiesContainer &sharedProperties,
+      gd::ResourcesContainer &outputResourcesContainer);
+
 private:
   static void AddPropertiesToVariablesContainer(
       const PropertiesContainer &properties,
       gd::VariablesContainer &outputVariablesContainer);
+
+  static void AddPropertiesToResourcesContainer(
+      const PropertiesContainer &properties,
+      gd::ResourcesContainer &outputResourcesContainer);
 };
 }  // namespace gd

--- a/Core/GDCore/Project/ResourcesContainersList.cpp
+++ b/Core/GDCore/Project/ResourcesContainersList.cpp
@@ -52,12 +52,9 @@ ResourcesContainersList ResourcesContainersList::
   resourcesContainersList.Push(project.GetResourcesManager());
 
   gd::EventsFunctionTools::PropertiesToResourcesContainer(
+      eventsBasedBehavior.GetPropertyDescriptors(),
       eventsBasedBehavior.GetSharedPropertyDescriptors(),
       propertyResourcesContainer);
-  resourcesContainersList.Push(propertyResourcesContainer);
-
-  gd::EventsFunctionTools::PropertiesToResourcesContainer(
-      eventsBasedBehavior.GetPropertyDescriptors(), propertyResourcesContainer);
   resourcesContainersList.Push(propertyResourcesContainer);
 
   gd::EventsFunctionTools::ParametersToResourcesContainer(

--- a/Core/tests/EventsBasedObjectVariantHelper.cpp
+++ b/Core/tests/EventsBasedObjectVariantHelper.cpp
@@ -520,3 +520,79 @@ TEST_CASE("EventsBasedObjectVariantHelper", "[common]") {
             false);
   }
 }
+
+TEST_CASE("EventsBasedObjectVariantHelper (FindAllChildrenCustomObjectType)",
+          "[common]") {
+  SECTION("Can find the types of children custom objects at every level") {
+    gd::Project project;
+    gd::Platform platform;
+    SetupProjectWithDummyPlatform(project, platform);
+    auto &eventsExtension =
+        project.InsertNewEventsFunctionsExtension("MyEventsExtension", 0);
+
+    auto &grandChildEventsBasedObject =
+        eventsExtension.GetEventsBasedObjects().InsertNew(
+            "MyGrandChildEventsBasedObject", 0);
+    grandChildEventsBasedObject.GetObjects().InsertNewObject(
+        project, "MyExtension::Sprite", "MySprite", 0);
+
+    auto &childEventsBasedObject =
+        eventsExtension.GetEventsBasedObjects().InsertNew(
+            "MyChildEventsBasedObject", 1);
+    childEventsBasedObject.GetObjects().InsertNewObject(
+        project, "MyEventsExtension::MyGrandChildEventsBasedObject",
+        "MyGrandChildObject", 0);
+
+    auto &eventsBasedObject = eventsExtension.GetEventsBasedObjects().InsertNew(
+        "MyEventsBasedObject", 2);
+    eventsBasedObject.GetObjects().InsertNewObject(
+        project, "MyEventsExtension::MyChildEventsBasedObject", "MyChildObject",
+        0);
+    eventsBasedObject.GetObjects().InsertNewObject(
+        project, "MyExtension::Sprite", "MySprite", 1);
+
+    auto objectTypes =
+        gd::EventsBasedObjectVariantHelper::FindAllChildrenCustomObjectType(
+            project, eventsBasedObject);
+
+    REQUIRE(objectTypes.size() == 2);
+    REQUIRE(std::find(objectTypes.begin(), objectTypes.end(),
+                      "MyEventsExtension::MyChildEventsBasedObject") !=
+            objectTypes.end());
+    REQUIRE(std::find(objectTypes.begin(), objectTypes.end(),
+                      "MyEventsExtension::MyGrandChildEventsBasedObject") !=
+            objectTypes.end());
+  }
+
+  SECTION("Can handle cyclic dependencies between custom objects") {
+    gd::Project project;
+    gd::Platform platform;
+    SetupProjectWithDummyPlatform(project, platform);
+    auto &eventsExtension =
+        project.InsertNewEventsFunctionsExtension("MyEventsExtension", 0);
+
+    auto &eventsBasedObjectA =
+        eventsExtension.GetEventsBasedObjects().InsertNew(
+            "MyEventsBasedObjectA", 0);
+    auto &eventsBasedObjectB =
+        eventsExtension.GetEventsBasedObjects().InsertNew(
+            "MyEventsBasedObjectB", 1);
+    // This is an invalid project, but it must not make the helper loop forever.
+    eventsBasedObjectA.GetObjects().InsertNewObject(
+        project, "MyEventsExtension::MyEventsBasedObjectB", "MyObjectB", 0);
+    eventsBasedObjectB.GetObjects().InsertNewObject(
+        project, "MyEventsExtension::MyEventsBasedObjectA", "MyObjectA", 0);
+
+    auto objectTypes =
+        gd::EventsBasedObjectVariantHelper::FindAllChildrenCustomObjectType(
+            project, eventsBasedObjectA);
+
+    REQUIRE(objectTypes.size() == 2);
+    REQUIRE(std::find(objectTypes.begin(), objectTypes.end(),
+                      "MyEventsExtension::MyEventsBasedObjectB") !=
+            objectTypes.end());
+    REQUIRE(std::find(objectTypes.begin(), objectTypes.end(),
+                      "MyEventsExtension::MyEventsBasedObjectA") !=
+            objectTypes.end());
+  }
+}

--- a/Core/tests/ResourcesContainersList.cpp
+++ b/Core/tests/ResourcesContainersList.cpp
@@ -1,0 +1,122 @@
+/*
+ * GDevelop Core
+ * Copyright 2008-2025 Florian Rival (Florian.Rival@gmail.com). All rights
+ * reserved. This project is released under the MIT License.
+ */
+/**
+ * @file Tests covering gd::ResourcesContainersList.
+ */
+#include "GDCore/Project/ResourcesContainersList.h"
+
+#include "DummyPlatform.h"
+#include "GDCore/Extensions/Platform.h"
+#include "GDCore/Project/EventsBasedBehavior.h"
+#include "GDCore/Project/EventsFunction.h"
+#include "GDCore/Project/EventsFunctionsExtension.h"
+#include "GDCore/Project/Project.h"
+#include "GDCore/Project/PropertiesContainer.h"
+#include "GDCore/Project/ResourcesContainer.h"
+#include "catch.hpp"
+
+namespace {
+void AddResourceProperty(gd::PropertiesContainer &properties,
+                         const gd::String &name) {
+  properties.InsertNew(name, properties.GetCount())
+      .SetType("Resource")
+      .AddExtraInfo("image");
+}
+} // namespace
+
+TEST_CASE("ResourcesContainersList", "[common]") {
+  SECTION("Resource properties of a behavior are all found (shared or not)") {
+    gd::Project project;
+    gd::Platform platform;
+    SetupProjectWithDummyPlatform(project, platform);
+    project.GetResourcesManager().AddResource("MyProjectResource", "image.png",
+                                              "image");
+
+    auto &eventsExtension =
+        project.InsertNewEventsFunctionsExtension("MyEventsExtension", 0);
+    auto &eventsBasedBehavior =
+        eventsExtension.GetEventsBasedBehaviors().InsertNew(
+            "MyEventsBasedBehavior", 0);
+    auto &eventsFunction =
+        eventsBasedBehavior.GetEventsFunctions().InsertNewEventsFunction(
+            "MyFunction", 0);
+    eventsFunction.GetParameters()
+        .InsertNewParameter("MyResourceParameter", 0)
+        .SetType("imageResource");
+
+    AddResourceProperty(eventsBasedBehavior.GetPropertyDescriptors(),
+                        "MyResourceProperty");
+    AddResourceProperty(eventsBasedBehavior.GetSharedPropertyDescriptors(),
+                        "MySharedResourceProperty");
+
+    gd::ResourcesContainer parameterResourcesContainer(
+        gd::ResourcesContainer::SourceType::Parameters);
+    gd::ResourcesContainer propertyResourcesContainer(
+        gd::ResourcesContainer::SourceType::Properties);
+    auto resourcesContainersList =
+        gd::ResourcesContainersList::
+            MakeNewResourcesContainersListForBehaviorEventsFunction(
+                project, eventsExtension, eventsBasedBehavior, eventsFunction,
+                parameterResourcesContainer, propertyResourcesContainer);
+
+    REQUIRE(resourcesContainersList.HasResourceNamed("MyResourceProperty"));
+    REQUIRE(
+        resourcesContainersList.HasResourceNamed("MySharedResourceProperty"));
+    REQUIRE(resourcesContainersList.GetResourcesContainerSourceType(
+                "MyResourceProperty") ==
+            gd::ResourcesContainer::SourceType::Properties);
+    REQUIRE(resourcesContainersList.GetResourcesContainerSourceType(
+                "MySharedResourceProperty") ==
+            gd::ResourcesContainer::SourceType::Properties);
+
+    REQUIRE(resourcesContainersList.GetResourcesContainerSourceType(
+                "MyResourceParameter") ==
+            gd::ResourcesContainer::SourceType::Parameters);
+    REQUIRE(resourcesContainersList.GetResourcesContainerSourceType(
+                "MyProjectResource") ==
+            gd::ResourcesContainer::SourceType::Global);
+    REQUIRE(resourcesContainersList.GetResourcesContainerSourceType(
+                "NotAResource") ==
+            gd::ResourcesContainer::SourceType::Unknown);
+
+    // The project resources, the behavior properties and the function
+    // parameters.
+    REQUIRE(resourcesContainersList.GetResourcesContainersCount() == 3);
+  }
+
+  SECTION("Resource properties of a custom object are found") {
+    gd::Project project;
+    gd::Platform platform;
+    SetupProjectWithDummyPlatform(project, platform);
+
+    auto &eventsExtension =
+        project.InsertNewEventsFunctionsExtension("MyEventsExtension", 0);
+    auto &eventsBasedObject = eventsExtension.GetEventsBasedObjects().InsertNew(
+        "MyEventsBasedObject", 0);
+    auto &eventsFunction =
+        eventsBasedObject.GetEventsFunctions().InsertNewEventsFunction(
+            "MyFunction", 0);
+
+    AddResourceProperty(eventsBasedObject.GetPropertyDescriptors(),
+                        "MyResourceProperty");
+
+    gd::ResourcesContainer parameterResourcesContainer(
+        gd::ResourcesContainer::SourceType::Parameters);
+    gd::ResourcesContainer propertyResourcesContainer(
+        gd::ResourcesContainer::SourceType::Properties);
+    auto resourcesContainersList =
+        gd::ResourcesContainersList::
+            MakeNewResourcesContainersListForObjectEventsFunction(
+                project, eventsExtension, eventsBasedObject, eventsFunction,
+                parameterResourcesContainer, propertyResourcesContainer);
+
+    REQUIRE(resourcesContainersList.HasResourceNamed("MyResourceProperty"));
+    REQUIRE(resourcesContainersList.GetResourcesContainerSourceType(
+                "MyResourceProperty") ==
+            gd::ResourcesContainer::SourceType::Properties);
+    REQUIRE(resourcesContainersList.GetResourcesContainersCount() == 3);
+  }
+}


### PR DESCRIPTION
- `FindAllChildrenCustomObjectType` was recursing on the events-based object it was already iterating on, instead of the child events-based object. Only the direct children custom object types were found (so variants of deeper children were not complied when installing an asset).

- `MakeNewResourcesContainersListForBehaviorEventsFunction` was filling and pushing the same `propertyResourcesContainer` twice => the shared properties were erased by the non-shared ones. Resource shared properties were then not recognized in behavior events.